### PR TITLE
Implement tournament admin editing

### DIFF
--- a/src/components/admin/NewsAdminPanel.tsx
+++ b/src/components/admin/NewsAdminPanel.tsx
@@ -39,7 +39,11 @@ const NewsAdminPanel = () => {
         </div>
         <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>
-          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+          <select
+            className="input w-full"
+            value={type}
+            onChange={e => setType(e.target.value as 'announcement' | 'transfer' | 'result' | 'rumor' | 'statement')}
+          >
             <option value="announcement">Anuncio</option>
             <option value="transfer">Fichaje</option>
             <option value="result">Resultado</option>

--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -1,13 +1,41 @@
 import { useState } from 'react';
 import { useDataStore } from '../../store/dataStore';
-import { Tournament } from '../../types';
+import { Match, Tournament } from '../../types';
 
 const TournamentsAdminPanel = () => {
-  const { tournaments, addTournament } = useDataStore();
+  const { tournaments, addTournament, updateTournaments } = useDataStore();
   const [name, setName] = useState('');
   const [type, setType] = useState<'league' | 'cup' | 'friendly'>('league');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [editId, setEditId] = useState(tournaments[0]?.id || '');
+
+  const selectedTournament = tournaments.find(t => t.id === editId);
+
+  const updateMatchResult = (match: Match, home: number, away: number) => {
+    const updated = tournaments.map(t => {
+      if (t.id !== editId) return t;
+      const updatedMatches = t.matches.map(m =>
+        m.id === match.id ? { ...m, homeScore: home, awayScore: away, status: 'finished' } : m
+      );
+      return { ...t, matches: updatedMatches, results: updatedMatches };
+    });
+    updateTournaments(updated);
+  };
+
+  const changeStatus = (status: 'upcoming' | 'active' | 'finished') => {
+    const updated = tournaments.map(t =>
+      t.id === editId ? { ...t, status } : t
+    );
+    updateTournaments(updated);
+  };
+
+  const changeWinner = (winner: string) => {
+    const updated = tournaments.map(t =>
+      t.id === editId ? { ...t, winner } : t
+    );
+    updateTournaments(updated);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -23,6 +51,7 @@ const TournamentsAdminPanel = () => {
       teams: [],
       rounds: 0,
       matches: [],
+      results: [],
       description: ''
     };
     addTournament(newTournament);
@@ -51,7 +80,11 @@ const TournamentsAdminPanel = () => {
         </div>
         <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>
-          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+          <select
+            className="input w-full"
+            value={type}
+            onChange={e => setType(e.target.value as 'league' | 'cup' | 'friendly')}
+          >
             <option value="league">Liga</option>
             <option value="cup">Copa</option>
             <option value="friendly">Amistoso</option>
@@ -80,8 +113,99 @@ const TournamentsAdminPanel = () => {
               ))}
             </tbody>
           </table>
-        </div>
       </div>
+    </div>
+
+      {/* Edit section */}
+      {selectedTournament && (
+        <div className="bg-dark-light rounded-lg border border-gray-800 p-4 mt-6 space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Torneo</label>
+            <select className="input w-full" value={editId} onChange={e => setEditId(e.target.value)}>
+              {tournaments.map(t => (
+                <option key={t.id} value={t.id}>{t.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Estado</label>
+            <select
+              className="input w-full"
+              value={selectedTournament.status}
+              onChange={e => changeStatus(e.target.value as 'upcoming' | 'active' | 'finished')}
+            >
+              <option value="upcoming">Próximamente</option>
+              <option value="active">Activo</option>
+              <option value="finished">Finalizado</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Campeón</label>
+            <select
+              className="input w-full"
+              value={selectedTournament.winner || ''}
+              onChange={e => changeWinner(e.target.value)}
+            >
+              <option value="">--</option>
+              {selectedTournament.teams.map(team => (
+                <option key={team} value={team}>{team}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <h3 className="font-bold mb-2">Resultados</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-gray-400 border-b border-gray-800">
+                    <th className="px-2 py-2">Local</th>
+                    <th className="px-2 py-2">Marcador</th>
+                    <th className="px-2 py-2">Visitante</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedTournament.matches.map(match => (
+                    <tr key={match.id} className="border-b border-gray-800">
+                      <td className="px-2 py-1 text-right">{match.homeTeam}</td>
+                      <td className="px-2 py-1 text-center">
+                        <input
+                          type="number"
+                          className="w-12 text-center bg-gray-800 rounded mr-1"
+                          value={match.homeScore ?? ''}
+                          onChange={e =>
+                            updateMatchResult(
+                              match,
+                              Number(e.target.value),
+                              match.awayScore ?? 0
+                            )
+                          }
+                        />
+                        -
+                        <input
+                          type="number"
+                          className="w-12 text-center bg-gray-800 rounded ml-1"
+                          value={match.awayScore ?? ''}
+                          onChange={e =>
+                            updateMatchResult(
+                              match,
+                              match.homeScore ?? 0,
+                              Number(e.target.value)
+                            )
+                          }
+                        />
+                      </td>
+                      <td className="px-2 py-1">{match.awayTeam}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -136,12 +136,29 @@ const Tournaments = () => {
                 <p>No se encontraron torneos con los filtros seleccionados.</p>
               </div>
             )}
-          </div>
         </div>
-        
+      </div>
+
+      {/* Finished tournaments */}
+      {tournaments.filter(t => t.status === 'finished').length > 0 && (
         <div className="mt-12">
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold">Cómo participar</h2>
+          <h2 className="text-2xl font-bold mb-6">Finalizados</h2>
+          <ul className="space-y-2">
+            {tournaments.filter(t => t.status === 'finished').map(t => (
+              <li key={t.id} className="flex items-center justify-between bg-dark-light rounded p-3">
+                <Link to={`/torneos/${t.id}`} className="hover:text-primary font-medium">
+                  {t.name}
+                </Link>
+                {t.winner && <span className="text-gray-400 text-sm">{t.winner}</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-12">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-2xl font-bold">Cómo participar</h2>
           </div>
           
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,7 @@ export interface Tournament {
   teams: string[];
   rounds: number;
   matches: Match[];
+  results?: Match[];
   winner?: string;
   topScorer?: TopScorer;
   description: string;


### PR DESCRIPTION
## Summary
- extend `Tournament` type with `results`
- allow admins to edit tournament results and winner
- persist tournament updates in data store
- list finished tournaments with champions
- improve select typing in admin panels

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685451faefb48333910487ec85d8123d