### PR TITLE
Improve Card semantics

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -9,16 +9,25 @@ interface CardProps {
 }
 
 export default function Card({ title, image, onClick, children, className }: CardProps) {
-  return (
-    <div
-      className={`bg-zinc-800 rounded border border-[var(--primary)] shadow hover:shadow-lg overflow-hidden cursor-pointer transform transition-transform hover:scale-105 ${className ?? ''}`}
-      onClick={onClick}
-    >
+  const base = `bg-zinc-800 rounded border border-[var(--primary)] shadow hover:shadow-lg overflow-hidden w-full text-left ${
+    onClick ? 'cursor-pointer transform transition-transform hover:scale-105' : ''
+  } ${className ?? ''}`
+
+  const content = (
+    <>
       {image && <img src={image} alt={title} className="w-full h-40 object-cover" />}
       <div className="p-4 space-y-2">
         <h3 className="text-lg font-semibold">{title}</h3>
         {children}
       </div>
-    </div>
+    </>
+  )
+
+  return onClick ? (
+    <button type="button" className={base} onClick={onClick}>
+      {content}
+    </button>
+  ) : (
+    <div className={base}>{content}</div>
   )
 }


### PR DESCRIPTION
## Summary
- replace clickable Card div wrapper with a `<button>`
- keep the same Tailwind classes for appearance and cursor behaviour

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68530c9565988333916c892dfef44836