### PR TITLE
Add create helpers to data store

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,13 +1,14 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
-import { clubs, players } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 
 const Admin = () => {
   const [activeTab, setActiveTab] = useState('dashboard');
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
+  const { clubs, players, addClub, addPlayer, addTournament } = useDataStore();
 
   // Redirect if not admin
   if (!isAuthenticated || user?.role !== 'admin') {
@@ -246,7 +247,26 @@ const Admin = () => {
                         <span className="text-sm">Abrir/cerrar mercado</span>
                       </button>
                       
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => {
+                          const name = prompt('Nombre del torneo');
+                          if (!name) return;
+                          addTournament({
+                            id: `tournament${Date.now()}`,
+                            name,
+                            type: 'friendly',
+                            logo: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=7f39fb&color=fff&size=128`,
+                            startDate: new Date().toISOString().slice(0, 10),
+                            endDate: new Date().toISOString().slice(0, 10),
+                            status: 'upcoming',
+                            teams: clubs.map(c => c.name),
+                            rounds: 1,
+                            matches: [],
+                            description: ''
+                          });
+                        }}
+                      >
                         <Trophy size={18} className="mb-1" />
                         <span className="text-sm">Crear torneo</span>
                       </button>
@@ -442,7 +462,29 @@ const Admin = () => {
             <div>
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-2xl font-bold">Gestión de Clubes</h2>
-                <button className="btn-primary flex items-center">
+                <button
+                  className="btn-primary flex items-center"
+                  onClick={() => {
+                    const name = prompt('Nombre del club');
+                    if (!name) return;
+                    addClub({
+                      id: `club${Date.now()}`,
+                      name,
+                      logo: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=111827&color=fff&size=128`,
+                      foundedYear: new Date().getFullYear(),
+                      stadium: `${name} Stadium`,
+                      budget: 20000000,
+                      manager: 'DT',
+                      playStyle: 'Equilibrado',
+                      primaryColor: '#ffffff',
+                      secondaryColor: '#000000',
+                      description: '',
+                      titles: [],
+                      reputation: 50,
+                      fanBase: 0
+                    });
+                  }}
+                >
                   <Plus size={16} className="mr-2" />
                   Nuevo club
                 </button>
@@ -505,7 +547,42 @@ const Admin = () => {
             <div>
               <div className="flex justify-between items-center mb-6">
                 <h2 className="text-2xl font-bold">Gestión de Jugadores</h2>
-                <button className="btn-primary flex items-center">
+                <button
+                  className="btn-primary flex items-center"
+                  onClick={() => {
+                    const name = prompt('Nombre del jugador');
+                    if (!name) return;
+                    addPlayer({
+                      id: `player${Date.now()}`,
+                      name,
+                      age: 18,
+                      position: 'ST',
+                      nationality: 'Desconocido',
+                      clubId: clubs[0]?.id || '',
+                      overall: 60,
+                      potential: 70,
+                      transferListed: false,
+                      transferValue: 1000000,
+                      image: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=1e293b&color=fff&size=128`,
+                      attributes: {
+                        pace: 60,
+                        shooting: 60,
+                        passing: 60,
+                        dribbling: 60,
+                        defending: 60,
+                        physical: 60
+                      },
+                      contract: {
+                        expires: `${new Date().getFullYear() + 2}-06-30`,
+                        salary: 1000
+                      },
+                      form: 3,
+                      goals: 0,
+                      assists: 0,
+                      appearances: 0
+                    });
+                  }}
+                >
                   <Plus size={16} className="mr-2" />
                   Nuevo jugador
                 </button>

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -1,19 +1,19 @@
-import  { create } from 'zustand';
-import { 
-  clubs,
-  players,
-  tournaments,
-  transfers,
-  offers,
-  marketStatus,
+import { create } from 'zustand';
+import {
+  clubs as defaultClubs,
+  players as defaultPlayers,
+  tournaments as defaultTournaments,
+  transfers as defaultTransfers,
+  offers as defaultOffers,
+  marketStatus as defaultMarketStatus,
   leagueStandings,
-  newsItems,
-  mediaItems,
-  faqs,
-  storeItems
+  newsItems as defaultNews,
+  mediaItems as defaultMedia,
+  faqs as defaultFaqs,
+  storeItems as defaultStoreItems
 } from '../data/mockData';
-import { 
-  Club, 
+import {
+  Club,
   Player,
   Tournament,
   Transfer,
@@ -25,7 +25,9 @@ import {
   StoreItem
 } from '../types';
 
-interface DataState {
+const DATA_KEY = 'virtual_zone_data';
+
+interface StoreData {
   clubs: Club[];
   players: Player[];
   tournaments: Tournament[];
@@ -37,55 +39,158 @@ interface DataState {
   faqs: FAQ[];
   storeItems: StoreItem[];
   marketStatus: boolean;
-  
+}
+
+interface DataState extends StoreData {
   updateClubs: (newClubs: Club[]) => void;
   updatePlayers: (newPlayers: Player[]) => void;
   updateTournaments: (newTournaments: Tournament[]) => void;
   updateTransfers: (newTransfers: Transfer[]) => void;
   updateOffers: (newOffers: TransferOffer[]) => void;
   updateMarketStatus: (status: boolean) => void;
+  addClub: (club: Club) => void;
+  addPlayer: (player: Player) => void;
+  addTournament: (tournament: Tournament) => void;
+  addNewsItem: (item: NewsItem) => void;
+  addMediaItem: (item: MediaItem) => void;
+  addFAQ: (faq: FAQ) => void;
+  addStoreItem: (item: StoreItem) => void;
   addOffer: (offer: TransferOffer) => void;
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
   addTransfer: (transfer: Transfer) => void;
 }
 
-export const useDataStore = create<DataState>((set) => ({
-  clubs,
-  players,
-  tournaments,
-  transfers,
-  offers,
-  standings: leagueStandings,
-  newsItems,
-  mediaItems,
-  faqs,
-  storeItems,
-  marketStatus,
-  
-  updateClubs: (newClubs) => set({ clubs: newClubs }),
-  
-  updatePlayers: (newPlayers) => set({ players: newPlayers }),
-  
-  updateTournaments: (newTournaments) => set({ tournaments: newTournaments }),
-  
-  updateTransfers: (newTransfers) => set({ transfers: newTransfers }),
-  
-  updateOffers: (newOffers) => set({ offers: newOffers }),
-  
-  updateMarketStatus: (status) => set({ marketStatus: status }),
-  
-  addOffer: (offer) => set((state) => ({
-    offers: [...state.offers, offer]
-  })),
-  
-  updateOfferStatus: (offerId, status) => set((state) => ({
-    offers: state.offers.map(offer => 
-      offer.id === offerId ? { ...offer, status } : offer
-    )
-  })),
-  
-  addTransfer: (transfer) => set((state) => ({
-    transfers: [transfer, ...state.transfers]
-  }))
-}));
- 
+function loadData(): Partial<StoreData> | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const json = localStorage.getItem(DATA_KEY);
+    return json ? (JSON.parse(json) as StoreData) : null;
+  } catch (err) {
+    console.error('Failed to load data', err);
+    return null;
+  }
+}
+
+function saveData(state: StoreData): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(DATA_KEY, JSON.stringify(state));
+  } catch (err) {
+    console.error('Failed to save data', err);
+  }
+}
+
+export const useDataStore = create<DataState>((set, get) => {
+  const saved = loadData();
+  const initial: StoreData = {
+    clubs: saved?.clubs || defaultClubs,
+    players: saved?.players || defaultPlayers,
+    tournaments: saved?.tournaments || defaultTournaments,
+    transfers: saved?.transfers || defaultTransfers,
+    offers: saved?.offers || defaultOffers,
+    standings: leagueStandings,
+    newsItems: saved?.newsItems || defaultNews,
+    mediaItems: saved?.mediaItems || defaultMedia,
+    faqs: saved?.faqs || defaultFaqs,
+    storeItems: saved?.storeItems || defaultStoreItems,
+    marketStatus: saved?.marketStatus ?? defaultMarketStatus
+  };
+
+  const persist = (partial?: Partial<StoreData>) => {
+    const current = { ...get(), ...partial } as DataState;
+    const data: StoreData = {
+      clubs: current.clubs,
+      players: current.players,
+      tournaments: current.tournaments,
+      transfers: current.transfers,
+      offers: current.offers,
+      standings: current.standings,
+      newsItems: current.newsItems,
+      mediaItems: current.mediaItems,
+      faqs: current.faqs,
+      storeItems: current.storeItems,
+      marketStatus: current.marketStatus
+    };
+    saveData(data);
+  };
+
+  return {
+    ...initial,
+    updateClubs: (newClubs) => set(() => {
+      persist({ clubs: newClubs });
+      return { clubs: newClubs };
+    }),
+    updatePlayers: (newPlayers) => set(() => {
+      persist({ players: newPlayers });
+      return { players: newPlayers };
+    }),
+    updateTournaments: (newTournaments) => set(() => {
+      persist({ tournaments: newTournaments });
+      return { tournaments: newTournaments };
+    }),
+    updateTransfers: (newTransfers) => set(() => {
+      persist({ transfers: newTransfers });
+      return { transfers: newTransfers };
+    }),
+    updateOffers: (newOffers) => set(() => {
+      persist({ offers: newOffers });
+      return { offers: newOffers };
+    }),
+    updateMarketStatus: (status) => set(() => {
+      persist({ marketStatus: status });
+      return { marketStatus: status };
+    }),
+    addClub: (club) => set((state) => {
+      const clubs = [...state.clubs, club];
+      persist({ clubs });
+      return { clubs };
+    }),
+    addPlayer: (player) => set((state) => {
+      const players = [...state.players, player];
+      persist({ players });
+      return { players };
+    }),
+    addTournament: (tournament) => set((state) => {
+      const tournaments = [...state.tournaments, tournament];
+      persist({ tournaments });
+      return { tournaments };
+    }),
+    addNewsItem: (item) => set((state) => {
+      const newsItems = [...state.newsItems, item];
+      persist({ newsItems });
+      return { newsItems };
+    }),
+    addMediaItem: (item) => set((state) => {
+      const mediaItems = [...state.mediaItems, item];
+      persist({ mediaItems });
+      return { mediaItems };
+    }),
+    addFAQ: (faq) => set((state) => {
+      const faqs = [...state.faqs, faq];
+      persist({ faqs });
+      return { faqs };
+    }),
+    addStoreItem: (item) => set((state) => {
+      const storeItems = [...state.storeItems, item];
+      persist({ storeItems });
+      return { storeItems };
+    }),
+    addOffer: (offer) => set((state) => {
+      const offers = [...state.offers, offer];
+      persist({ offers });
+      return { offers };
+    }),
+    updateOfferStatus: (offerId, status) => set((state) => {
+      const offers = state.offers.map((offer) =>
+        offer.id === offerId ? { ...offer, status } : offer
+      );
+      persist({ offers });
+      return { offers };
+    }),
+    addTransfer: (transfer) => set((state) => {
+      const transfers = [transfer, ...state.transfers];
+      persist({ transfers });
+      return { transfers };
+    })
+  };
+});


### PR DESCRIPTION
## Summary
- add `addClub`, `addPlayer`, `addTournament` and other helpers to data store
- persist store data to localStorage
- update Admin panel to use store helpers when creating records

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68541ef1079c83339bafdd797f97cc60