### PR TITLE
Normalize imports and extract admin tables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import  { lazy, Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout/Layout';
 import LoadingScreen from './components/common/LoadingScreen';

--- a/src/components/Home/FeaturedTournaments.tsx
+++ b/src/components/Home/FeaturedTournaments.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Trophy, Calendar, Award, Users } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate } from '../../utils/helpers';

--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Users, TrendingUp, Trophy } from 'lucide-react';
 
 const HeroSection = () => {

--- a/src/components/Home/LatestNews.tsx
+++ b/src/components/Home/LatestNews.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate, formatNewsType, getNewsTypeColor } from '../../utils/helpers';

--- a/src/components/Home/LeagueStandings.tsx
+++ b/src/components/Home/LeagueStandings.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 

--- a/src/components/Home/UpcomingMatches.tsx
+++ b/src/components/Home/UpcomingMatches.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate, formatTime } from '../../utils/helpers';

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { 
   Trophy, 
   Mail, 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import  { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import  { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Menu, X, User, LogOut, ChevronDown, Settings, Trophy, Shield, ShoppingCart } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';

--- a/src/components/admin/PlayersTable.tsx
+++ b/src/components/admin/PlayersTable.tsx
@@ -1,0 +1,69 @@
+import { Edit, Trash } from 'lucide-react';
+import { Club, Player } from '../../types';
+
+interface Props {
+  players: Player[];
+  clubs: Club[];
+  onEdit: (player: Player) => void;
+  onDelete: (player: Player) => void;
+}
+
+const PlayersTable = ({ players, clubs, onEdit, onDelete }: Props) => (
+  <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+            <th className="px-4 py-3 text-left">Jugador</th>
+            <th className="px-4 py-3 text-center">Pos</th>
+            <th className="px-4 py-3 text-center">Media</th>
+            <th className="px-4 py-3 text-center">Edad</th>
+            <th className="px-4 py-3 text-center">Club</th>
+            <th className="px-4 py-3 text-center">Valor</th>
+            <th className="px-4 py-3 text-center">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map(player => (
+            <tr key={player.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+              <td className="px-4 py-3">
+                <div className="flex items-center">
+                  <div className="w-8 h-8 bg-dark-lighter rounded-full flex items-center justify-center mr-2">
+                    <span className="text-xs font-bold">{player.id}</span>
+                  </div>
+                  <div>
+                    <div className="font-medium">{player.name}</div>
+                    <div className="text-xs text-gray-400">{player.nationality}</div>
+                  </div>
+                </div>
+              </td>
+              <td className="px-4 py-3 text-center">{player.position}</td>
+              <td className="px-4 py-3 text-center font-medium">{player.overall}</td>
+              <td className="px-4 py-3 text-center">{player.age}</td>
+              <td className="px-4 py-3 text-center">{clubs.find(c => c.id === player.clubId)?.name}</td>
+              <td className="px-4 py-3 text-center font-medium">
+                {new Intl.NumberFormat('es-ES', {
+                  style: 'currency',
+                  currency: 'EUR',
+                  maximumFractionDigits: 0
+                }).format(player.transferValue)}
+              </td>
+              <td className="px-4 py-3 text-center">
+                <div className="flex justify-center space-x-2">
+                  <button className="p-1 text-gray-400 hover:text-primary" onClick={() => onEdit(player)}>
+                    <Edit size={16} />
+                  </button>
+                  <button className="p-1 text-gray-400 hover:text-red-500" onClick={() => onDelete(player)}>
+                    <Trash size={16} />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+export default PlayersTable;

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -1,0 +1,83 @@
+import { Edit, Trash } from 'lucide-react';
+import { Club, User } from '../../types';
+
+interface Props {
+  users: User[];
+  clubs: Club[];
+  onEdit: (user: User) => void;
+  onDelete: (user: User) => void;
+}
+
+const UsersTable = ({ users, clubs, onEdit, onDelete }: Props) => (
+  <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+            <th className="px-4 py-3 text-left">Usuario</th>
+            <th className="px-4 py-3 text-center">Correo</th>
+            <th className="px-4 py-3 text-center">Rol</th>
+            <th className="px-4 py-3 text-center">Club</th>
+            <th className="px-4 py-3 text-center">Estado</th>
+            <th className="px-4 py-3 text-center">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(u => {
+            const roleClasses =
+              u.role === 'admin'
+                ? 'bg-neon-red/20 text-neon-red'
+                : u.role === 'dt'
+                  ? 'bg-neon-green/20 text-neon-green'
+                  : 'bg-secondary/20 text-secondary';
+            const roleLabel =
+              u.role === 'admin' ? 'Admin' : u.role === 'dt' ? 'DT' : 'Usuario';
+            const userWithClub = u as User & { clubId?: string; club?: string };
+            const clubName =
+              clubs.find(c => c.id === userWithClub.clubId)?.name ||
+              userWithClub.club ||
+              '-';
+
+            return (
+              <tr key={u.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                <td className="px-4 py-3">
+                  <div className="flex items-center">
+                    <div className="w-8 h-8 rounded-full overflow-hidden mr-3">
+                      <img src={u.avatar} alt={u.username} />
+                    </div>
+                    <span className="font-medium">{u.username}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-center">{u.email}</td>
+                <td className="px-4 py-3 text-center">
+                  <span className={`inline-block px-2 py-1 text-xs rounded-full ${roleClasses}`}>
+                    {roleLabel}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-center">{clubName}</td>
+                <td className="px-4 py-3 text-center">
+                  <span className="inline-flex items-center px-2 py-1 bg-green-500/20 text-green-500 text-xs rounded-full">
+                    <span className="w-1.5 h-1.5 bg-green-500 rounded-full mr-1" />
+                    Activo
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-center">
+                  <div className="flex justify-center space-x-2">
+                    <button className="p-1 text-gray-400 hover:text-primary" onClick={() => onEdit(u)}>
+                      <Edit size={16} />
+                    </button>
+                    <button className="p-1 text-gray-400 hover:text-red-500" onClick={() => onDelete(u)}>
+                      <Trash size={16} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+export default UsersTable;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { LogIn, User, Lock } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { User, Mail, Lock, CheckCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';

--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -1,4 +1,4 @@
-import  { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { X, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,4 +1,4 @@
-import  { 
+import { 
   Club, 
   Player, 
   Tournament, 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import  { StrictMode } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash } from 'lucide-react';
 import NewUserModal from '../components/admin/NewUserModal';
@@ -8,6 +8,8 @@ import EditUserModal from '../components/admin/EditUserModal';
 import EditClubModal from '../components/admin/EditClubModal';
 import EditPlayerModal from '../components/admin/EditPlayerModal';
 import ConfirmDeleteModal from '../components/admin/ConfirmDeleteModal';
+import UsersTable from '../components/admin/UsersTable';
+import PlayersTable from '../components/admin/PlayersTable';
 import { User, Club, Player } from '../types';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
@@ -307,93 +309,12 @@ const Admin = () => {
                 </button>
               </div>
               
-              <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
-                        <th className="px-4 py-3 text-left">Usuario</th>
-                        <th className="px-4 py-3 text-center">Correo</th>
-                        <th className="px-4 py-3 text-center">Rol</th>
-                        <th className="px-4 py-3 text-center">Club</th>
-                        <th className="px-4 py-3 text-center">Estado</th>
-                        <th className="px-4 py-3 text-center">Acciones</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {users.map((u) => {
-                        const roleClasses =
-                          u.role === 'admin'
-                            ? 'bg-neon-red/20 text-neon-red'
-                            : u.role === 'dt'
-                            ? 'bg-neon-green/20 text-neon-green'
-                            : 'bg-secondary/20 text-secondary';
-                        const roleLabel =
-                          u.role === 'admin'
-                            ? 'Admin'
-                            : u.role === 'dt'
-                            ? 'DT'
-                            : 'Usuario';
-                        const userWithClub = u as User & {
-                          clubId?: string;
-                          club?: string;
-                        };
-                        const clubName =
-                          clubs.find(c => c.id === userWithClub.clubId)?.name ||
-                          userWithClub.club ||
-                          '-';
-
-                        return (
-                          <tr
-                            key={u.id}
-                            className="border-b border-gray-800 hover:bg-dark-lighter"
-                          >
-                            <td className="px-4 py-3">
-                              <div className="flex items-center">
-                                <div className="w-8 h-8 rounded-full overflow-hidden mr-3">
-                                  <img src={u.avatar} alt={u.username} />
-                                </div>
-                                <span className="font-medium">{u.username}</span>
-                              </div>
-                            </td>
-                            <td className="px-4 py-3 text-center">{u.email}</td>
-                            <td className="px-4 py-3 text-center">
-                              <span
-                                className={`inline-block px-2 py-1 text-xs rounded-full ${roleClasses}`}
-                              >
-                                {roleLabel}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-center">{clubName}</td>
-                            <td className="px-4 py-3 text-center">
-                              <span className="inline-flex items-center px-2 py-1 bg-green-500/20 text-green-500 text-xs rounded-full">
-                                <span className="w-1.5 h-1.5 bg-green-500 rounded-full mr-1"></span>
-                                Activo
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-center">
-                              <div className="flex justify-center space-x-2">
-                                <button
-                                  className="p-1 text-gray-400 hover:text-primary"
-                                  onClick={() => setEditingUser(u)}
-                                >
-                                  <Edit size={16} />
-                                </button>
-                                <button
-                                  className="p-1 text-gray-400 hover:text-red-500"
-                                  onClick={() => setUserToDelete(u)}
-                                >
-                                  <Trash size={16} />
-                                </button>
-                              </div>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+              <UsersTable
+                users={users}
+                clubs={clubs}
+                onEdit={u => setEditingUser(u)}
+                onDelete={u => setUserToDelete(u)}
+              />
             </div>
           )}
           
@@ -476,67 +397,12 @@ const Admin = () => {
                 </button>
               </div>
               
-              <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
-                        <th className="px-4 py-3 text-left">Jugador</th>
-                        <th className="px-4 py-3 text-center">Pos</th>
-                        <th className="px-4 py-3 text-center">Media</th>
-                        <th className="px-4 py-3 text-center">Edad</th>
-                        <th className="px-4 py-3 text-center">Club</th>
-                        <th className="px-4 py-3 text-center">Valor</th>
-                        <th className="px-4 py-3 text-center">Acciones</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {players.slice(0, 5).map(player => (
-                        <tr key={player.id} className="border-b border-gray-800 hover:bg-dark-lighter">
-                          <td className="px-4 py-3">
-                            <div className="flex items-center">
-                              <div className="w-8 h-8 bg-dark-lighter rounded-full flex items-center justify-center mr-2">
-                                <span className="text-xs font-bold">{player.id}</span>
-                              </div>
-                              <div>
-                                <div className="font-medium">{player.name}</div>
-                                <div className="text-xs text-gray-400">{player.nationality}</div>
-                              </div>
-                            </div>
-                          </td>
-                          <td className="px-4 py-3 text-center">{player.position}</td>
-                          <td className="px-4 py-3 text-center font-medium">{player.overall}</td>
-                          <td className="px-4 py-3 text-center">{player.age}</td>
-                          <td className="px-4 py-3 text-center">{clubs.find(c => c.id === player.clubId)?.name}</td>
-                          <td className="px-4 py-3 text-center font-medium">
-                            {new Intl.NumberFormat('es-ES', {
-                              style: 'currency',
-                              currency: 'EUR',
-                              maximumFractionDigits: 0
-                            }).format(player.transferValue)}
-                          </td>
-                          <td className="px-4 py-3 text-center">
-                            <div className="flex justify-center space-x-2">
-                              <button
-                                className="p-1 text-gray-400 hover:text-primary"
-                                onClick={() => setEditingPlayer(player)}
-                              >
-                                <Edit size={16} />
-                              </button>
-                              <button
-                                className="p-1 text-gray-400 hover:text-red-500"
-                                onClick={() => setPlayerToDelete(player)}
-                              >
-                                <Trash size={16} />
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+              <PlayersTable
+                players={players.slice(0, 5)}
+                clubs={clubs}
+                onEdit={p => setEditingPlayer(p)}
+                onDelete={p => setPlayerToDelete(p)}
+              />
             </div>
           )}
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Calendar, Search, ChevronRight, FileText } from 'lucide-react';

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Calendar, ChevronLeft, MessageSquare, Share, ThumbsUp, ArrowRight } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
 

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { 
   ChevronLeft, 

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronLeft, ChevronUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Image, Search, Calendar, User, Tag, Plus } from 'lucide-react';
 

--- a/src/pages/HallOfFame.tsx
+++ b/src/pages/HallOfFame.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Award, ChevronLeft, Star, Shield, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Mail, ChevronDown, ChevronUp, AlertCircle, Calendar, ShoppingBag, Trophy, FileText, Info } from 'lucide-react';
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import  HeroSection from '../components/Home/HeroSection';
+import HeroSection from '../components/Home/HeroSection';
 import LeagueStandings from '../components/Home/LeagueStandings';
 import FeaturedTournaments from '../components/Home/FeaturedTournaments';
 import LatestNews from '../components/Home/LatestNews';

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { 
   Trophy, 
   Users, 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { LogIn, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Search, Filter, ChevronDown, ChevronUp } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
 import { Player } from '../types';

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Home } from 'lucide-react';
 
 const NotFound = () => {

--- a/src/pages/Rankings.tsx
+++ b/src/pages/Rankings.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronLeft } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { User, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Search, AlertCircle } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/TestMarket.tsx
+++ b/src/pages/TestMarket.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { User, CheckCircle, X, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 

--- a/src/pages/TournamentDetail.tsx
+++ b/src/pages/TournamentDetail.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, ChevronLeft, Image, ArrowRight, Star } from 'lucide-react';

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, Calendar, Users, ChevronRight, Filter } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/UserPanel.tsx
+++ b/src/pages/UserPanel.tsx
@@ -1,4 +1,4 @@
-import   { useState } from 'react';
+import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { 
   User, 

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';


### PR DESCRIPTION
## Summary
- normalize import spacing across the project
- move the admin users table into `UsersTable` component
- move the admin players table into `PlayersTable` component
- format files with ESLint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542fcde424833389b8cb48b57b6cb5