### PR TITLE
Fix import in ClubSquad page

### DIFF
--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -1,5 +1,5 @@
 import  { useParams, Link } from 'react-router-dom';
-import { users, Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
+import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { clubs, players } from '../data/mockData';
 import { formatCurrency } from '../utils/helpers';


### PR DESCRIPTION
## Summary
- remove unused lowercase `users` icon from the ClubSquad import

## Testing
- `npm install`
- `npm run lint` *(fails: 30 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68541bc965c88333807c7a90cf7889c1