### PR TITLE
Implement persistent user deletion

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
-import { getUsers, updateUser as persistUser } from '../utils/authService';
+import {
+  getUsers,
+  updateUser as persistUser,
+  deleteUser as persistDeleteUser
+} from '../utils/authService';
 import {
   clubs,
   players,
@@ -128,9 +132,13 @@ export const useDataStore = create<DataState>((set) => ({
     };
   }),
 
-  removeUser: (id) => set((state) => ({
-    users: state.users.filter(u => u.id !== id)
-  })),
+  removeUser: (id) =>
+    set((state) => {
+      persistDeleteUser(id);
+      return {
+        users: state.users.filter(u => u.id !== id)
+      };
+    }),
 
   updateClubEntry: (club) => set((state) => ({
     clubs: state.clubs.map(c => (c.id === club.id ? club : c))

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -254,4 +254,16 @@ export const getUserById = (userId: string): User | null => {
   const users = getUsers();
   return users.find(u => u.id === userId) || null;
 };
+
+// Delete a user by ID and update localStorage
+export const deleteUser = (id: string): void => {
+  const users = getUsers();
+  const updatedUsers = users.filter(u => u.id !== id);
+  saveUsers(updatedUsers);
+
+  const currentUser = getCurrentUser();
+  if (currentUser && currentUser.id === id) {
+    saveCurrentUser(null);
+  }
+};
  


### PR DESCRIPTION
## Summary
- support deleting users from persistent storage
- wire `removeUser` to call persistent deletion

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854638dd7dc8333b791fff540a1458e