### PR TITLE
Add lazy loading to card images

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -15,7 +15,14 @@ export default function Card({ title, image, onClick, children, className }: Car
 
   const content = (
     <>
-      {image && <img src={image} alt={title} className="w-full h-40 object-cover" />}
+      {image && (
+        <img
+          src={image}
+          alt={title}
+          loading="lazy"
+          className="w-full h-40 object-cover"
+        />
+      )}
       <div className="p-4 space-y-2">
         <h3 className="text-lg font-semibold">{title}</h3>
         {children}


### PR DESCRIPTION
## Summary
- use `loading="lazy"` when rendering card images

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685391050cd8833384da70f80d03099f