### PR TITLE
Add news images, publication date and comment moderation

### DIFF
--- a/src/components/Home/LatestNews.tsx
+++ b/src/components/Home/LatestNews.tsx
@@ -33,7 +33,7 @@ const LatestNews = () => {
                   {formatNewsType(news.type)}
                 </span>
                 <span className="text-gray-400 text-sm">
-                  {formatDate(news.date)}
+                  {formatDate(news.publishDate)}
                 </span>
               </div>
               

--- a/src/components/admin/NewsAdminPanel.tsx
+++ b/src/components/admin/NewsAdminPanel.tsx
@@ -1,11 +1,21 @@
 import { useState } from 'react';
 import { useDataStore } from '../../store/dataStore';
-import { NewsItem } from '../../types';
+import { NewsItem, ReportedComment } from '../../types';
 
 const NewsAdminPanel = () => {
-  const { newsItems, addNewsItem, removeNewsItem } = useDataStore();
+  const {
+    newsItems,
+    addNewsItem,
+    removeNewsItem,
+    reportedComments,
+    approveComment,
+    hideComment,
+    deleteComment
+  } = useDataStore();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [image, setImage] = useState('');
+  const [publishDate, setPublishDate] = useState('');
   const [type, setType] = useState<'transfer' | 'rumor' | 'result' | 'announcement' | 'statement'>('announcement');
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -16,13 +26,16 @@ const NewsAdminPanel = () => {
       title,
       content,
       type,
-      date: new Date().toISOString(),
+      image,
+      publishDate,
       author: 'Admin',
       featured: false
     };
     addNewsItem(item);
     setTitle('');
     setContent('');
+    setImage('');
+    setPublishDate('');
   };
 
   return (
@@ -38,8 +51,16 @@ const NewsAdminPanel = () => {
           <textarea className="input w-full" rows={3} value={content} onChange={e => setContent(e.target.value)} />
         </div>
         <div>
+          <label className="block text-sm text-gray-400 mb-1">Imagen</label>
+          <input className="input w-full" value={image} onChange={e => setImage(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Fecha de publicación</label>
+          <input type="date" className="input w-full" value={publishDate} onChange={e => setPublishDate(e.target.value)} />
+        </div>
+        <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>
-          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+          <select className="input w-full" value={type} onChange={e => setType(e.target.value as NewsItem['type'])}>
             <option value="announcement">Anuncio</option>
             <option value="transfer">Fichaje</option>
             <option value="result">Resultado</option>
@@ -67,6 +88,33 @@ const NewsAdminPanel = () => {
                   <td className="px-4 py-3 text-center">{n.type}</td>
                   <td className="px-4 py-3 text-center">
                     <button onClick={() => removeNewsItem(n.id)} className="text-red-500">Eliminar</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <h3 className="text-xl font-bold mt-8 mb-4">Comentarios Reportados</h3>
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Autor</th>
+                <th className="px-4 py-3 text-left">Comentario</th>
+                <th className="px-4 py-3 text-center">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reportedComments.map((c: ReportedComment) => (
+                <tr key={c.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                  <td className="px-4 py-3">{c.author}</td>
+                  <td className="px-4 py-3">{c.content}</td>
+                  <td className="px-4 py-3 text-center space-x-2">
+                    <button onClick={() => approveComment(c.id)} className="text-green-500">Aprobar</button>
+                    <button onClick={() => hideComment(c.id)} className="text-yellow-500">Ocultar</button>
+                    <button onClick={() => deleteComment(c.id)} className="text-red-500">Eliminar</button>
                   </td>
                 </tr>
               ))}

--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -51,7 +51,7 @@ const TournamentsAdminPanel = () => {
         </div>
         <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>
-          <select className="input w-full" value={type} onChange={e => setType(e.target.value as any)}>
+          <select className="input w-full" value={type} onChange={e => setType(e.target.value as Tournament['type'])}>
             <option value="league">Liga</option>
             <option value="cup">Copa</option>
             <option value="friendly">Amistoso</option>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -10,7 +10,8 @@ import  {
   Post,
   Standing,
   FAQ,
-  StoreItem
+  StoreItem,
+  ReportedComment
 } from '../types';
 
 // Mock Clubs Data
@@ -646,7 +647,7 @@ export const newsItems: NewsItem[] = [
     content: 'La temporada 2025 de La Virtual Zone ha arrancado oficialmente. 10 clubes compiten por el título en una liga que promete emociones hasta la última jornada.',
     type: 'announcement',
     image: 'https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
-    date: '2025-01-15',
+    publishDate: '2025-01-15',
     author: 'Admin',
     featured: true
   },
@@ -656,7 +657,7 @@ export const newsItems: NewsItem[] = [
     content: 'Desde hoy los clubes pueden realizar ofertas por jugadores de otros equipos. El mercado permanecerá abierto hasta el 15 de febrero.',
     type: 'announcement',
     image: 'https://images.unsplash.com/photo-1494178270175-e96de2971df9?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw0fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
-    date: '2025-01-16',
+    publishDate: '2025-01-16',
     author: 'Admin',
     featured: false
   },
@@ -665,7 +666,8 @@ export const newsItems: NewsItem[] = [
     title: 'Diego López ficha por Rayo Digital FC',
     content: 'El delantero ha firmado un contrato de 3 temporadas tras el pago de 8.5 millones. "Estoy emocionado por este nuevo reto", declaró el jugador.',
     type: 'transfer',
-    date: '2025-01-05',
+    image: 'https://via.placeholder.com/300x200',
+    publishDate: '2025-01-05',
     author: 'Admin',
     clubId: 'club1',
     playerId: 'player21',
@@ -676,7 +678,8 @@ export const newsItems: NewsItem[] = [
     title: 'Rayo Digital vence en el derbi',
     content: 'Los rojiblancos se impusieron 3-1 a Atlético Pixelado en un partido vibrante. Diego López, nuevo fichaje, marcó dos goles.',
     type: 'result',
-    date: '2025-01-20',
+    image: 'https://via.placeholder.com/300x200',
+    publishDate: '2025-01-20',
     author: 'Admin',
     clubId: 'club1',
     tournamentId: 'tournament1',
@@ -687,7 +690,8 @@ export const newsItems: NewsItem[] = [
     title: 'Rumor: Neón FC tras una estrella de Binary Strikers',
     content: 'Según fuentes cercanas al club, los neonistas estarían dispuestos a pagar hasta 15 millones por un centrocampista de los Strikers.',
     type: 'rumor',
-    date: '2025-01-22',
+    image: 'https://via.placeholder.com/300x200',
+    publishDate: '2025-01-22',
     author: 'Admin',
     clubId: 'club4',
     featured: false
@@ -697,11 +701,12 @@ export const newsItems: NewsItem[] = [
     title: 'DT de Glitchers 404: "Vamos a por el título"',
     content: '"Este año tenemos un equipo para luchar arriba. No renunciamos a nada y vamos partido a partido", declaró el técnico tras la victoria 2-0 ante Connection FC.',
     type: 'statement',
-    date: '2025-01-23',
+    image: 'https://via.placeholder.com/300x200',
+    publishDate: '2025-01-23',
     author: 'Admin',
     clubId: 'club6',
     featured: false
-  } 
+  }
 ];
 
 // Blog posts
@@ -977,6 +982,23 @@ export const storeItems: StoreItem[] = [
     image: 'https://ui-avatars.com/api/?name=PF&background=ef4444&color=fff&size=128&bold=true',
     minLevel: 1,
     inStock: true
+  }
+];
+
+export const reportedComments: ReportedComment[] = [
+  {
+    id: 'comment1',
+    author: 'usuario1',
+    content: 'Este es un comentario inapropiado',
+    status: 'pending',
+    date: '2025-01-20'
+  },
+  {
+    id: 'comment2',
+    author: 'usuario2',
+    content: 'Spam en los comentarios',
+    status: 'pending',
+    date: '2025-01-22'
   }
 ];
  

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -11,7 +11,8 @@ import {
   newsItems,
   mediaItems,
   faqs,
-  storeItems
+  storeItems,
+  reportedComments
 } from '../data/mockData';
 import {
   Club,
@@ -25,6 +26,7 @@ import {
   MediaItem,
   FAQ,
   StoreItem
+  , ReportedComment
 } from '../types';
 
 interface DataState {
@@ -39,6 +41,7 @@ interface DataState {
   mediaItems: MediaItem[];
   faqs: FAQ[];
   storeItems: StoreItem[];
+  reportedComments: ReportedComment[];
   marketStatus: boolean;
   
   updateClubs: (newClubs: Club[]) => void;
@@ -63,6 +66,9 @@ interface DataState {
   addNewsItem: (item: NewsItem) => void;
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
+  approveComment: (id: string) => void;
+  hideComment: (id: string) => void;
+  deleteComment: (id: string) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -76,6 +82,7 @@ export const useDataStore = create<DataState>((set) => ({
   mediaItems,
   faqs,
   storeItems,
+  reportedComments,
   marketStatus,
   users: getUsers(),
   
@@ -156,6 +163,22 @@ export const useDataStore = create<DataState>((set) => ({
     newsItems: state.newsItems.filter(n => n.id !== id)
   })),
 
-  updateStandings: (newStandings) => set({ standings: newStandings })
+  updateStandings: (newStandings) => set({ standings: newStandings }),
+
+  approveComment: (id) => set((state) => ({
+    reportedComments: state.reportedComments.map(c =>
+      c.id === id ? { ...c, status: 'approved' } : c
+    )
+  })),
+
+  hideComment: (id) => set((state) => ({
+    reportedComments: state.reportedComments.map(c =>
+      c.id === id ? { ...c, status: 'hidden' } : c
+    )
+  })),
+
+  deleteComment: (id) => set((state) => ({
+    reportedComments: state.reportedComments.filter(c => c.id !== id)
+  }))
 }));
  

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -155,13 +155,21 @@ export interface NewsItem {
   title: string;
   content: string;
   type: 'transfer' | 'rumor' | 'result' | 'announcement' | 'statement';
-  image?: string;
-  date: string;
+  image: string;
+  publishDate: string;
   author: string;
   clubId?: string;
   playerId?: string;
   tournamentId?: string;
   featured: boolean;
+}
+
+export interface ReportedComment {
+  id: string;
+  author: string;
+  content: string;
+  status: 'pending' | 'approved' | 'hidden';
+  date: string;
 }
 
 // Blog post type


### PR DESCRIPTION
## Summary
- add `image` and `publishDate` fields in `NewsItem`
- define `ReportedComment` interface
- include new fields in mock news data
- provide sample `reportedComments` seed data
- support `reportedComments` in data store with moderation actions
- update admin panel to set image and publication date for news
- display reported comments table with approve/hide/delete
- use `publishDate` in latest news view
- fix strict typing in tournaments panel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685451fb5c7c8333b930ecab65becf4b