### PR TITLE
Add admin edit/delete controls

### DIFF
--- a/src/components/admin/ConfirmDeleteModal.tsx
+++ b/src/components/admin/ConfirmDeleteModal.tsx
@@ -1,0 +1,27 @@
+import { X } from 'lucide-react';
+
+interface Props {
+  message: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const ConfirmDeleteModal = ({ message, onConfirm, onClose }: Props) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-6 text-center">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <p className="mb-6">{message}</p>
+        <div className="flex justify-center space-x-4">
+          <button className="btn-outline" onClick={onClose}>Cancelar</button>
+          <button className="btn-primary" onClick={() => { onConfirm(); onClose(); }}>Eliminar</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDeleteModal;

--- a/src/components/admin/EditClubModal.tsx
+++ b/src/components/admin/EditClubModal.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { Club } from '../../types';
+
+interface Props {
+  club: Club;
+  onClose: () => void;
+}
+
+const EditClubModal = ({ club, onClose }: Props) => {
+  const { updateClubEntry } = useDataStore();
+  const [name, setName] = useState(club.name);
+  const [manager, setManager] = useState(club.manager);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateClubEntry({ ...club, name, manager });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Editar Club</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre</label>
+            <input className="input w-full" value={name} onChange={e => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Entrenador</label>
+            <input className="input w-full" value={manager} onChange={e => setManager(e.target.value)} />
+          </div>
+          <button type="submit" className="btn-primary w-full">Guardar</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EditClubModal;

--- a/src/components/admin/EditPlayerModal.tsx
+++ b/src/components/admin/EditPlayerModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { Player } from '../../types';
+
+interface Props {
+  player: Player;
+  onClose: () => void;
+}
+
+const EditPlayerModal = ({ player, onClose }: Props) => {
+  const { clubs, updatePlayerEntry } = useDataStore();
+  const [name, setName] = useState(player.name);
+  const [position, setPosition] = useState(player.position);
+  const [clubId, setClubId] = useState(player.clubId);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updatePlayerEntry({ ...player, name, position, clubId });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Editar Jugador</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre</label>
+            <input className="input w-full" value={name} onChange={e => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Posición</label>
+            <input className="input w-full" value={position} onChange={e => setPosition(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Club</label>
+            <select className="input w-full" value={clubId} onChange={e => setClubId(e.target.value)}>
+              {clubs.map(c => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+          <button type="submit" className="btn-primary w-full">Guardar</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EditPlayerModal;

--- a/src/components/admin/EditUserModal.tsx
+++ b/src/components/admin/EditUserModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { User } from '../../types';
+
+interface Props {
+  user: User;
+  onClose: () => void;
+}
+
+const EditUserModal = ({ user, onClose }: Props) => {
+  const { updateUserEntry } = useDataStore();
+  const [username, setUsername] = useState(user.username);
+  const [email, setEmail] = useState(user.email);
+  const [role, setRole] = useState<User['role']>(user.role);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateUserEntry({ ...user, username, email, role });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Editar Usuario</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Nombre de usuario</label>
+            <input className="input w-full" value={username} onChange={e => setUsername(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Correo</label>
+            <input className="input w-full" value={email} onChange={e => setEmail(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Rol</label>
+            <select className="input w-full" value={role} onChange={e => setRole(e.target.value as User['role'])}>
+              <option value="user">Usuario</option>
+              <option value="dt">DT</option>
+              <option value="admin">Admin</option>
+            </select>
+          </div>
+          <button type="submit" className="btn-primary w-full">Guardar</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EditUserModal;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,6 +4,11 @@ import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, B
 import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
+import EditUserModal from '../components/admin/EditUserModal';
+import EditClubModal from '../components/admin/EditClubModal';
+import EditPlayerModal from '../components/admin/EditPlayerModal';
+import ConfirmDeleteModal from '../components/admin/ConfirmDeleteModal';
+import { User, Club, Player } from '../types';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
 
@@ -12,7 +17,20 @@ const Admin = () => {
   const [showUserModal, setShowUserModal] = useState(false);
   const [showClubModal, setShowClubModal] = useState(false);
   const [showPlayerModal, setShowPlayerModal] = useState(false);
-  const { clubs, players, users } = useDataStore();
+  const [editingUser, setEditingUser] = useState(null as User | null);
+  const [editingClub, setEditingClub] = useState(null as Club | null);
+  const [editingPlayer, setEditingPlayer] = useState(null as Player | null);
+  const [userToDelete, setUserToDelete] = useState(null as User | null);
+  const [clubToDelete, setClubToDelete] = useState(null as Club | null);
+  const [playerToDelete, setPlayerToDelete] = useState(null as Player | null);
+  const {
+    clubs,
+    players,
+    users,
+    removeUser,
+    removeClub,
+    removePlayer
+  } = useDataStore();
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 
@@ -316,9 +334,13 @@ const Admin = () => {
                             : u.role === 'dt'
                             ? 'DT'
                             : 'Usuario';
+                        const userWithClub = u as User & {
+                          clubId?: string;
+                          club?: string;
+                        };
                         const clubName =
-                          clubs.find((c) => c.id === (u as any).clubId)?.name ||
-                          (u as any).club ||
+                          clubs.find(c => c.id === userWithClub.clubId)?.name ||
+                          userWithClub.club ||
                           '-';
 
                         return (
@@ -351,10 +373,16 @@ const Admin = () => {
                             </td>
                             <td className="px-4 py-3 text-center">
                               <div className="flex justify-center space-x-2">
-                                <button className="p-1 text-gray-400 hover:text-primary">
+                                <button
+                                  className="p-1 text-gray-400 hover:text-primary"
+                                  onClick={() => setEditingUser(u)}
+                                >
                                   <Edit size={16} />
                                 </button>
-                                <button className="p-1 text-gray-400 hover:text-red-500">
+                                <button
+                                  className="p-1 text-gray-400 hover:text-red-500"
+                                  onClick={() => setUserToDelete(u)}
+                                >
                                   <Trash size={16} />
                                 </button>
                               </div>
@@ -415,10 +443,16 @@ const Admin = () => {
                           <td className="px-4 py-3 text-center">{club.playStyle}</td>
                           <td className="px-4 py-3 text-center">
                             <div className="flex justify-center space-x-2">
-                              <button className="p-1 text-gray-400 hover:text-primary">
+                              <button
+                                className="p-1 text-gray-400 hover:text-primary"
+                                onClick={() => setEditingClub(club)}
+                              >
                                 <Edit size={16} />
                               </button>
-                              <button className="p-1 text-gray-400 hover:text-red-500">
+                              <button
+                                className="p-1 text-gray-400 hover:text-red-500"
+                                onClick={() => setClubToDelete(club)}
+                              >
                                 <Trash size={16} />
                               </button>
                             </div>
@@ -483,10 +517,16 @@ const Admin = () => {
                           </td>
                           <td className="px-4 py-3 text-center">
                             <div className="flex justify-center space-x-2">
-                              <button className="p-1 text-gray-400 hover:text-primary">
+                              <button
+                                className="p-1 text-gray-400 hover:text-primary"
+                                onClick={() => setEditingPlayer(player)}
+                              >
                                 <Edit size={16} />
                               </button>
-                              <button className="p-1 text-gray-400 hover:text-red-500">
+                              <button
+                                className="p-1 text-gray-400 hover:text-red-500"
+                                onClick={() => setPlayerToDelete(player)}
+                              >
                                 <Trash size={16} />
                               </button>
                             </div>
@@ -549,6 +589,39 @@ const Admin = () => {
       {showUserModal && <NewUserModal onClose={() => setShowUserModal(false)} />}
       {showClubModal && <NewClubModal onClose={() => setShowClubModal(false)} />}
       {showPlayerModal && <NewPlayerModal onClose={() => setShowPlayerModal(false)} />}
+      {editingUser && (
+        <EditUserModal user={editingUser} onClose={() => setEditingUser(null)} />
+      )}
+      {editingClub && (
+        <EditClubModal club={editingClub} onClose={() => setEditingClub(null)} />
+      )}
+      {editingPlayer && (
+        <EditPlayerModal
+          player={editingPlayer}
+          onClose={() => setEditingPlayer(null)}
+        />
+      )}
+      {userToDelete && (
+        <ConfirmDeleteModal
+          message="¿Eliminar este usuario?"
+          onConfirm={() => removeUser(userToDelete.id)}
+          onClose={() => setUserToDelete(null)}
+        />
+      )}
+      {clubToDelete && (
+        <ConfirmDeleteModal
+          message="¿Eliminar este club?"
+          onConfirm={() => removeClub(clubToDelete.id)}
+          onClose={() => setClubToDelete(null)}
+        />
+      )}
+      {playerToDelete && (
+        <ConfirmDeleteModal
+          message="¿Eliminar este jugador?"
+          onConfirm={() => removePlayer(playerToDelete.id)}
+          onClose={() => setPlayerToDelete(null)}
+        />
+      )}
     </div>
   );
 };

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { getUsers } from '../utils/authService';
+import { getUsers, updateUser as persistUser } from '../utils/authService';
 import { 
   clubs,
   players,
@@ -53,6 +53,12 @@ interface DataState {
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
+  updateUserEntry: (user: User) => void;
+  removeUser: (id: string) => void;
+  updateClubEntry: (club: Club) => void;
+  removeClub: (id: string) => void;
+  updatePlayerEntry: (player: Player) => void;
+  removePlayer: (id: string) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -105,6 +111,33 @@ export const useDataStore = create<DataState>((set) => ({
 
   addPlayer: (player) => set((state) => ({
     players: [...state.players, player]
+  })),
+
+  updateUserEntry: (user) => set((state) => {
+    persistUser(user);
+    return {
+      users: state.users.map(u => (u.id === user.id ? user : u))
+    };
+  }),
+
+  removeUser: (id) => set((state) => ({
+    users: state.users.filter(u => u.id !== id)
+  })),
+
+  updateClubEntry: (club) => set((state) => ({
+    clubs: state.clubs.map(c => (c.id === club.id ? club : c))
+  })),
+
+  removeClub: (id) => set((state) => ({
+    clubs: state.clubs.filter(c => c.id !== id)
+  })),
+
+  updatePlayerEntry: (player) => set((state) => ({
+    players: state.players.map(p => (p.id === player.id ? player : p))
+  })),
+
+  removePlayer: (id) => set((state) => ({
+    players: state.players.filter(p => p.id !== id)
   }))
 }));
  


### PR DESCRIPTION
## Summary
- extend data store with update/remove helpers
- create edit & confirm modals for admin panel
- hook admin tables to new modals

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68542b961c848333bdb789d9900351c2