### PR TITLE
Add menu aria-label

### DIFF
--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -13,6 +13,7 @@ export default function Navbar() {
         className={styles.hamburger}
         aria-expanded={open}
         aria-controls={navId}
+        aria-label="Menú"
         onClick={() => setOpen(!open)}
       >
         <span></span>


### PR DESCRIPTION
## Summary
- add `aria-label="Menú"` to the navbar toggle button

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685386b7c6ac8333be8c20c0e318b42a