### PR TITLE
Add initial Liga Master pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Este repositorio contiene un prototipo sencillo para el sitio **La Virtual Zone. Incluye un flujo básico de registro y login que se almacena en `localStorage` y unas páginas iniciales de ejemplo.
 
 Abre `index.html` en tu navegador para comenzar.
+
+Se añadieron páginas iniciales para la Liga Master en `liga-master.html` con
+algunos clubes ficticios y enlaces a su plantilla, el mercado de fichajes y el
+fixture de ejemplo.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <a href="registro.html">Registro</a>
     <a href="usuario.html">Panel</a>
     <a href="torneos.html">Torneos</a>
+    <a href="liga-master.html">Liga Master</a>
     <a href="blog.html">Blog</a>
   </nav>
 </header>

--- a/liga-master.html
+++ b/liga-master.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Liga Master - La Virtual Zone</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+  <h1>Liga Master</h1>
+  <nav>
+    <a href="index.html">Inicio</a>
+    <a href="usuario.html">Panel</a>
+    <a href="liga-master/mercado.html">Mercado</a>
+    <a href="liga-master/fixture.html">Fixture</a>
+  </nav>
+</header>
+<main>
+  <section id="clubs">
+    <!-- Lista de clubes cargada via JS -->
+  </section>
+</main>
+<script src="liga-master.js"></script>
+</body>
+</html>

--- a/liga-master.js
+++ b/liga-master.js
@@ -1,0 +1,29 @@
+const clubs = [
+  {
+    name: 'Rayo Digital FC',
+    coach: 'DT Ficticio',
+    budget: 20,
+    link: 'liga-master/club/rayo-digital-fc.html'
+  },
+  {
+    name: 'Atlético Pixelado',
+    coach: 'DT Pixel',
+    budget: 22,
+    link: 'liga-master/club/atletico-pixelado.html'
+  }
+];
+
+function renderClubs() {
+  const container = document.getElementById('clubs');
+  if (!container) return;
+  const list = document.createElement('ul');
+  clubs.forEach(c => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${c.name}</strong> - DT: ${c.coach} - Presupuesto: $${c.budget}M ` +
+      `<a href="${c.link}">Ver club</a>`;
+    list.appendChild(li);
+  });
+  container.appendChild(list);
+}
+
+document.addEventListener('DOMContentLoaded', renderClubs);

--- a/liga-master/club/plantilla.html
+++ b/liga-master/club/plantilla.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Plantilla - Rayo Digital FC</title>
+<link rel="stylesheet" href="../../styles.css">
+</head>
+<body>
+<header>
+  <h1>Plantilla - Rayo Digital FC</h1>
+  <nav>
+    <a href="rayo-digital-fc.html">Volver al club</a>
+  </nav>
+</header>
+<main>
+  <table>
+    <thead>
+      <tr><th>Jugador</th><th>Posición</th><th>Media</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Jugador 1</td><td>DEL</td><td>80</td></tr>
+      <tr><td>Jugador 2</td><td>MED</td><td>78</td></tr>
+      <tr><td>Jugador 3</td><td>DEF</td><td>77</td></tr>
+    </tbody>
+  </table>
+</main>
+</body>
+</html>

--- a/liga-master/club/rayo-digital-fc.html
+++ b/liga-master/club/rayo-digital-fc.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Rayo Digital FC - La Virtual Zone</title>
+<link rel="stylesheet" href="../../styles.css">
+</head>
+<body>
+<header>
+  <h1>Rayo Digital FC</h1>
+  <nav>
+    <a href="../../liga-master.html">Liga Master</a>
+  </nav>
+</header>
+<main>
+  <p>Club ficticio fundado en 2023 con estilo ofensivo.</p>
+  <ul>
+    <li>DT: DT Ficticio</li>
+    <li>Presupuesto: $20M</li>
+    <li><a href="plantilla.html">Ver plantilla</a></li>
+  </ul>
+</main>
+</body>
+</html>

--- a/liga-master/fixture.html
+++ b/liga-master/fixture.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fixture - Liga Master</title>
+<link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+<header>
+  <h1>Fixture</h1>
+  <nav>
+    <a href="../liga-master.html">Liga Master</a>
+  </nav>
+</header>
+<main>
+  <table>
+    <thead>
+      <tr><th>Jornada</th><th>Local</th><th>Visitante</th><th>Resultado</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>1</td><td>Rayo Digital FC</td><td>Atlético Pixelado</td><td>3-1</td></tr>
+      <tr><td>2</td><td>Atlético Pixelado</td><td>Rayo Digital FC</td><td>2-2</td></tr>
+    </tbody>
+  </table>
+</main>
+</body>
+</html>

--- a/liga-master/mercado.html
+++ b/liga-master/mercado.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mercado de Fichajes - La Virtual Zone</title>
+<link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+<header>
+  <h1>Mercado de Fichajes</h1>
+  <nav>
+    <a href="../liga-master.html">Liga Master</a>
+  </nav>
+</header>
+<main>
+  <p>Lista de jugadores disponibles (contenido ficticio):</p>
+  <ul>
+    <li>Jugador 1 - $5M</li>
+    <li>Jugador 2 - $4M</li>
+    <li>Jugador 3 - $7M</li>
+  </ul>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add main Liga Master page with club list and navigation
- add club example with plantilla page
- add basic fixture and mercado pages
- link Liga Master from index
- document new section in README

## Testing
- `node -v`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685226a658f88333a324dc9cccedf43b