### PR TITLE
Add admin management interfaces

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -53,6 +53,9 @@ interface DataState {
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
+  updateNewsItems: (items: NewsItem[]) => void;
+  addNewsItem: (item: NewsItem) => void;
+  updateStandings: (newStandings: Standing[]) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -105,6 +108,14 @@ export const useDataStore = create<DataState>((set) => ({
 
   addPlayer: (player) => set((state) => ({
     players: [...state.players, player]
-  }))
+  })),
+
+  updateNewsItems: (items) => set({ newsItems: items }),
+
+  addNewsItem: (item) => set((state) => ({
+    newsItems: [item, ...state.newsItems]
+  })),
+
+  updateStandings: (newStandings) => set({ standings: newStandings })
 }));
  


### PR DESCRIPTION
## Summary
- extend data store with news and standings helpers
- connect admin panel to store data
- implement management tables for transfer market, tournaments, news, stats and calendar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68542b9675bc833390ad48dd26cf0979