### PR TITLE
Refactor pages to use zustand store

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -5,13 +5,14 @@ import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
 import { useAuthStore } from '../store/authStore';
-import { clubs, players } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 
 const Admin = () => {
   const [activeTab, setActiveTab] = useState('dashboard');
   const [showUserModal, setShowUserModal] = useState(false);
   const [showClubModal, setShowClubModal] = useState(false);
   const [showPlayerModal, setShowPlayerModal] = useState(false);
+  const { clubs, players } = useDataStore();
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -2,11 +2,13 @@ import  { useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Calendar, Search, ChevronRight, FileText } from 'lucide-react';
-import { posts } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 
 const Blog = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
+
+  const { posts } = useDataStore();
   
   // Filter posts
   const filteredPosts = posts.filter(post => {

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,9 +1,11 @@
 import  { useParams, Link } from 'react-router-dom';
 import { Calendar, ChevronLeft, MessageSquare, Share, ThumbsUp, ArrowRight } from 'lucide-react';
-import { posts } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 
 const BlogPost = () => {
   const { slug } = useParams<{ slug: string }>();
+
+  const { posts } = useDataStore();
   
   // Find post by slug
   const post = posts.find(p => p.slug === slug);

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -1,11 +1,13 @@
 import  { useParams, Link } from 'react-router-dom';
 import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
-import { clubs, transfers } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 import { formatCurrency, formatDate } from '../utils/helpers';
 
 const ClubFinances = () => {
   const { clubName } = useParams<{ clubName: string }>();
+
+  const { clubs, transfers } = useDataStore();
   
   // Find club by slug
   const club = clubs.find(c => c.name.toLowerCase().replace(/\s+/g, '-') === clubName);

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -1,7 +1,7 @@
 import  { useParams, Link } from 'react-router-dom';
 import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
-import { clubs, players } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 import { formatCurrency } from '../utils/helpers';
 import { useState } from 'react';
 
@@ -9,6 +9,8 @@ const ClubSquad = () => {
   const { clubName } = useParams<{ clubName: string }>();
   const [sortBy, setSortBy] = useState('overall');
   const [sortOrder, setSortOrder] = useState('desc');
+
+  const { clubs, players } = useDataStore();
   
   // Find club by slug
   const club = clubs.find(c => c.name.toLowerCase().replace(/\s+/g, '-') === clubName);

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,12 +1,14 @@
 import  { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Search, AlertCircle } from 'lucide-react';
-import { storeItems } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 import { formatCurrency } from '../utils/helpers';
 
 const Store = () => {
   const [activeCategory, setActiveCategory] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
+
+  const { storeItems } = useDataStore();
   
   // Filter store items
   const filteredItems = storeItems.filter(product => {

--- a/src/pages/TournamentDetail.tsx
+++ b/src/pages/TournamentDetail.tsx
@@ -2,13 +2,15 @@ import  { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, ChevronLeft, Image, ArrowRight, Star } from 'lucide-react';
-import { tournaments, clubs } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 import { Match } from '../types';
 import { formatDate } from '../utils/helpers';
 
 const TournamentDetail = () => {
   const { tournamentName } = useParams<{ tournamentName: string }>();
   const [activeTab, setActiveTab] = useState('overview');
+
+  const { tournaments, clubs } = useDataStore();
   
   // Find tournament by slug
   const tournament = tournaments.find(t => t.slug === tournamentName);

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -1,11 +1,13 @@
 import  { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, Calendar, Users, ChevronRight, Filter } from 'lucide-react';
-import { tournaments } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 import { useState } from 'react';
 
 const Tournaments = () => {
   const [filter, setFilter] = useState('all'); // 'all', 'ongoing', 'open', 'finished'
+
+  const { tournaments } = useDataStore();
   
   // Filter tournaments
   const filteredTournaments = filter === 'all' 

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,10 +1,12 @@
 import  { useParams, Link } from 'react-router-dom';
 import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
-import { clubs } from '../data/mockData';
+import { useDataStore } from '../store/dataStore';
 
 const UserProfile = () => {
   const { username } = useParams<{ username: string }>();
+
+  const { clubs } = useDataStore();
   
   // Mock user for demo
   const user = {


### PR DESCRIPTION
## Summary
- fetch data from `useDataStore` hook instead of static imports
- clean up imports across pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685424e3e6b48333b2457c848c5b23aa