### PR TITLE
Add transfers table and activity logs

### DIFF
--- a/src/components/admin/MarketAdminPanel.tsx
+++ b/src/components/admin/MarketAdminPanel.tsx
@@ -1,16 +1,38 @@
+import { useState } from 'react';
 import { useDataStore } from '../../store/dataStore';
+import { useActivityLogStore } from '../../store/activityLogStore';
 
 const MarketAdminPanel = () => {
-  const { marketStatus, updateMarketStatus } = useDataStore();
+  const {
+    marketStatus,
+    updateMarketStatus,
+    transfers,
+    clubs,
+    removeTransfer
+  } = useDataStore();
+  const { addLog } = useActivityLogStore();
+  const [clubFilter, setClubFilter] = useState('');
+  const [playerFilter, setPlayerFilter] = useState('');
 
   const toggleMarket = () => {
     updateMarketStatus(!marketStatus);
+    addLog(marketStatus ? 'Mercado cerrado' : 'Mercado abierto');
+  };
+
+  const handleRemove = (id: string) => {
+    const t = transfers.find(tr => tr.id === id);
+    if (t) {
+      addLog(
+        `Transferencia anulada: ${t.playerName} ${t.fromClub} -> ${t.toClub}`
+      );
+    }
+    removeTransfer(id);
   };
 
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">Gestión de Mercado</h2>
-      <div className="bg-dark-light rounded-lg border border-gray-800 p-6 space-y-4">
+      <div className="bg-dark-light rounded-lg border border-gray-800 p-6 space-y-4 mb-6">
         <div className="flex items-center justify-between">
           <span className="text-gray-400">Estado actual</span>
           <span className={`font-bold ${marketStatus ? 'text-neon-green' : 'text-neon-red'}`}>{marketStatus ? 'Abierto' : 'Cerrado'}</span>
@@ -18,6 +40,77 @@ const MarketAdminPanel = () => {
         <button className="btn-primary" onClick={toggleMarket}>
           {marketStatus ? 'Cerrar Mercado' : 'Abrir Mercado'}
         </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Filtrar por club</label>
+          <select
+            className="input w-full"
+            value={clubFilter}
+            onChange={e => setClubFilter(e.target.value)}
+          >
+            <option value="">Todos</option>
+            {clubs.map(c => (
+              <option key={c.id} value={c.name}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Filtrar por jugador</label>
+          <input
+            className="input w-full"
+            value={playerFilter}
+            onChange={e => setPlayerFilter(e.target.value)}
+            placeholder="Nombre del jugador"
+          />
+        </div>
+      </div>
+
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Jugador</th>
+                <th className="px-4 py-3 text-center">De</th>
+                <th className="px-4 py-3 text-center">A</th>
+                <th className="px-4 py-3 text-center">Valor</th>
+                <th className="px-4 py-3 text-center">Fecha</th>
+                <th className="px-4 py-3 text-center">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {transfers
+                .filter(t =>
+                  (!clubFilter || t.fromClub === clubFilter || t.toClub === clubFilter) &&
+                  (!playerFilter || t.playerName.toLowerCase().includes(playerFilter.toLowerCase()))
+                )
+                .map(t => (
+                  <tr key={t.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                    <td className="px-4 py-3">{t.playerName}</td>
+                    <td className="px-4 py-3 text-center">{t.fromClub}</td>
+                    <td className="px-4 py-3 text-center">{t.toClub}</td>
+                    <td className="px-4 py-3 text-center font-medium">
+                      {new Intl.NumberFormat('es-ES', {
+                        style: 'currency',
+                        currency: 'EUR',
+                        maximumFractionDigits: 0
+                      }).format(t.fee)}
+                    </td>
+                    <td className="px-4 py-3 text-center">{t.date}</td>
+                    <td className="px-4 py-3 text-center">
+                      <button className="text-red-500" onClick={() => handleRemove(t.id)}>
+                        Anular
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/components/admin/NewsAdminPanel.tsx
+++ b/src/components/admin/NewsAdminPanel.tsx
@@ -39,7 +39,15 @@ const NewsAdminPanel = () => {
         </div>
         <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>
-          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+          <select
+            className="input w-full"
+            value={type}
+            onChange={e =>
+              setType(
+                e.target.value as 'transfer' | 'rumor' | 'result' | 'announcement' | 'statement'
+              )
+            }
+          >
             <option value="announcement">Anuncio</option>
             <option value="transfer">Fichaje</option>
             <option value="result">Resultado</option>

--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -51,7 +51,11 @@ const TournamentsAdminPanel = () => {
         </div>
         <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>
-          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+          <select
+            className="input w-full"
+            value={type}
+            onChange={e => setType(e.target.value as 'league' | 'cup' | 'friendly')}
+          >
             <option value="league">Liga</option>
             <option value="cup">Copa</option>
             <option value="friendly">Amistoso</option>

--- a/src/store/activityLogStore.ts
+++ b/src/store/activityLogStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+export interface ActivityLogEntry {
+  id: string;
+  action: string;
+  date: string;
+  details?: string;
+}
+
+interface ActivityLogState {
+  logs: ActivityLogEntry[];
+  addLog: (action: string, details?: string) => void;
+  clearLogs: () => void;
+}
+
+export const useActivityLogStore = create<ActivityLogState>((set) => ({
+  logs: [],
+  addLog: (action, details) =>
+    set((state) => ({
+      logs: [
+        { id: `${Date.now()}`, action, date: new Date().toISOString(), details },
+        ...state.logs
+      ]
+    })),
+  clearLogs: () => set({ logs: [] })
+}));

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -50,6 +50,7 @@ interface DataState {
   addOffer: (offer: TransferOffer) => void;
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
   addTransfer: (transfer: Transfer) => void;
+  removeTransfer: (id: string) => void;
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
@@ -103,6 +104,10 @@ export const useDataStore = create<DataState>((set) => ({
 
   addTransfer: (transfer) => set((state) => ({
     transfers: [transfer, ...state.transfers]
+  })),
+
+  removeTransfer: (id) => set((state) => ({
+    transfers: state.transfers.filter(t => t.id !== id)
   })),
 
   addUser: (user) => set((state) => ({


### PR DESCRIPTION
## Summary
- create an activity log store
- allow removing transfers in the data store
- extend market admin panel with filters and cancel actions
- clean up `any` types in news and tournament admin panels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685451fa6eec8333be21f960fb483a89