### PR TITLE
Add news manager with CRUD

### DIFF
--- a/src/components/admin/NewsItemModal.tsx
+++ b/src/components/admin/NewsItemModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { NewsItem } from '../../types';
+
+interface Props {
+  onClose: () => void;
+  onSave: (item: NewsItem) => void;
+  item?: NewsItem;
+}
+
+const NewsItemModal = ({ onClose, onSave, item }: Props) => {
+  const [title, setTitle] = useState(item?.title || '');
+  const [content, setContent] = useState(item?.content || '');
+  const [type, setType] = useState<NewsItem['type']>(item?.type || 'announcement');
+  const [featured, setFeatured] = useState<boolean>(item?.featured || false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newItem: NewsItem = {
+      id: item?.id || `${Date.now()}`,
+      title,
+      content,
+      type,
+      date: item?.date || new Date().toISOString().slice(0, 10),
+      author: item?.author || 'Admin',
+      featured,
+    };
+    onSave(newItem);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-lg p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        <h3 className="text-xl font-bold mb-4">{item ? 'Editar Noticia' : 'Nueva Noticia'}</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Título</label>
+            <input className="input w-full" value={title} onChange={(e) => setTitle(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Contenido</label>
+            <textarea className="input w-full h-24" value={content} onChange={(e) => setContent(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Tipo</label>
+            <select className="input w-full" value={type} onChange={(e) => setType(e.target.value as NewsItem['type'])}>
+              <option value="announcement">Anuncio</option>
+              <option value="transfer">Fichaje</option>
+              <option value="result">Resultado</option>
+              <option value="rumor">Rumor</option>
+              <option value="statement">Declaración</option>
+            </select>
+          </div>
+          <div className="flex items-center space-x-2">
+            <input type="checkbox" id="featured" checked={featured} onChange={(e) => setFeatured(e.target.checked)} />
+            <label htmlFor="featured" className="text-sm text-gray-400">Destacada</label>
+          </div>
+          <button type="submit" className="btn-primary w-full">{item ? 'Guardar' : 'Crear'}</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewsItemModal;

--- a/src/components/admin/NewsManager.tsx
+++ b/src/components/admin/NewsManager.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { Edit, Plus, Trash } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { NewsItem } from '../../types';
+import { formatDate, formatNewsType, getNewsTypeColor } from '../../utils/helpers';
+import NewsItemModal from './NewsItemModal';
+
+const NewsManager = () => {
+  const { newsItems, addNewsItem, editNewsItem, deleteNewsItem } = useDataStore();
+  const [showModal, setShowModal] = useState(false);
+  const [editingItem, setEditingItem] = useState<NewsItem | undefined>();
+
+  const handleCreate = () => {
+    setEditingItem(undefined);
+    setShowModal(true);
+  };
+
+  const handleEdit = (item: NewsItem) => {
+    setEditingItem(item);
+    setShowModal(true);
+  };
+
+  const handleSave = (item: NewsItem) => {
+    if (editingItem) {
+      editNewsItem(item);
+    } else {
+      addNewsItem(item);
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    if (confirm('¿Eliminar noticia?')) {
+      deleteNewsItem(id);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-bold">Gestión de Noticias</h2>
+        <button className="btn-primary flex items-center" onClick={handleCreate}>
+          <Plus size={16} className="mr-2" />
+          Nueva noticia
+        </button>
+      </div>
+
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Título</th>
+                <th className="px-4 py-3 text-center">Fecha</th>
+                <th className="px-4 py-3 text-center">Tipo</th>
+                <th className="px-4 py-3 text-center">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {newsItems.map((n) => (
+                <tr key={n.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                  <td className="px-4 py-3">{n.title}</td>
+                  <td className="px-4 py-3 text-center">{formatDate(n.date)}</td>
+                  <td className="px-4 py-3 text-center">
+                    <span className={`badge ${getNewsTypeColor(n.type)}`}>{formatNewsType(n.type)}</span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <div className="flex justify-center space-x-2">
+                      <button className="p-1 text-gray-400 hover:text-primary" onClick={() => handleEdit(n)}>
+                        <Edit size={16} />
+                      </button>
+                      <button className="p-1 text-gray-400 hover:text-red-500" onClick={() => handleDelete(n.id)}>
+                        <Trash size={16} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {showModal && (
+        <NewsItemModal
+          onClose={() => setShowModal(false)}
+          onSave={handleSave}
+          item={editingItem}
+        />
+      )}
+    </div>
+  );
+};
+
+export default NewsManager;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,6 +4,7 @@ import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, B
 import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
+import NewsManager from '../components/admin/NewsManager';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
 
@@ -316,9 +317,10 @@ const Admin = () => {
                             : u.role === 'dt'
                             ? 'DT'
                             : 'Usuario';
+                        const userClub = u as User & { clubId?: string };
                         const clubName =
-                          clubs.find((c) => c.id === (u as any).clubId)?.name ||
-                          (u as any).club ||
+                          clubs.find((c) => c.id === userClub.clubId)?.name ||
+                          userClub.club ||
                           '-';
 
                         return (
@@ -518,14 +520,7 @@ const Admin = () => {
             </div>
           )}
 
-          {activeTab === 'news' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">Gestión de Noticias</h2>
-              <div className="bg-dark-light rounded-lg border border-gray-800 p-6 text-gray-300">
-                Panel para crear y editar noticias de la liga.
-              </div>
-            </div>
-          )}
+          {activeTab === 'news' && <NewsManager />}
 
           {activeTab === 'stats' && (
             <div>

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -53,6 +53,10 @@ interface DataState {
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
+  updateNewsItems: (items: NewsItem[]) => void;
+  addNewsItem: (item: NewsItem) => void;
+  editNewsItem: (item: NewsItem) => void;
+  deleteNewsItem: (id: string) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -105,6 +109,20 @@ export const useDataStore = create<DataState>((set) => ({
 
   addPlayer: (player) => set((state) => ({
     players: [...state.players, player]
+  })),
+
+  updateNewsItems: (items) => set({ newsItems: items }),
+
+  addNewsItem: (item) => set((state) => ({
+    newsItems: [item, ...state.newsItems]
+  })),
+
+  editNewsItem: (item) => set((state) => ({
+    newsItems: state.newsItems.map(n => n.id === item.id ? item : n)
+  })),
+
+  deleteNewsItem: (id) => set((state) => ({
+    newsItems: state.newsItems.filter(n => n.id !== id)
   }))
 }));
  


### PR DESCRIPTION
## Summary
- extend `useDataStore` with CRUD for news items
- add admin components to manage news
- wire up the new NewsManager in the admin page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542b99111883339d9dc60d2d3dea34