### PR TITLE
Implement user registration service

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,6 +1,11 @@
-import  { create } from 'zustand';
+import { create } from 'zustand';
 import { User } from '../types';
-import { login as authLogin, getCurrentUser, logout as authLogout } from '../utils/authService';
+import {
+  login as authLogin,
+  register as authRegister,
+  getCurrentUser,
+  logout as authLogout
+} from '../utils/authService';
 
 interface AuthState {
   user: User | null;
@@ -32,8 +37,14 @@ export const useAuthStore = create<AuthState>((set) => {
     },
     
     register: (email, username, password) => {
-      // Implementation remains in authService.ts
-      throw new Error('Not implemented');
+      try {
+        const user = authRegister(email, username, password);
+        set({ user, isAuthenticated: true });
+        return user;
+      } catch (error) {
+        console.error('Register failed:', error);
+        throw error;
+      }
     },
     
     logout: () => {

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -1,4 +1,4 @@
-import  { User } from '../types';
+import { User } from '../types';
 
 // Simulated backend - using localStorage for persistence
 const USERS_KEY = 'virtual_zone_users';
@@ -88,6 +88,52 @@ export const saveCurrentUser = (user: User | null): void => {
   } else {
     localStorage.removeItem(CURRENT_USER_KEY);
   }
+};
+
+// Register a new user and log them in
+export const register = (
+  email: string,
+  username: string,
+  password: string
+): User => {
+  const users = getUsers();
+
+  const usernameExists = users.some(
+    u => u.username.toLowerCase() === username.toLowerCase()
+  );
+  if (usernameExists) {
+    throw new Error('El nombre de usuario ya está en uso');
+  }
+
+  const emailExists = users.some(
+    u => u.email.toLowerCase() === email.toLowerCase()
+  );
+  if (emailExists) {
+    throw new Error('El correo electrónico ya está en uso');
+  }
+
+  const newUser: User = {
+    id: `${Date.now()}`,
+    username,
+    email,
+    role: 'user',
+    avatar: `https://ui-avatars.com/api/?name=${encodeURIComponent(
+      username
+    )}&background=111827&color=fff&size=128`,
+    xp: 0,
+    joinDate: new Date().toISOString(),
+    status: 'active',
+    notifications: true,
+    lastLogin: new Date().toISOString(),
+    followers: 0,
+    following: 0
+  };
+
+  users.push(newUser);
+  saveUsers(users);
+  saveCurrentUser(newUser);
+
+  return newUser;
 };
 
 // Login function


### PR DESCRIPTION
## Summary
- add register API in `authService`
- use authService.register inside the auth store

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685411dff6f483339effcb083afc571c