### PR TITLE
Fix club play style field

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -482,7 +482,7 @@ const Admin = () => {
                               maximumFractionDigits: 0
                             }).format(club.budget)}
                           </td>
-                          <td className="px-4 py-3 text-center">{club.style}</td>
+                          <td className="px-4 py-3 text-center">{club.playStyle}</td>
                           <td className="px-4 py-3 text-center">
                             <div className="flex justify-center space-x-2">
                               <button className="p-1 text-gray-400 hover:text-primary">


### PR DESCRIPTION
## Summary
- use `club.playStyle` instead of `club.style` in the Admin panel

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build` *(fails: Could not resolve './components/layout/Layout')*

------
https://chatgpt.com/codex/tasks/task_e_685417b179c4833392bf7b056c36857b