### PR TITLE
Implement admin management panels

### DIFF
--- a/src/components/admin/CalendarAdminPanel.tsx
+++ b/src/components/admin/CalendarAdminPanel.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Match } from '../../types';
+
+const CalendarAdminPanel = () => {
+  const { tournaments, updateTournaments, clubs } = useDataStore();
+  const [tournamentId, setTournamentId] = useState(tournaments[0]?.id || '');
+  const [home, setHome] = useState('');
+  const [away, setAway] = useState('');
+  const [date, setDate] = useState('');
+
+  const addMatch = (e: React.FormEvent) => {
+    e.preventDefault();
+    const tournament = tournaments.find(t => t.id === tournamentId);
+    if (!tournament || !home || !away || !date) return;
+    const match: Match = {
+      id: `${Date.now()}`,
+      tournamentId,
+      round: tournament.rounds + 1,
+      date,
+      homeTeam: home,
+      awayTeam: away,
+      status: 'scheduled'
+    };
+    const updated = tournaments.map(t =>
+      t.id === tournamentId ? { ...t, matches: [...t.matches, match] } : t
+    );
+    updateTournaments(updated);
+    setHome('');
+    setAway('');
+    setDate('');
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Calendario de Partidos</h2>
+      <form onSubmit={addMatch} className="bg-dark-light rounded-lg border border-gray-800 p-4 mb-6 space-y-4">
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Torneo</label>
+          <select className="input w-full" value={tournamentId} onChange={e => setTournamentId(e.target.value)}>
+            {tournaments.map(t => (
+              <option key={t.id} value={t.id}>{t.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Local</label>
+            <select className="input w-full" value={home} onChange={e => setHome(e.target.value)}>
+              <option value="">--</option>
+              {clubs.map(c => (
+                <option key={c.id} value={c.name}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Visitante</label>
+            <select className="input w-full" value={away} onChange={e => setAway(e.target.value)}>
+              <option value="">--</option>
+              {clubs.map(c => (
+                <option key={c.id} value={c.name}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Fecha</label>
+          <input type="datetime-local" className="input w-full" value={date} onChange={e => setDate(e.target.value)} />
+        </div>
+        <button type="submit" className="btn-primary w-full">Agregar Partido</button>
+      </form>
+    </div>
+  );
+};
+
+export default CalendarAdminPanel;

--- a/src/components/admin/MarketAdminPanel.tsx
+++ b/src/components/admin/MarketAdminPanel.tsx
@@ -1,0 +1,26 @@
+import { useDataStore } from '../../store/dataStore';
+
+const MarketAdminPanel = () => {
+  const { marketStatus, updateMarketStatus } = useDataStore();
+
+  const toggleMarket = () => {
+    updateMarketStatus(!marketStatus);
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Gestión de Mercado</h2>
+      <div className="bg-dark-light rounded-lg border border-gray-800 p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <span className="text-gray-400">Estado actual</span>
+          <span className={`font-bold ${marketStatus ? 'text-neon-green' : 'text-neon-red'}`}>{marketStatus ? 'Abierto' : 'Cerrado'}</span>
+        </div>
+        <button className="btn-primary" onClick={toggleMarket}>
+          {marketStatus ? 'Cerrar Mercado' : 'Abrir Mercado'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MarketAdminPanel;

--- a/src/components/admin/NewsAdminPanel.tsx
+++ b/src/components/admin/NewsAdminPanel.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { NewsItem } from '../../types';
+
+const NewsAdminPanel = () => {
+  const { newsItems, addNewsItem, removeNewsItem } = useDataStore();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [type, setType] = useState<'transfer' | 'rumor' | 'result' | 'announcement' | 'statement'>('announcement');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title || !content) return;
+    const item: NewsItem = {
+      id: `${Date.now()}`,
+      title,
+      content,
+      type,
+      date: new Date().toISOString(),
+      author: 'Admin',
+      featured: false
+    };
+    addNewsItem(item);
+    setTitle('');
+    setContent('');
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Gestión de Noticias</h2>
+      <form onSubmit={handleSubmit} className="bg-dark-light rounded-lg border border-gray-800 p-4 mb-6 space-y-4">
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Título</label>
+          <input className="input w-full" value={title} onChange={e => setTitle(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Contenido</label>
+          <textarea className="input w-full" rows={3} value={content} onChange={e => setContent(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Tipo</label>
+          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+            <option value="announcement">Anuncio</option>
+            <option value="transfer">Fichaje</option>
+            <option value="result">Resultado</option>
+            <option value="rumor">Rumor</option>
+            <option value="statement">Declaración</option>
+          </select>
+        </div>
+        <button type="submit" className="btn-primary w-full">Publicar</button>
+      </form>
+
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Título</th>
+                <th className="px-4 py-3 text-center">Tipo</th>
+                <th className="px-4 py-3 text-center">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {newsItems.map(n => (
+                <tr key={n.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                  <td className="px-4 py-3">{n.title}</td>
+                  <td className="px-4 py-3 text-center">{n.type}</td>
+                  <td className="px-4 py-3 text-center">
+                    <button onClick={() => removeNewsItem(n.id)} className="text-red-500">Eliminar</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NewsAdminPanel;

--- a/src/components/admin/StatsAdminPanel.tsx
+++ b/src/components/admin/StatsAdminPanel.tsx
@@ -1,0 +1,50 @@
+import { useDataStore } from '../../store/dataStore';
+
+const StatsAdminPanel = () => {
+  const { standings, clubs, updateStandings } = useDataStore();
+
+  const handleChange = (clubId: string, points: number) => {
+    const newTable = standings.map(s => s.clubId === clubId ? { ...s, points } : s);
+    updateStandings(newTable);
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Estadísticas Generales</h2>
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Club</th>
+                <th className="px-4 py-3 text-center">PJ</th>
+                <th className="px-4 py-3 text-center">Pts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {standings.map(row => {
+                const club = clubs.find(c => c.id === row.clubId);
+                return (
+                  <tr key={row.clubId} className="border-b border-gray-800 hover:bg-dark-lighter">
+                    <td className="px-4 py-3">{club?.name}</td>
+                    <td className="px-4 py-3 text-center">{row.played}</td>
+                    <td className="px-4 py-3 text-center">
+                      <input
+                        type="number"
+                        className="input w-20 text-center"
+                        value={row.points}
+                        onChange={e => handleChange(row.clubId, Number(e.target.value))}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatsAdminPanel;

--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Tournament } from '../../types';
+
+const TournamentsAdminPanel = () => {
+  const { tournaments, addTournament } = useDataStore();
+  const [name, setName] = useState('');
+  const [type, setType] = useState<'league' | 'cup' | 'friendly'>('league');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !startDate || !endDate) return;
+    const newTournament: Tournament = {
+      id: `${Date.now()}`,
+      name,
+      type,
+      logo: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=7f39fb&color=fff&size=128`,
+      startDate,
+      endDate,
+      status: 'upcoming',
+      teams: [],
+      rounds: 0,
+      matches: [],
+      description: ''
+    };
+    addTournament(newTournament);
+    setName('');
+    setStartDate('');
+    setEndDate('');
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Gestión de Torneos</h2>
+      <form onSubmit={handleSubmit} className="bg-dark-light rounded-lg border border-gray-800 p-4 mb-6 space-y-4">
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Nombre</label>
+          <input className="input w-full" value={name} onChange={e => setName(e.target.value)} />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Inicio</label>
+            <input type="date" className="input w-full" value={startDate} onChange={e => setStartDate(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Fin</label>
+            <input type="date" className="input w-full" value={endDate} onChange={e => setEndDate(e.target.value)} />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Tipo</label>
+          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+            <option value="league">Liga</option>
+            <option value="cup">Copa</option>
+            <option value="friendly">Amistoso</option>
+          </select>
+        </div>
+        <button type="submit" className="btn-primary w-full">Crear Torneo</button>
+      </form>
+
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Nombre</th>
+                <th className="px-4 py-3 text-center">Tipo</th>
+                <th className="px-4 py-3 text-center">Estado</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tournaments.map(t => (
+                <tr key={t.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                  <td className="px-4 py-3">{t.name}</td>
+                  <td className="px-4 py-3 text-center">{t.type}</td>
+                  <td className="px-4 py-3 text-center">{t.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TournamentsAdminPanel;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -8,6 +8,11 @@ import EditUserModal from '../components/admin/EditUserModal';
 import EditClubModal from '../components/admin/EditClubModal';
 import EditPlayerModal from '../components/admin/EditPlayerModal';
 import ConfirmDeleteModal from '../components/admin/ConfirmDeleteModal';
+import MarketAdminPanel from '../components/admin/MarketAdminPanel';
+import TournamentsAdminPanel from '../components/admin/TournamentsAdminPanel';
+import NewsAdminPanel from '../components/admin/NewsAdminPanel';
+import StatsAdminPanel from '../components/admin/StatsAdminPanel';
+import CalendarAdminPanel from '../components/admin/CalendarAdminPanel';
 import { User, Club, Player } from '../types';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
@@ -29,7 +34,9 @@ const Admin = () => {
     users,
     removeUser,
     removeClub,
-    removePlayer
+    removePlayer,
+    marketStatus,
+    updateMarketStatus
   } = useDataStore();
   const { user, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
@@ -249,7 +256,10 @@ const Admin = () => {
                       </div>
                       
                       <div className="mt-4 pt-4 border-t border-gray-800">
-                        <button className="btn-primary w-full">
+                        <button
+                          className="btn-primary w-full"
+                          onClick={() => setActiveTab('market')}
+                        >
                           Administrar estado del sistema
                         </button>
                       </div>
@@ -261,32 +271,50 @@ const Admin = () => {
                   <h3 className="text-xl font-bold mb-4">Acciones rápidas</h3>
                   <div className="bg-dark-light rounded-lg border border-gray-800 p-4">
                     <div className="grid grid-cols-2 gap-4">
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setActiveTab('users')}
+                      >
                         <Users size={18} className="mb-1" />
                         <span className="text-sm">Gestionar usuarios</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => updateMarketStatus(!marketStatus)}
+                      >
                         <ShoppingCart size={18} className="mb-1" />
                         <span className="text-sm">Abrir/cerrar mercado</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setActiveTab('tournaments')}
+                      >
                         <Trophy size={18} className="mb-1" />
                         <span className="text-sm">Crear torneo</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setActiveTab('calendar')}
+                      >
                         <Calendar size={18} className="mb-1" />
                         <span className="text-sm">Registrar resultados</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setActiveTab('news')}
+                      >
                         <FileText size={18} className="mb-1" />
                         <span className="text-sm">Crear noticia</span>
                       </button>
-                      
-                      <button className="btn-outline py-3 flex flex-col items-center justify-center">
+
+                      <button
+                        className="btn-outline py-3 flex flex-col items-center justify-center"
+                        onClick={() => setActiveTab('stats')}
+                      >
                         <Settings size={18} className="mb-1" />
                         <span className="text-sm">Configuración</span>
                       </button>
@@ -536,50 +564,15 @@ const Admin = () => {
             </div>
           )}
 
-          {activeTab === 'market' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">Gestión de Mercado</h2>
-              <div className="bg-dark-light rounded-lg border border-gray-800 p-6 text-gray-300">
-                Panel de administración del mercado de fichajes.
-              </div>
-            </div>
-          )}
+          {activeTab === 'market' && <MarketAdminPanel />}
 
-          {activeTab === 'tournaments' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">Gestión de Torneos</h2>
-              <div className="bg-dark-light rounded-lg border border-gray-800 p-6 text-gray-300">
-                Panel de administración de torneos y competiciones.
-              </div>
-            </div>
-          )}
+          {activeTab === 'tournaments' && <TournamentsAdminPanel />}
 
-          {activeTab === 'news' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">Gestión de Noticias</h2>
-              <div className="bg-dark-light rounded-lg border border-gray-800 p-6 text-gray-300">
-                Panel para crear y editar noticias de la liga.
-              </div>
-            </div>
-          )}
+          {activeTab === 'news' && <NewsAdminPanel />}
 
-          {activeTab === 'stats' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">Estadísticas Generales</h2>
-              <div className="bg-dark-light rounded-lg border border-gray-800 p-6 text-gray-300">
-                Resumen estadístico de clubes y jugadores.
-              </div>
-            </div>
-          )}
+          {activeTab === 'stats' && <StatsAdminPanel />}
 
-          {activeTab === 'calendar' && (
-            <div>
-              <h2 className="text-2xl font-bold mb-4">Calendario de Partidos</h2>
-              <div className="bg-dark-light rounded-lg border border-gray-800 p-6 text-gray-300">
-                Gestión del calendario de encuentros y eventos.
-              </div>
-            </div>
-          )}
+          {activeTab === 'calendar' && <CalendarAdminPanel />}
         </div>
       </div>
       {showUserModal && <NewUserModal onClose={() => setShowUserModal(false)} />}

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -59,6 +59,10 @@ interface DataState {
   removeClub: (id: string) => void;
   updatePlayerEntry: (player: Player) => void;
   removePlayer: (id: string) => void;
+  addTournament: (tournament: Tournament) => void;
+  addNewsItem: (item: NewsItem) => void;
+  removeNewsItem: (id: string) => void;
+  updateStandings: (newStandings: Standing[]) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -138,6 +142,20 @@ export const useDataStore = create<DataState>((set) => ({
 
   removePlayer: (id) => set((state) => ({
     players: state.players.filter(p => p.id !== id)
-  }))
+  })),
+
+  addTournament: (tournament) => set((state) => ({
+    tournaments: [...state.tournaments, tournament]
+  })),
+
+  addNewsItem: (item) => set((state) => ({
+    newsItems: [item, ...state.newsItems]
+  })),
+
+  removeNewsItem: (id) => set((state) => ({
+    newsItems: state.newsItems.filter(n => n.id !== id)
+  })),
+
+  updateStandings: (newStandings) => set({ standings: newStandings })
 }));
  


### PR DESCRIPTION
## Summary
- add Market/Tournaments/News/Stats/Calendar admin panels
- extend data store with helpers to manage market, tournaments, news and standings
- wire dashboard quick actions to open these panels
- replace placeholder content in admin tabs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854334189908333809c9b9d22028ad4