### PR TITLE
Add home hero and sample data

### DIFF
--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom'
+
+export default function HeroSection() {
+  return (
+    <section className="relative h-[60vh] flex items-center justify-center bg-gradient-to-br from-zinc-800 via-black to-zinc-900">
+      <div className="absolute inset-0 bg-black/50" />
+      <div className="relative z-10 text-center space-y-4">
+        <h1 className="text-4xl md:text-6xl font-bold text-[var(--primary)] drop-shadow-[0_0_6px_var(--primary-glow)]">
+          La Virtual Zone
+        </h1>
+        <Link
+          to="/torneos"
+          className="inline-block px-6 py-2 bg-[var(--primary)] text-black rounded hover:scale-105 transition-transform"
+        >
+          Explorar Torneos
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -11,7 +11,7 @@ interface CardProps {
 export default function Card({ title, image, onClick, children, className }: CardProps) {
   return (
     <div
-      className={`bg-gray-800 rounded shadow hover:shadow-lg overflow-hidden cursor-pointer ${className ?? ''}`}
+      className={`bg-zinc-800 rounded shadow hover:shadow-lg overflow-hidden cursor-pointer transform transition-transform hover:scale-105 ${className ?? ''}`}
       onClick={onClick}
     >
       {image && <img src={image} alt={title} className="w-full h-40 object-cover" />}

--- a/src/data/blog.json
+++ b/src/data/blog.json
@@ -1,0 +1,5 @@
+[
+  { "slug": "bienvenida-2025", "titulo": "¡Bienvenido a la temporada 2025!", "resumen": "Arrancan los torneos...", "thumb": "https://via.placeholder.com/300x200?text=Temporada+2025" },
+  { "slug": "mercado-abierto", "titulo": "El mercado ya está abierto", "resumen": "Rumores y fichajes...", "thumb": "https://via.placeholder.com/300x200?text=Mercado" },
+  { "slug": "guia-managers", "titulo": "Guía para nuevos managers", "resumen": "Consejos básicos...", "thumb": "https://via.placeholder.com/300x200?text=Guia" }
+]

--- a/src/data/torneos.json
+++ b/src/data/torneos.json
@@ -1,0 +1,5 @@
+[
+  { "slug": "copa-verano", "nombre": "Copa de Verano", "estado": "Inscripciones", "banner": "https://via.placeholder.com/300x200?text=Copa+Verano" },
+  { "slug": "liga-pixel-2025", "nombre": "Liga Pixel 2025", "estado": "En curso", "banner": "https://via.placeholder.com/300x200?text=Liga+Pixel" },
+  { "slug": "retro-cup", "nombre": "Retro Cup", "estado": "Próximo", "banner": "https://via.placeholder.com/300x200?text=Retro+Cup" }
+]

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,3 +1,49 @@
+import HeroSection from '../../components/Home/HeroSection'
+import Card from '../../components/ui/Card'
+import torneos from '../../data/torneos.json'
+import noticias from '../../data/blog.json'
+
+type Torneo = {
+  slug: string
+  nombre: string
+  estado: string
+  banner: string
+}
+
+type Noticia = {
+  slug: string
+  titulo: string
+  resumen: string
+  thumb: string
+}
+
 export default function Home() {
-  return <h1>Home</h1>
+  const proximos = (torneos as Torneo[]).slice(0, 3)
+  const ultimas = (noticias as Noticia[]).slice(0, 3)
+
+  return (
+    <div className="space-y-8">
+      <HeroSection />
+      <section className="space-y-4">
+        <h2 className="text-2xl font-bold text-[var(--primary)]">Próximos eventos</h2>
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {proximos.map((t) => (
+            <Card key={t.slug} title={t.nombre} image={t.banner}>
+              <p className="text-sm">{t.estado}</p>
+            </Card>
+          ))}
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-bold text-[var(--primary)]">Últimas noticias</h2>
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {ultimas.map((n) => (
+            <Card key={n.slug} title={n.titulo} image={n.thumb}>
+              <p className="text-sm">{n.resumen}</p>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- create HeroSection component for landing page
- show tournaments and blog entries on Home
- tweak Card component style
- add sample torneos and blog datasets

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685301aa35d08333afbb821a2c69b843