### PR TITLE
Implement skip link for accessibility

### DIFF
--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -11,3 +11,17 @@
   width: 100%;
   margin-inline: auto;
 }
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background-color: #fff;
+  color: #000;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  left: 0;
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,8 +5,9 @@ import styles from './Layout.module.css'
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className={styles.container}>
+      <a href="#contenido" className="skip-link">Saltar al contenido</a>
       <Navbar />
-      <main className={styles.main}>{children}</main>
+      <main id="contenido" className={styles.main}>{children}</main>
       <Footer />
     </div>
   )


### PR DESCRIPTION
## Summary
- add a skip link in `Layout.tsx`
- expose the main content via `id="contenido"`
- style `.skip-link` for visibility only on focus

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68539103bdfc8333819409cfa16fe8fc