### PR TITLE
Improve navbar semantics

### DIFF
--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -4,23 +4,31 @@ import styles from './Navbar.module.css'
 
 export default function Navbar() {
   const [open, setOpen] = useState(false)
+  const navId = 'main-nav'
 
   return (
     <header className={styles.navbar}>
       <Link to="/" className={styles.logo}>La Virtual Zone</Link>
-      <button className={styles.hamburger} onClick={() => setOpen(!open)}>
+      <button
+        className={styles.hamburger}
+        aria-expanded={open}
+        aria-controls={navId}
+        onClick={() => setOpen(!open)}
+      >
         <span></span>
         <span></span>
         <span></span>
       </button>
-      <ul className={`${styles.links} ${open ? styles.open : ''}`}>
-        <li><Link to="/" onClick={() => setOpen(false)}>Inicio</Link></li>
-        <li><Link to="/liga-master" onClick={() => setOpen(false)}>Liga Master</Link></li>
-        <li><Link to="/torneos" onClick={() => setOpen(false)}>Torneos</Link></li>
-        <li><Link to="/galeria" onClick={() => setOpen(false)}>Galería</Link></li>
-        <li><Link to="/blog" onClick={() => setOpen(false)}>Blog</Link></li>
-        <li><Link to="/login" onClick={() => setOpen(false)}>Iniciar Sesión</Link></li>
-      </ul>
+      <nav>
+        <ul id={navId} className={`${styles.links} ${open ? styles.open : ''}`}>
+          <li><Link to="/" onClick={() => setOpen(false)}>Inicio</Link></li>
+          <li><Link to="/liga-master" onClick={() => setOpen(false)}>Liga Master</Link></li>
+          <li><Link to="/torneos" onClick={() => setOpen(false)}>Torneos</Link></li>
+          <li><Link to="/galeria" onClick={() => setOpen(false)}>Galería</Link></li>
+          <li><Link to="/blog" onClick={() => setOpen(false)}>Blog</Link></li>
+          <li><Link to="/login" onClick={() => setOpen(false)}>Iniciar Sesión</Link></li>
+        </ul>
+      </nav>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- wrap navigation links in `<nav>`
- expose open state via `aria-expanded`
- connect the button to the nav with `aria-controls`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68530c96d9f88333a32f75e8aa25e40a