### PR TITLE
Add admin market and tournament management

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -41,6 +41,7 @@ interface DataState {
   updateClubs: (newClubs: Club[]) => void;
   updatePlayers: (newPlayers: Player[]) => void;
   updateTournaments: (newTournaments: Tournament[]) => void;
+  addTournament: (tournament: Tournament) => void;
   updateTransfers: (newTransfers: Transfer[]) => void;
   updateOffers: (newOffers: TransferOffer[]) => void;
   updateMarketStatus: (status: boolean) => void;
@@ -67,6 +68,10 @@ export const useDataStore = create<DataState>((set) => ({
   updatePlayers: (newPlayers) => set({ players: newPlayers }),
   
   updateTournaments: (newTournaments) => set({ tournaments: newTournaments }),
+
+  addTournament: (tournament) => set((state) => ({
+    tournaments: [...state.tournaments, tournament]
+  })),
   
   updateTransfers: (newTransfers) => set({ transfers: newTransfers }),
   


### PR DESCRIPTION
## Summary
- add `addTournament` store action
- build admin market tab with offers list and market toggle
- build tournament management UI with creation/edit/delete

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68541ef45d3c8333809fbeea48c6185a