### PR TITLE
Fix Trophy icon import

### DIFF
--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,5 +1,5 @@
 import  { useParams, Link } from 'react-router-dom';
-import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight } from 'lucide-react';
+import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 


### PR DESCRIPTION
## Summary
- import Trophy icon in UserProfile page

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6854593454d0833391dd3f481b1d59ec