### PR TITLE
Use flex layout and CSS module for main padding

### DIFF
--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,0 +1,10 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main {
+  flex: 1;
+  padding-inline: 1rem;
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,14 +1,13 @@
 import Navbar from './Navbar'
 import Footer from './Footer'
+import styles from './Layout.module.css'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <div className={styles.container}>
       <Navbar />
-      <main style={{ paddingInline: '1rem', minHeight: 'calc(100vh - 160px)' }}>
-        {children}
-      </main>
+      <main className={styles.main}>{children}</main>
       <Footer />
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- create `Layout.module.css` with flex column styles
- refactor `Layout` component to use the CSS module instead of inline styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68530c980db48333900c17fab5997640