### PR TITLE
Enhance 404 page design

### DIFF
--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,11 +1,16 @@
 import { Link } from 'react-router-dom'
+import { FaExclamationTriangle } from 'react-icons/fa'
 
 export default function NotFound() {
   return (
-    <div className="space-y-4 text-center">
-      <h1 className="text-2xl font-bold">Página no encontrada</h1>
-      <p>La URL que visitaste no existe.</p>
-      <Link to="/" className="underline text-[var(--primary)]">
+    <div className="min-h-[60vh] flex flex-col items-center justify-center space-y-4 text-center">
+      <FaExclamationTriangle className="text-6xl text-[var(--accent)]" />
+      <h1 className="neon text-6xl md:text-8xl font-bold text-[var(--primary)] drop-shadow-[0_0_8px_var(--primary-glow)]">404</h1>
+      <p className="text-lg">Lo sentimos, la página que buscas no existe.</p>
+      <Link
+        to="/"
+        className="inline-block px-6 py-2 bg-[var(--primary)] text-black font-bold rounded hover:scale-105 transition-transform"
+      >
         Volver al inicio
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- overhaul 404 page with neon heading and home button
- include a warning icon for style

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685391066e508333b35dd4a458ed0497