### PR TITLE
Implement torneos pages with details

### DIFF
--- a/src/pages/Torneos/Torneo.tsx
+++ b/src/pages/Torneos/Torneo.tsx
@@ -1,0 +1,142 @@
+import { Tab } from '@headlessui/react'
+import { useParams } from 'react-router-dom'
+import torneos from '../../data/torneos.json'
+
+interface Torneo {
+  slug: string
+  nombre: string
+  estado: string
+  banner: string
+}
+
+export default function Torneo() {
+  const { slug } = useParams()
+  const torneo = (torneos as Torneo[]).find((t) => t.slug === slug)
+
+  if (!torneo) {
+    return <p className="text-center">Torneo no encontrado</p>
+  }
+
+  const participantes = [
+    'Club Alpha',
+    'Club Beta',
+    'Club Gamma',
+    'Club Delta',
+    'Club Epsilon',
+    'Club Zeta',
+  ]
+
+  const fixture = [
+    { fecha: '01/10', local: 'Club Alpha', visita: 'Club Beta', marcador: '2-1' },
+    { fecha: '08/10', local: 'Club Gamma', visita: 'Club Delta', marcador: '0-0' },
+    { fecha: '15/10', local: 'Club Alpha', visita: 'Club Gamma', marcador: '-' },
+  ]
+
+  const posiciones = [
+    { equipo: 'Club Alpha', pj: 2, g: 1, e: 1, p: 0, pts: 4 },
+    { equipo: 'Club Gamma', pj: 2, g: 1, e: 1, p: 0, pts: 4 },
+    { equipo: 'Club Beta', pj: 2, g: 0, e: 1, p: 1, pts: 1 },
+    { equipo: 'Club Delta', pj: 2, g: 0, e: 1, p: 1, pts: 1 },
+  ]
+
+  const goleadores = [
+    { jugador: 'Juan Pérez', goles: 5 },
+    { jugador: 'Luis Díaz', goles: 3 },
+    { jugador: 'Carlos García', goles: 2 },
+    { jugador: 'Marco López', goles: 1 },
+    { jugador: 'Miguel Torres', goles: 1 },
+  ]
+
+  return (
+    <div className="space-y-4">
+      <img
+        src={torneo.banner}
+        alt={torneo.nombre}
+        className="w-full h-52 md:h-64 object-cover rounded"
+      />
+      <h1 className="text-2xl font-bold">{torneo.nombre}</h1>
+      <Tab.Group>
+        <Tab.List className="flex space-x-4 border-b border-zinc-700">
+          {['Participantes', 'Fixture', 'Tabla', 'Goleadores'].map((tab) => (
+            <Tab
+              key={tab}
+              className={({ selected }) =>
+                `py-2 px-3 border-b-2 ${
+                  selected
+                    ? 'border-[var(--primary)] text-[var(--primary)]'
+                    : 'border-transparent'
+                }`
+              }
+            >
+              {tab}
+            </Tab>
+          ))}
+        </Tab.List>
+        <Tab.Panels className="mt-4">
+          <Tab.Panel>
+            <ul className="list-disc pl-4 space-y-1">
+              {participantes.map((c) => (
+                <li key={c}>{c}</li>
+              ))}
+            </ul>
+          </Tab.Panel>
+          <Tab.Panel>
+            <table className="w-full text-left">
+              <thead>
+                <tr>
+                  <th className="py-1">Fecha</th>
+                  <th className="py-1">Local</th>
+                  <th className="py-1">Visita</th>
+                  <th className="py-1">Marcador</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fixture.map((f, idx) => (
+                  <tr key={idx} className="border-t border-zinc-700">
+                    <td className="py-1">{f.fecha}</td>
+                    <td className="py-1">{f.local}</td>
+                    <td className="py-1">{f.visita}</td>
+                    <td className="py-1">{f.marcador}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Tab.Panel>
+          <Tab.Panel>
+            <table className="w-full text-left">
+              <thead>
+                <tr>
+                  <th className="py-1">Equipo</th>
+                  <th className="py-1">PJ</th>
+                  <th className="py-1">G</th>
+                  <th className="py-1">E</th>
+                  <th className="py-1">P</th>
+                  <th className="py-1">PTS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {posiciones.map((p, idx) => (
+                  <tr key={idx} className="border-t border-zinc-700">
+                    <td className="py-1">{p.equipo}</td>
+                    <td className="py-1">{p.pj}</td>
+                    <td className="py-1">{p.g}</td>
+                    <td className="py-1">{p.e}</td>
+                    <td className="py-1">{p.p}</td>
+                    <td className="py-1">{p.pts}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Tab.Panel>
+          <Tab.Panel>
+            <ol className="list-decimal pl-4 space-y-1">
+              {goleadores.map((g, idx) => (
+                <li key={idx}>{`${g.jugador} - ${g.goles}`}</li>
+              ))}
+            </ol>
+          </Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  )
+}

--- a/src/pages/Torneos/index.tsx
+++ b/src/pages/Torneos/index.tsx
@@ -1,39 +1,48 @@
 import { useState } from 'react'
-import tournaments from '../../data/tournaments.json'
+import { useNavigate } from 'react-router-dom'
+import torneos from '../../data/torneos.json'
 import Card from '../../components/ui/Card'
-import Modal from '../../components/ui/Modal'
 
-interface Tournament {
-  id: number
-  name: string
-  game: string
-  date: string
-  image: string
-  details: string
+interface Torneo {
+  slug: string
+  nombre: string
+  estado: string
+  banner: string
 }
 
 export default function Torneos() {
-  const [selected, setSelected] = useState<Tournament | null>(null)
+  const [filtro, setFiltro] = useState('Todos')
+  const navigate = useNavigate()
+
+  const lista = (torneos as Torneo[]).filter(
+    (t) => filtro === 'Todos' || t.estado === filtro,
+  )
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Torneos</h1>
+      <select
+        value={filtro}
+        onChange={(e) => setFiltro(e.target.value)}
+        className="bg-zinc-900 border border-[var(--primary)] rounded px-2 py-1"
+      >
+        <option value="Todos">Todos</option>
+        <option value="Inscripciones">Inscripciones</option>
+        <option value="En curso">En curso</option>
+        <option value="Finalizado">Finalizado</option>
+      </select>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {(tournaments as Tournament[]).map(t => (
-          <Card key={t.id} title={t.name} image={t.image} onClick={() => setSelected(t)}>
-            <p className="text-sm">{t.game}</p>
-            <p className="text-sm">{new Date(t.date).toLocaleDateString()}</p>
+        {lista.map((t) => (
+          <Card
+            key={t.slug}
+            title={t.nombre}
+            image={t.banner}
+            onClick={() => navigate('/torneos/' + t.slug)}
+          >
+            <p className="text-sm">{t.estado}</p>
           </Card>
         ))}
       </div>
-      {selected && (
-        <Modal open={true} onClose={() => setSelected(null)} title={selected.name}>
-          <img src={selected.image} alt={selected.name} className="w-full h-56 object-cover rounded" />
-          <p className="text-sm">Juego: {selected.game}</p>
-          <p className="text-sm">Fecha: {new Date(selected.date).toLocaleDateString()}</p>
-          <p>{selected.details}</p>
-        </Modal>
-      )}
     </div>
   )
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,6 +9,7 @@ import Fixture from './pages/LigaMaster/Fixture'
 import Rankings from './pages/LigaMaster/Rankings'
 import HallOfFame from './pages/LigaMaster/HallOfFame'
 import Torneos from './pages/Torneos'
+import Torneo from './pages/Torneos/Torneo'
 import Galeria from './pages/Galeria'
 import Blog from './pages/Blog'
 import Tienda from './pages/Tienda'
@@ -33,6 +34,7 @@ const routes: AppRoute[] = [
   { path: '/liga-master/rankings', element: <Rankings /> },
   { path: '/liga-master/halloffame', element: <HallOfFame /> },
   { path: '/torneos', element: <Torneos /> },
+  { path: '/torneos/:slug', element: <Torneo /> },
   { path: '/galeria', element: <Galeria /> },
   { path: '/blog', element: <Blog /> },
   { path: '/tienda', element: <Tienda /> },


### PR DESCRIPTION
## Summary
- list torneos with a filter and cards
- add single torneo page with Headless UI tabs
- wire new pages into the router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68530a125d0c83339628ed90ff317756