### PR TITLE
Improve glass effects and hero animation

### DIFF
--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -5,12 +5,12 @@ export default function HeroSection() {
     <section className="relative h-[70vh] flex items-center justify-center bg-gradient-to-br from-[#1a0033] via-black to-[#00040a]">
       <div className="absolute inset-0 bg-black/50" />
       <div className="relative z-10 text-center space-y-4">
-        <h1 className="text-5xl md:text-7xl font-bold text-[var(--primary)] drop-shadow-[0_0_8px_var(--primary-glow)]">
+        <h1 className="neon text-5xl md:text-7xl font-bold text-[var(--primary)] drop-shadow-[0_0_8px_var(--primary-glow)]">
           La Virtual Zone
         </h1>
         <Link
           to="/torneos"
-          className="inline-block px-6 py-2 bg-[var(--primary)] text-black rounded hover:scale-105 transition-transform"
+          className="inline-block px-6 py-2 bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] text-black rounded hover:scale-105 transition-transform"
         >
           Explorar Torneos
         </Link>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -9,7 +9,7 @@ interface CardProps {
 }
 
 export default function Card({ title, image, onClick, children, className }: CardProps) {
-  const base = `bg-[var(--card)] rounded border border-[var(--primary)] shadow-md hover:shadow-[0_0_8px_var(--primary-glow)] overflow-hidden w-full text-left ${
+  const base = `glass rounded border border-[var(--primary)] shadow-md hover:shadow-[0_0_8px_var(--primary-glow)] overflow-hidden w-full text-left ${
     onClick ? 'cursor-pointer transform transition-transform hover:scale-105' : ''
   } ${className ?? ''}`
 

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -12,7 +12,7 @@ export default function Modal({ open, onClose, title, children }: ModalProps) {
   return (
     <Dialog open={open} onClose={onClose} className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
-      <div className="relative bg-gray-900 text-white rounded-lg p-4 max-w-lg w-full">
+      <div className="relative glass text-white rounded-lg p-4 max-w-lg w-full">
         <Dialog.Title className="text-xl font-semibold mb-2">{title}</Dialog.Title>
         <div className="mb-4 space-y-2">{children}</div>
         <button className="mt-2 px-4 py-1 bg-blue-600 rounded" onClick={onClose}>Cerrar</button>

--- a/src/index.css
+++ b/src/index.css
@@ -39,3 +39,23 @@ a:hover {
   color: var(--accent);
   text-shadow: 0 0 6px var(--accent-glow);
 }
+
+/* Simple glassmorphism card style */
+.glass {
+  background: rgba(23, 23, 23, 0.6);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--primary-glow);
+}
+
+@keyframes pulse-glow {
+  0%, 100% {
+    text-shadow: 0 0 6px var(--primary-glow);
+  }
+  50% {
+    text-shadow: 0 0 12px var(--accent-glow);
+  }
+}
+
+.neon {
+  animation: pulse-glow 2s infinite;
+}

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -4,7 +4,7 @@ export default function Login() {
   return (
     <div className="max-w-sm mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Iniciar Sesión</h1>
-      <form className="space-y-3 bg-zinc-800 p-4 rounded">
+      <form className="space-y-3 glass p-4 rounded">
         <input
           type="email"
           placeholder="Correo electrónico"

--- a/src/pages/Registro/index.tsx
+++ b/src/pages/Registro/index.tsx
@@ -2,7 +2,7 @@ export default function Registro() {
   return (
     <div className="max-w-md mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Registro</h1>
-      <form className="space-y-3 bg-zinc-800 p-4 rounded">
+      <form className="space-y-3 glass p-4 rounded">
         <input
           type="text"
           placeholder="Nombre de usuario"


### PR DESCRIPTION
## Summary
- add `glass` and `neon` styles
- enhance hero section with gradient button and neon title
- apply glass style to modal, cards, login and register forms

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68537ce6d61083338874fe7dcad62a2c