### PR TITLE
Fix auth store imports

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import  { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { LogIn, User, Lock } from 'lucide-react';
-import useAuthStore from '../../store/authStore';
+import { useAuthStore } from '../../store/authStore';
 
 const LoginForm = () => {
   const [username, setUsername] = useState('');

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -1,7 +1,7 @@
 import  { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { User, Mail, Lock, CheckCircle } from 'lucide-react';
-import useAuthStore from '../../store/authStore';
+import { useAuthStore } from '../../store/authStore';
 
 const RegisterForm = () => {
   const [username, setUsername] = useState('');

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,7 +1,7 @@
 import  { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash } from 'lucide-react';
-import useAuthStore from '../store/authStore';
+import { useAuthStore } from '../store/authStore';
 import { clubs, players } from '../data/mockData';
 
 const Admin = () => {


### PR DESCRIPTION
## Summary
- update Admin page to import named auth store
- update Login and Register forms to import named auth store

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_685417ad41848333a04e609d0e058dad