### PR TITLE
Fix login instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm run preview
 To access the administrator interface:
 
 1. Start the development server with `npm run dev`.
-2. Open the app in your browser and log in using the demo admin account (`admin` / any password).
+2. Open the app in your browser and log in using the demo admin account (`admin` / `password`).
 3. Click on your avatar in the navigation bar and choose **Panel Admin** or navigate directly to `/admin`.
 
 Within the admin panel you will find management sections for:

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -114,9 +114,9 @@ const Login = () => {
             <div className="mt-8 pt-6 border-t border-gray-800">
               <div className="text-xs text-gray-500 text-center">
                 <p>Para pruebas, puedes usar:</p>
-                <p className="mt-1">Usuario: <span className="text-primary">usuario</span> / Contraseña: <span className="text-primary">cualquiera</span></p>
-                <p className="mt-1">DT: <span className="text-primary">entrenador</span> / Contraseña: <span className="text-primary">cualquiera</span></p>
-                <p className="mt-1">Admin: <span className="text-primary">admin</span> / Contraseña: <span className="text-primary">cualquiera</span></p>
+                <p className="mt-1">Usuario: <span className="text-primary">usuario</span> / Contraseña: <span className="text-primary">password</span></p>
+                <p className="mt-1">DT: <span className="text-primary">entrenador</span> / Contraseña: <span className="text-primary">password</span></p>
+                <p className="mt-1">Admin: <span className="text-primary">admin</span> / Contraseña: <span className="text-primary">password</span></p>
               </div>
             </div>
           </div>

--- a/src/pages/TestMarket.tsx
+++ b/src/pages/TestMarket.tsx
@@ -18,7 +18,7 @@ const TestMarket = () => {
     }
     
     try {
-      await login(username, password || 'password'); // Any password works for test accounts
+  await login(username, password || 'password'); // The password for test accounts is fixed
       setError(null);
       setLoginSuccess(true);
       
@@ -140,7 +140,7 @@ const TestMarket = () => {
                     className="input w-full"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    placeholder="Cualquier contraseña funciona para las cuentas de prueba"
+                    placeholder="La contraseña es 'password' para las cuentas de prueba"
                   />
                 </div>
                 
@@ -161,7 +161,7 @@ const TestMarket = () => {
                   <li><span className="text-primary">usuario</span> - Usuario estándar sin club</li>
                   <li><span className="text-primary">admin</span> - Usuario con rol de administrador</li>
                 </ul>
-                <p className="text-sm text-gray-500 mt-2">Nota: Para los usuarios de prueba, cualquier contraseña funcionará.</p>
+                <p className="text-sm text-gray-500 mt-2">Nota: Para los usuarios de prueba, la contraseña es 'password'.</p>
               </div>
             </div>
           )}
@@ -173,9 +173,9 @@ const TestMarket = () => {
           <div className="space-y-6">
             <div>
               <h4 className="font-bold text-primary mb-2">1. Inicia sesión con un DT</h4>
-              <p className="text-gray-300 text-sm">
-                Usa el usuario <span className="text-primary">entrenador</span> con cualquier contraseña para iniciar sesión como DT de Neón FC.
-              </p>
+                <p className="text-gray-300 text-sm">
+                  Usa el usuario <span className="text-primary">entrenador</span> con la contraseña <span className="text-primary">password</span> para iniciar sesión como DT de Neón FC.
+                </p>
             </div>
             
             <div>


### PR DESCRIPTION
## Summary
- clarify default admin password in README
- update login page instructions with real password
- adjust transfer market test page to show the fixed password

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854638cee488333863a34a3c3025e28