### PR TITLE
Add update/delete functions

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -27,6 +27,9 @@ import {
   StoreItem
 } from '../types';
 
+const USERS_KEY = 'virtual_zone_users';
+const CURRENT_USER_KEY = 'virtual_zone_current_user';
+
 interface DataState {
   clubs: Club[];
   players: Player[];
@@ -51,8 +54,14 @@ interface DataState {
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
   addTransfer: (transfer: Transfer) => void;
   addUser: (user: User) => void;
+  updateUser: (user: User) => void;
+  deleteUser: (userId: string) => void;
   addClub: (club: Club) => void;
+  updateClub: (club: Club) => void;
+  deleteClub: (clubId: string) => void;
   addPlayer: (player: Player) => void;
+  updatePlayer: (player: Player) => void;
+  deletePlayer: (playerId: string) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -105,6 +114,52 @@ export const useDataStore = create<DataState>((set) => ({
 
   addPlayer: (player) => set((state) => ({
     players: [...state.players, player]
+  })),
+
+  updateUser: (user) => set((state) => {
+    const users = state.users.map(u => (u.id === user.id ? user : u));
+    localStorage.setItem(USERS_KEY, JSON.stringify(users));
+
+    const currentJson = localStorage.getItem(CURRENT_USER_KEY);
+    if (currentJson) {
+      const current = JSON.parse(currentJson) as User;
+      if (current.id === user.id) {
+        localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(user));
+      }
+    }
+
+    return { users };
+  }),
+
+  deleteUser: (userId) => set((state) => {
+    const users = state.users.filter(u => u.id !== userId);
+    localStorage.setItem(USERS_KEY, JSON.stringify(users));
+
+    const currentJson = localStorage.getItem(CURRENT_USER_KEY);
+    if (currentJson) {
+      const current = JSON.parse(currentJson) as User;
+      if (current.id === userId) {
+        localStorage.removeItem(CURRENT_USER_KEY);
+      }
+    }
+
+    return { users };
+  }),
+
+  updateClub: (club) => set((state) => ({
+    clubs: state.clubs.map(c => (c.id === club.id ? club : c))
+  })),
+
+  deleteClub: (clubId) => set((state) => ({
+    clubs: state.clubs.filter(c => c.id !== clubId)
+  })),
+
+  updatePlayer: (player) => set((state) => ({
+    players: state.players.map(p => (p.id === player.id ? player : p))
+  })),
+
+  deletePlayer: (playerId) => set((state) => ({
+    players: state.players.filter(p => p.id !== playerId)
   }))
 }));
  


### PR DESCRIPTION
## Summary
- extend `DataState` with update and delete actions
- persist user updates and deletions to localStorage
- add generic update/delete functions for clubs and players

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68542b9a934083338fd6c11d36215a0c