### PR TITLE
Add system state admin modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Within the admin panel you will find management sections for:
 - **Estadísticas Generales** – overview of club and player statistics.
 - **Calendario de Partidos** – schedule fixtures and events.
 
+Within the **Dashboard** section there is an _Estado del sistema_ card. Use the
+"Administrar estado del sistema" button to open a modal where you can:
+
+- Toggle the transfer market on or off.
+- Change the current season number.
+- Update the active matchday (jornada).
+
 ## Data Persistence
 
 User accounts and login state are stored in the browser using `localStorage`. Clearing your browser data resets this information. Other league data (clubs, players, tournaments, etc.) comes from mock files and is kept in memory only, so changes are lost on page refresh.

--- a/src/components/admin/SystemStateModal.tsx
+++ b/src/components/admin/SystemStateModal.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+
+interface Props {
+  onClose: () => void;
+}
+
+const SystemStateModal = ({ onClose }: Props) => {
+  const {
+    marketStatus,
+    season,
+    jornada,
+    updateMarketStatus,
+    updateSeason,
+    updateJornada
+  } = useDataStore();
+
+  const [localMarket, setLocalMarket] = useState(marketStatus);
+  const [localSeason, setLocalSeason] = useState(season);
+  const [localJornada, setLocalJornada] = useState(jornada);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateMarketStatus(localMarket);
+    updateSeason(Number(localSeason));
+    updateJornada(Number(localJornada));
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">Estado del Sistema</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Mercado de fichajes</label>
+            <select
+              className="input w-full"
+              value={localMarket ? 'open' : 'closed'}
+              onChange={(e) => setLocalMarket(e.target.value === 'open')}
+            >
+              <option value="open">Abierto</option>
+              <option value="closed">Cerrado</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Temporada</label>
+            <input
+              type="number"
+              className="input w-full"
+              value={localSeason}
+              onChange={(e) => setLocalSeason(Number(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Jornada actual</label>
+            <input
+              type="number"
+              className="input w-full"
+              value={localJornada}
+              onChange={(e) => setLocalJornada(Number(e.target.value))}
+            />
+          </div>
+          <button type="submit" className="btn-primary w-full">Guardar cambios</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SystemStateModal;

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -533,6 +533,10 @@ export const offers: TransferOffer[] = [
 // Market status
 export const marketStatus = true;
 
+// Current season and matchday
+export const currentSeason = 2025;
+export const currentJornada = 3;
+
 // Generate standings based on past matches
 export function generateStandings(tournamentId: string): Standing[] {
   const tournament = tournaments.find(t => t.id === tournamentId);

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,6 +4,7 @@ import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, B
 import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
+import SystemStateModal from '../components/admin/SystemStateModal';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
 
@@ -12,7 +13,8 @@ const Admin = () => {
   const [showUserModal, setShowUserModal] = useState(false);
   const [showClubModal, setShowClubModal] = useState(false);
   const [showPlayerModal, setShowPlayerModal] = useState(false);
-  const { clubs, players, users } = useDataStore();
+  const [showStateModal, setShowStateModal] = useState(false);
+  const { clubs, players, users, marketStatus, season, jornada } = useDataStore();
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 
@@ -210,19 +212,21 @@ const Admin = () => {
                       <div className="flex items-center justify-between">
                         <span className="text-gray-400">Mercado de fichajes</span>
                         <div className="flex items-center">
-                          <span className="h-2 w-2 rounded-full bg-green-500 mr-2"></span>
-                          <span className="font-medium">Abierto</span>
+                          <span
+                            className={`h-2 w-2 rounded-full mr-2 ${marketStatus ? 'bg-green-500' : 'bg-red-500'}`}
+                          ></span>
+                          <span className="font-medium">{marketStatus ? 'Abierto' : 'Cerrado'}</span>
                         </div>
                       </div>
                       
                       <div className="flex items-center justify-between">
                         <span className="text-gray-400">Jornada actual</span>
-                        <span className="font-medium">Jornada 3/38</span>
+                        <span className="font-medium">Jornada {jornada}</span>
                       </div>
                       
                       <div className="flex items-center justify-between">
                         <span className="text-gray-400">Temporada</span>
-                        <span className="font-medium">2025</span>
+                        <span className="font-medium">{season}</span>
                       </div>
                       
                       <div className="flex items-center justify-between">
@@ -231,7 +235,7 @@ const Admin = () => {
                       </div>
                       
                       <div className="mt-4 pt-4 border-t border-gray-800">
-                        <button className="btn-primary w-full">
+                        <button className="btn-primary w-full" onClick={() => setShowStateModal(true)}>
                           Administrar estado del sistema
                         </button>
                       </div>
@@ -316,9 +320,10 @@ const Admin = () => {
                             : u.role === 'dt'
                             ? 'DT'
                             : 'Usuario';
+                        const userClub = u as unknown as { clubId?: string; club?: string };
                         const clubName =
-                          clubs.find((c) => c.id === (u as any).clubId)?.name ||
-                          (u as any).club ||
+                          clubs.find((c) => c.id === userClub.clubId)?.name ||
+                          userClub.club ||
                           '-';
 
                         return (
@@ -549,6 +554,7 @@ const Admin = () => {
       {showUserModal && <NewUserModal onClose={() => setShowUserModal(false)} />}
       {showClubModal && <NewClubModal onClose={() => setShowClubModal(false)} />}
       {showPlayerModal && <NewPlayerModal onClose={() => setShowPlayerModal(false)} />}
+      {showStateModal && <SystemStateModal onClose={() => setShowStateModal(false)} />}
     </div>
   );
 };

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -7,6 +7,8 @@ import {
   transfers,
   offers,
   marketStatus,
+  currentSeason,
+  currentJornada,
   leagueStandings,
   newsItems,
   mediaItems,
@@ -40,6 +42,8 @@ interface DataState {
   faqs: FAQ[];
   storeItems: StoreItem[];
   marketStatus: boolean;
+  season: number;
+  jornada: number;
   
   updateClubs: (newClubs: Club[]) => void;
   updatePlayers: (newPlayers: Player[]) => void;
@@ -47,6 +51,8 @@ interface DataState {
   updateTransfers: (newTransfers: Transfer[]) => void;
   updateOffers: (newOffers: TransferOffer[]) => void;
   updateMarketStatus: (status: boolean) => void;
+  updateSeason: (season: number) => void;
+  updateJornada: (jornada: number) => void;
   addOffer: (offer: TransferOffer) => void;
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
   addTransfer: (transfer: Transfer) => void;
@@ -67,6 +73,8 @@ export const useDataStore = create<DataState>((set) => ({
   faqs,
   storeItems,
   marketStatus,
+  season: currentSeason,
+  jornada: currentJornada,
   users: getUsers(),
   
   updateClubs: (newClubs) => set({ clubs: newClubs }),
@@ -80,6 +88,8 @@ export const useDataStore = create<DataState>((set) => ({
   updateOffers: (newOffers) => set({ offers: newOffers }),
   
   updateMarketStatus: (status) => set({ marketStatus: status }),
+  updateSeason: (season) => set({ season }),
+  updateJornada: (jornada) => set({ jornada }),
   
   addOffer: (offer) => set((state) => ({
     offers: [...state.offers, offer]


### PR DESCRIPTION
## Summary
- allow updating market status, season, and matchday in a new modal
- wire new modal into Admin dashboard
- track season & jornada in the datastore
- document how to use the system state controls

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68542b96cc20833382d42325a07b0f3f