### PR TITLE
Fix inconsistent creation date field

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -184,7 +184,7 @@ export const addUser = (
     )}&background=111827&color=fff&size=128`,
     xp: 0,
     clubId,
-    joinDate: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
     status: 'active',
     notifications: true,
     lastLogin: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- standardize user creation date field as `createdAt`
- clean up addUser to match register user date handling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68542fc8b8ec83338c965b9309ee9548