### PR TITLE
Add NotFound page

### DIFF
--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFound() {
+  return (
+    <div className="space-y-4 text-center">
+      <h1 className="text-2xl font-bold">Página no encontrada</h1>
+      <p>La URL que visitaste no existe.</p>
+      <Link to="/" className="underline text-[var(--primary)]">
+        Volver al inicio
+      </Link>
+    </div>
+  )
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,6 +15,7 @@ import Blog from './pages/Blog'
 import Tienda from './pages/Tienda'
 import Admin from './pages/Admin'
 import Ayuda from './pages/Ayuda'
+import NotFound from './pages/NotFound'
 import type { ReactElement } from 'react'
 
 export interface AppRoute {
@@ -40,6 +41,7 @@ const routes: AppRoute[] = [
   { path: '/tienda', element: <Tienda /> },
   { path: '/admin', element: <Admin /> },
   { path: '/ayuda', element: <Ayuda /> },
+  { path: '*', element: <NotFound /> },
 ]
 
 export default routes


### PR DESCRIPTION
## Summary
- create a simple NotFound screen with a link back home
- register NotFound as a wildcard route

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685383f1ef84833389072ad4848d559b