### PR TITLE
Add quick create dialogs

### DIFF
--- a/src/components/admin/NewTournamentModal.tsx
+++ b/src/components/admin/NewTournamentModal.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { Tournament } from '../../types';
+
+interface Props {
+  onClose: () => void;
+}
+
+const NewTournamentModal = ({ onClose }: Props) => {
+  const addTournament = useDataStore(state => state.addTournament);
+  const [name, setName] = useState('');
+  const [type, setType] = useState<'league' | 'cup' | 'friendly'>('league');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!name || !startDate || !endDate) {
+      setError('Completa todos los campos');
+      return;
+    }
+
+    const newTournament: Tournament = {
+      id: `${Date.now()}`,
+      name,
+      type,
+      logo: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=7f39fb&color=fff&size=128&bold=true`,
+      startDate,
+      endDate,
+      status: 'upcoming',
+      teams: [],
+      rounds: 0,
+      matches: [],
+      description: ''
+    };
+
+    addTournament(newTournament);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Nuevo Torneo</h3>
+        {error && <div className="mb-4 p-3 bg-red-500/20 text-red-400 rounded-lg">{error}</div>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre</label>
+            <input className="input w-full" value={name} onChange={e => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Tipo</label>
+            <select className="input w-full" value={type} onChange={e => setType(e.target.value as 'league' | 'cup' | 'friendly') }>
+              <option value="league">Liga</option>
+              <option value="cup">Copa</option>
+              <option value="friendly">Amistoso</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Inicio</label>
+            <input type="date" className="input w-full" value={startDate} onChange={e => setStartDate(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Fin</label>
+            <input type="date" className="input w-full" value={endDate} onChange={e => setEndDate(e.target.value)} />
+          </div>
+          <button type="submit" className="btn-primary w-full">Crear</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewTournamentModal;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,6 +4,7 @@ import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, B
 import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
+import NewTournamentModal from '../components/admin/NewTournamentModal';
 import { useAuthStore } from '../store/authStore';
 import { clubs, players } from '../data/mockData';
 
@@ -12,6 +13,7 @@ const Admin = () => {
   const [showUserModal, setShowUserModal] = useState(false);
   const [showClubModal, setShowClubModal] = useState(false);
   const [showPlayerModal, setShowPlayerModal] = useState(false);
+  const [showTournamentModal, setShowTournamentModal] = useState(false);
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 
@@ -242,31 +244,40 @@ const Admin = () => {
                   <h3 className="text-xl font-bold mb-4">Acciones rápidas</h3>
                   <div className="bg-dark-light rounded-lg border border-gray-800 p-4">
                     <div className="grid grid-cols-2 gap-4">
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setShowClubModal(true)}
+                      >
                         <Users size={18} className="mb-1" />
-                        <span className="text-sm">Gestionar usuarios</span>
+                        <span className="text-sm">Nuevo club</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setShowPlayerModal(true)}
+                      >
                         <ShoppingCart size={18} className="mb-1" />
-                        <span className="text-sm">Abrir/cerrar mercado</span>
+                        <span className="text-sm">Nuevo jugador</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setShowTournamentModal(true)}
+                      >
                         <Trophy size={18} className="mb-1" />
-                        <span className="text-sm">Crear torneo</span>
+                        <span className="text-sm">Nuevo torneo</span>
                       </button>
-                      
+
                       <button className="btn-outline py-3 flex flex-col items-center justify-center">
                         <Calendar size={18} className="mb-1" />
                         <span className="text-sm">Registrar resultados</span>
                       </button>
-                      
+
                       <button className="btn-outline py-3 flex flex-col items-center justify-center">
                         <FileText size={18} className="mb-1" />
                         <span className="text-sm">Crear noticia</span>
                       </button>
-                      
+
                       <button className="btn-outline py-3 flex flex-col items-center justify-center">
                         <Settings size={18} className="mb-1" />
                         <span className="text-sm">Configuración</span>
@@ -624,6 +635,7 @@ const Admin = () => {
       {showUserModal && <NewUserModal onClose={() => setShowUserModal(false)} />}
       {showClubModal && <NewClubModal onClose={() => setShowClubModal(false)} />}
       {showPlayerModal && <NewPlayerModal onClose={() => setShowPlayerModal(false)} />}
+      {showTournamentModal && <NewTournamentModal onClose={() => setShowTournamentModal(false)} />}
     </div>
   );
 };

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -52,6 +52,7 @@ interface DataState {
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
+  addTournament: (tournament: Tournament) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -104,6 +105,10 @@ export const useDataStore = create<DataState>((set) => ({
 
   addPlayer: (player) => set((state) => ({
     players: [...state.players, player]
+  })),
+
+  addTournament: (tournament) => set((state) => ({
+    tournaments: [...state.tournaments, tournament]
   }))
 }));
  


### PR DESCRIPTION
## Summary
- add a dialog component for tournament creation
- expose `addTournament` in the store
- trigger club, player and tournament dialogs from admin quick actions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685424e4c6d88333a0abb5500fa80e51