### PR TITLE
Normalize user props

### DIFF
--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -23,8 +23,8 @@ const OfferModal = ({ player, onClose }: OfferModalProps) => {
   const playerClub = clubs.find(c => c.id === player.clubId);
   
   // Find user's club (if DT)
-  const userClub = user?.role === 'dt' && user?.clubId 
-    ? clubs.find(c => c.id === user.clubId) 
+  const userClub = user?.role === 'dt' && user?.club
+    ? clubs.find(c => c.name === user.club)
     : null;
   
   // Calculate min and max offer

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -15,15 +15,15 @@ const OffersPanel = () => {
   
   // Filter offers based on user role
   const filteredOffers = user ? 
-    user.role === 'admin' ? 
+    user.role === 'admin' ?
       // Admin sees all offers
-      offers : 
-    user.role === 'dt' && user.clubId ? 
+      offers :
+    user.role === 'dt' && user.club ?
       // DT sees offers for their club
       offers.filter(o => {
-        const userClub = clubs.find(c => c.id === user.clubId);
+        const userClub = clubs.find(c => c.name === user.club);
         return userClub && (o.fromClub === userClub.name || o.toClub === userClub.name);
-      }) : 
+      }) :
       // User made offers
       offers.filter(o => o.userId === user.id) :
     [];
@@ -68,8 +68,8 @@ const OffersPanel = () => {
     if (offer.status !== 'pending') return false;
     
     // Check if user is DT of the selling club
-    if (user.role === 'dt' && user.clubId) {
-      const userClub = clubs.find(c => c.id === user.clubId);
+    if (user.role === 'dt' && user.club) {
+      const userClub = clubs.find(c => c.name === user.club);
       return userClub && userClub.name === offer.fromClub;
     }
     

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,8 +6,8 @@ export interface User {
   role: 'user' | 'dt' | 'admin';
   avatar: string;
   xp: number;
-  clubId?: string;
-  joinDate: string;
+  club?: string;
+  createdAt: string;
   status: 'active' | 'suspended' | 'banned';
   notifications: boolean;
   lastLogin: string;

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -120,7 +120,7 @@ export const register = (
       username
     )}&background=111827&color=fff&size=128`,
     xp: 0,
-    joinDate: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
     status: 'active',
     notifications: true,
     lastLogin: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- rename `clubId` to `club` in User type
- rename `joinDate` to `createdAt`
- adjust auth service and market components for new fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68541ef1a4c083338703ec80520f2b86