### PR TITLE
Add theme switcher with hook

### DIFF
--- a/src/components/Layout/Navbar.module.css
+++ b/src/components/Layout/Navbar.module.css
@@ -51,6 +51,14 @@
   transition: all .3s;
 }
 
+.themeToggle {
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
 @media (max-width: 768px) {
   .links {
     position: fixed;

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { FaMoon, FaSun } from 'react-icons/fa'
+import { useTheme } from '../../hooks/useTheme'
 import styles from './Navbar.module.css'
 
 export default function Navbar() {
   const [open, setOpen] = useState(false)
   const navId = 'main-nav'
+  const { theme, toggleTheme } = useTheme()
 
   return (
     <header className={styles.navbar}>
@@ -19,6 +22,13 @@ export default function Navbar() {
         <span></span>
         <span></span>
         <span></span>
+      </button>
+      <button
+        className={styles.themeToggle}
+        onClick={toggleTheme}
+        aria-label="Alternar tema"
+      >
+        {theme === 'light' ? <FaMoon /> : <FaSun />}
       </button>
       <nav>
         <ul id={navId} className={`${styles.links} ${open ? styles.open : ''}`}>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'dark'
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored === 'light' || stored === 'dark') return stored
+    return 'dark'
+  })
+
+  useEffect(() => {
+    document.body.classList.toggle('light', theme === 'light')
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => setTheme(t => (t === 'light' ? 'dark' : 'light'))
+
+  return { theme, toggleTheme }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -58,3 +58,13 @@ a:hover {
 .neon {
   animation: pulse-glow 2s infinite;
 }
+
+body.light {
+  --bg: #f5f5f5;
+  --card: #ffffff;
+  --text: #0d0d0d;
+  --primary: #0077ff;
+  --primary-glow: rgba(0, 119, 255, 0.35);
+  --accent: #7c3aed;
+  --accent-glow: rgba(124, 58, 237, 0.4);
+}


### PR DESCRIPTION
## Summary
- create `useTheme` hook to store theme preference and toggle body class
- add theme toggle button to `Navbar`
- style toggle button and define light theme variables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685391030fb48333897b2030d1a76160