### PR TITLE
Add accessible labels for auth forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.1.10",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1567,6 +1568,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -3527,6 +3541,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.10",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -5,16 +5,24 @@ export default function Login() {
     <div className="max-w-sm mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Iniciar Sesión</h1>
       <form className="space-y-3 glass p-4 rounded">
-        <input
-          type="email"
-          placeholder="Correo electrónico"
-          className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
-        />
-        <input
-          type="password"
-          placeholder="Contraseña"
-          className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
-        />
+        <label htmlFor="login-email" className="block space-y-1">
+          <span className="text-sm">Correo electrónico</span>
+          <input
+            id="login-email"
+            type="email"
+            placeholder="Correo electrónico"
+            className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
+          />
+        </label>
+        <label htmlFor="login-password" className="block space-y-1">
+          <span className="text-sm">Contraseña</span>
+          <input
+            id="login-password"
+            type="password"
+            placeholder="Contraseña"
+            className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
+          />
+        </label>
         <button
           type="submit"
           className="w-full bg-[var(--primary)] text-black font-bold py-2 rounded"

--- a/src/pages/Registro/index.tsx
+++ b/src/pages/Registro/index.tsx
@@ -3,21 +3,33 @@ export default function Registro() {
     <div className="max-w-md mx-auto space-y-4">
       <h1 className="text-2xl font-bold text-center">Registro</h1>
       <form className="space-y-3 glass p-4 rounded">
-        <input
-          type="text"
-          placeholder="Nombre de usuario"
-          className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
-        />
-        <input
-          type="email"
-          placeholder="Correo electrónico"
-          className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
-        />
-        <input
-          type="password"
-          placeholder="Contraseña"
-          className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
-        />
+        <label htmlFor="reg-username" className="block space-y-1">
+          <span className="text-sm">Nombre de usuario</span>
+          <input
+            id="reg-username"
+            type="text"
+            placeholder="Nombre de usuario"
+            className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
+          />
+        </label>
+        <label htmlFor="reg-email" className="block space-y-1">
+          <span className="text-sm">Correo electrónico</span>
+          <input
+            id="reg-email"
+            type="email"
+            placeholder="Correo electrónico"
+            className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
+          />
+        </label>
+        <label htmlFor="reg-password" className="block space-y-1">
+          <span className="text-sm">Contraseña</span>
+          <input
+            id="reg-password"
+            type="password"
+            placeholder="Contraseña"
+            className="w-full px-3 py-2 bg-zinc-900 border border-[var(--primary)] rounded"
+          />
+        </label>
         <button
           type="submit"
           className="w-full bg-[var(--primary)] text-black font-bold py-2 rounded"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import forms from '@tailwindcss/forms'
+
 export default {
   content: [
     './index.html',
@@ -17,5 +19,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [forms],
 }


### PR DESCRIPTION
## Summary
- install `@tailwindcss/forms` for better form styles
- enable the plugin in Tailwind config
- wrap inputs in Login and Registro pages with accessible labels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685386b8a2f88333a52c7d2add134004