### PR TITLE
Add admin modals and store actions

### DIFF
--- a/src/components/admin/NewClubModal.tsx
+++ b/src/components/admin/NewClubModal.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { Club } from '../../types';
+
+interface Props {
+  onClose: () => void;
+}
+
+const NewClubModal = ({ onClose }: Props) => {
+  const [name, setName] = useState('');
+  const [manager, setManager] = useState('');
+  const [error, setError] = useState('');
+  const addClub = useDataStore(state => state.addClub);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!name || !manager) {
+      setError('Completa todos los campos');
+      return;
+    }
+
+    const newClub: Club = {
+      id: `${Date.now()}`,
+      name,
+      logo: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=3b82f6&color=fff&size=128`,
+      foundedYear: new Date().getFullYear(),
+      stadium: '',
+      budget: 0,
+      manager,
+      playStyle: '',
+      primaryColor: '#ffffff',
+      secondaryColor: '#000000',
+      description: '',
+      titles: [],
+      reputation: 50,
+      fanBase: 0
+    };
+
+    addClub(newClub);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Nuevo Club</h3>
+        {error && <div className="mb-4 p-3 bg-red-500/20 text-red-400 rounded-lg">{error}</div>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre</label>
+            <input className="input w-full" value={name} onChange={e => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Entrenador</label>
+            <input className="input w-full" value={manager} onChange={e => setManager(e.target.value)} />
+          </div>
+          <button type="submit" className="btn-primary w-full">Crear</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewClubModal;

--- a/src/components/admin/NewPlayerModal.tsx
+++ b/src/components/admin/NewPlayerModal.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { Player } from '../../types';
+
+interface Props {
+  onClose: () => void;
+}
+
+const NewPlayerModal = ({ onClose }: Props) => {
+  const { clubs, addPlayer } = useDataStore();
+  const [name, setName] = useState('');
+  const [position, setPosition] = useState('');
+  const [clubId, setClubId] = useState(clubs[0]?.id || '');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!name || !position || !clubId) {
+      setError('Completa todos los campos');
+      return;
+    }
+
+    const newPlayer: Player = {
+      id: `${Date.now()}`,
+      name,
+      age: 18,
+      position,
+      nationality: 'Argentina',
+      clubId,
+      overall: 60,
+      potential: 70,
+      transferListed: false,
+      transferValue: 0,
+      image: 'https://via.placeholder.com/150',
+      attributes: {
+        pace: 50,
+        shooting: 50,
+        passing: 50,
+        dribbling: 50,
+        defending: 50,
+        physical: 50
+      },
+      contract: {
+        expires: `${new Date().getFullYear() + 2}-06-30`,
+        salary: 0
+      },
+      form: 1,
+      goals: 0,
+      assists: 0,
+      appearances: 0
+    };
+
+    addPlayer(newPlayer);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Nuevo Jugador</h3>
+        {error && <div className="mb-4 p-3 bg-red-500/20 text-red-400 rounded-lg">{error}</div>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre</label>
+            <input className="input w-full" value={name} onChange={e => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Posición</label>
+            <input className="input w-full" value={position} onChange={e => setPosition(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Club</label>
+            <select className="input w-full" value={clubId} onChange={e => setClubId(e.target.value)}>
+              {clubs.map(c => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+          <button type="submit" className="btn-primary w-full">Crear</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewPlayerModal;

--- a/src/components/admin/NewUserModal.tsx
+++ b/src/components/admin/NewUserModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { addUser as persistUser } from '../../utils/authService';
+import { User } from '../../types';
+
+interface Props {
+  onClose: () => void;
+}
+
+const NewUserModal = ({ onClose }: Props) => {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<'user' | 'dt' | 'admin'>('user');
+  const [error, setError] = useState('');
+  const addUser = useDataStore(state => state.addUser);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!username || !email) {
+      setError('Completa todos los campos');
+      return;
+    }
+
+    try {
+      const newUser: User = persistUser(email, username, role);
+      addUser(newUser);
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Error al crear usuario';
+      setError(message);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Nuevo Usuario</h3>
+        {error && <div className="mb-4 p-3 bg-red-500/20 text-red-400 rounded-lg">{error}</div>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre de usuario</label>
+            <input className="input w-full" value={username} onChange={e => setUsername(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Correo</label>
+            <input type="email" className="input w-full" value={email} onChange={e => setEmail(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Rol</label>
+            <select className="input w-full" value={role} onChange={e => setRole(e.target.value as 'user' | 'dt' | 'admin')}>
+              <option value="user">Usuario</option>
+              <option value="dt">DT</option>
+              <option value="admin">Admin</option>
+            </select>
+          </div>
+          <button type="submit" className="btn-primary w-full">Crear</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewUserModal;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,11 +1,17 @@
 import  { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash } from 'lucide-react';
+import NewUserModal from '../components/admin/NewUserModal';
+import NewClubModal from '../components/admin/NewClubModal';
+import NewPlayerModal from '../components/admin/NewPlayerModal';
 import { useAuthStore } from '../store/authStore';
 import { clubs, players } from '../data/mockData';
 
 const Admin = () => {
   const [activeTab, setActiveTab] = useState('dashboard');
+  const [showUserModal, setShowUserModal] = useState(false);
+  const [showClubModal, setShowClubModal] = useState(false);
+  const [showPlayerModal, setShowPlayerModal] = useState(false);
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 
@@ -276,7 +282,7 @@ const Admin = () => {
             <div>
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-2xl font-bold">Gestión de Usuarios</h2>
-                <button className="btn-primary flex items-center">
+                <button className="btn-primary flex items-center" onClick={() => setShowUserModal(true)}>
                   <Plus size={16} className="mr-2" />
                   Nuevo usuario
                 </button>
@@ -442,7 +448,7 @@ const Admin = () => {
             <div>
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-2xl font-bold">Gestión de Clubes</h2>
-                <button className="btn-primary flex items-center">
+                <button className="btn-primary flex items-center" onClick={() => setShowClubModal(true)}>
                   <Plus size={16} className="mr-2" />
                   Nuevo club
                 </button>
@@ -505,7 +511,7 @@ const Admin = () => {
             <div>
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-2xl font-bold">Gestión de Jugadores</h2>
-                <button className="btn-primary flex items-center">
+                <button className="btn-primary flex items-center" onClick={() => setShowPlayerModal(true)}>
                   <Plus size={16} className="mr-2" />
                   Nuevo jugador
                 </button>
@@ -615,6 +621,9 @@ const Admin = () => {
           )}
         </div>
       </div>
+      {showUserModal && <NewUserModal onClose={() => setShowUserModal(false)} />}
+      {showClubModal && <NewClubModal onClose={() => setShowClubModal(false)} />}
+      {showPlayerModal && <NewPlayerModal onClose={() => setShowPlayerModal(false)} />}
     </div>
   );
 };

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -12,9 +12,10 @@ import {
   faqs,
   storeItems
 } from '../data/mockData';
-import { 
-  Club, 
+import {
+  Club,
   Player,
+  User,
   Tournament,
   Transfer,
   TransferOffer,
@@ -28,6 +29,7 @@ import {
 interface DataState {
   clubs: Club[];
   players: Player[];
+  users: User[];
   tournaments: Tournament[];
   transfers: Transfer[];
   offers: TransferOffer[];
@@ -47,6 +49,9 @@ interface DataState {
   addOffer: (offer: TransferOffer) => void;
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
   addTransfer: (transfer: Transfer) => void;
+  addUser: (user: User) => void;
+  addClub: (club: Club) => void;
+  addPlayer: (player: Player) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -61,6 +66,7 @@ export const useDataStore = create<DataState>((set) => ({
   faqs,
   storeItems,
   marketStatus,
+  users: [],
   
   updateClubs: (newClubs) => set({ clubs: newClubs }),
   
@@ -79,13 +85,25 @@ export const useDataStore = create<DataState>((set) => ({
   })),
   
   updateOfferStatus: (offerId, status) => set((state) => ({
-    offers: state.offers.map(offer => 
+    offers: state.offers.map(offer =>
       offer.id === offerId ? { ...offer, status } : offer
     )
   })),
-  
+
   addTransfer: (transfer) => set((state) => ({
     transfers: [transfer, ...state.transfers]
+  })),
+
+  addUser: (user) => set((state) => ({
+    users: [...state.users, user]
+  })),
+
+  addClub: (club) => set((state) => ({
+    clubs: [...state.clubs, club]
+  })),
+
+  addPlayer: (player) => set((state) => ({
+    players: [...state.players, player]
   }))
 }));
  

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -135,6 +135,53 @@ export const register = (
   return newUser;
 };
 
+// Add new user (admin)
+export const addUser = (
+  email: string,
+  username: string,
+  role: 'user' | 'dt' | 'admin',
+  clubId?: string
+): User => {
+  const users = getUsers();
+
+  const usernameExists = users.some(
+    u => u.username.toLowerCase() === username.toLowerCase()
+  );
+  if (usernameExists) {
+    throw new Error('El nombre de usuario ya está en uso');
+  }
+
+  const emailExists = users.some(
+    u => u.email.toLowerCase() === email.toLowerCase()
+  );
+  if (emailExists) {
+    throw new Error('El correo electrónico ya está en uso');
+  }
+
+  const newUser: User = {
+    id: `${Date.now()}`,
+    username,
+    email,
+    role,
+    avatar: `https://ui-avatars.com/api/?name=${encodeURIComponent(
+      username
+    )}&background=111827&color=fff&size=128`,
+    xp: 0,
+    clubId,
+    joinDate: new Date().toISOString(),
+    status: 'active',
+    notifications: true,
+    lastLogin: new Date().toISOString(),
+    followers: 0,
+    following: 0
+  };
+
+  users.push(newUser);
+  saveUsers(users);
+
+  return newUser;
+};
+
 // Login function
 export const login = (username: string): User => {
   // Get users, falling back to test users if none exist


### PR DESCRIPTION
## Summary
- add modals for creating users, clubs and players
- extend data store with users and add actions
- add `addUser` helper in auth service
- open modals from Admin panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68541eef29088333a43386bc2794a7f3