### PR TITLE
Add accessible labels for filters

### DIFF
--- a/src/pages/LigaMaster/Mercado.tsx
+++ b/src/pages/LigaMaster/Mercado.tsx
@@ -26,19 +26,32 @@ export default function Mercado() {
   return (
     <div>
       <h1>Mercado de Fichajes</h1>
-      <div>
-        <select value={pos} onChange={(e) => setPos(e.target.value)}>
-          <option value="">Todas las posiciones</option>
-          {positions.map((p) => (
-            <option key={p} value={p}>{p}</option>
-          ))}
-        </select>
-        <input
-          type="text"
-          placeholder="Buscar"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
+      <div className="flex flex-wrap gap-4 mb-4">
+        <label htmlFor="mercado-pos" className="block space-y-1">
+          <span className="text-sm">Posición</span>
+          <select
+            id="mercado-pos"
+            value={pos}
+            onChange={(e) => setPos(e.target.value)}
+            className="bg-zinc-900 border border-[var(--primary)] rounded px-2 py-1"
+          >
+            <option value="">Todas las posiciones</option>
+            {positions.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        </label>
+        <label htmlFor="mercado-search" className="block space-y-1">
+          <span className="text-sm">Buscar jugador</span>
+          <input
+            id="mercado-search"
+            type="text"
+            placeholder="Buscar"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="bg-zinc-900 border border-[var(--primary)] rounded px-2 py-1"
+          />
+        </label>
       </div>
       <table className={styles.table}>
         <thead>

--- a/src/pages/Torneos/index.tsx
+++ b/src/pages/Torneos/index.tsx
@@ -21,16 +21,20 @@ export default function Torneos() {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Torneos</h1>
-      <select
-        value={filtro}
-        onChange={(e) => setFiltro(e.target.value)}
-        className="bg-zinc-900 border border-[var(--primary)] rounded px-2 py-1"
-      >
-        <option value="Todos">Todos</option>
-        <option value="Inscripciones">Inscripciones</option>
-        <option value="En curso">En curso</option>
-        <option value="Finalizado">Finalizado</option>
-      </select>
+      <label htmlFor="filtro-torneos" className="block space-y-1">
+        <span className="text-sm">Filtrar torneos</span>
+        <select
+          id="filtro-torneos"
+          value={filtro}
+          onChange={(e) => setFiltro(e.target.value)}
+          className="bg-zinc-900 border border-[var(--primary)] rounded px-2 py-1"
+        >
+          <option value="Todos">Todos</option>
+          <option value="Inscripciones">Inscripciones</option>
+          <option value="En curso">En curso</option>
+          <option value="Finalizado">Finalizado</option>
+        </select>
+      </label>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {lista.map((t) => (
           <Card


### PR DESCRIPTION
## Summary
- label select to filter tournaments by state
- label position filter and search field in transfer market

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68538b90220c8333a06a44d49ac12e78