### PR TITLE
Add publish date and comment moderation

### DIFF
--- a/src/components/admin/NewsAdminPanel.tsx
+++ b/src/components/admin/NewsAdminPanel.tsx
@@ -6,23 +6,30 @@ const NewsAdminPanel = () => {
   const { newsItems, addNewsItem, removeNewsItem } = useDataStore();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [image, setImage] = useState('');
+  const [publishDate, setPublishDate] = useState('');
   const [type, setType] = useState<'transfer' | 'rumor' | 'result' | 'announcement' | 'statement'>('announcement');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title || !content) return;
+    const date = publishDate || new Date().toISOString();
     const item: NewsItem = {
       id: `${Date.now()}`,
       title,
       content,
       type,
-      date: new Date().toISOString(),
+      image: image || 'https://via.placeholder.com/300x200.png?text=News',
+      date,
+      publishDate: date,
       author: 'Admin',
       featured: false
     };
     addNewsItem(item);
     setTitle('');
     setContent('');
+    setImage('');
+    setPublishDate('');
   };
 
   return (
@@ -36,6 +43,24 @@ const NewsAdminPanel = () => {
         <div>
           <label className="block text-sm text-gray-400 mb-1">Contenido</label>
           <textarea className="input w-full" rows={3} value={content} onChange={e => setContent(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Imagen</label>
+          <input
+            className="input w-full"
+            value={image}
+            onChange={e => setImage(e.target.value)}
+            placeholder="URL de la imagen"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Fecha de publicaci\u00f3n</label>
+          <input
+            type="datetime-local"
+            className="input w-full"
+            value={publishDate}
+            onChange={e => setPublishDate(e.target.value)}
+          />
         </div>
         <div>
           <label className="block text-sm text-gray-400 mb-1">Tipo</label>

--- a/src/components/admin/ReportedCommentsPanel.tsx
+++ b/src/components/admin/ReportedCommentsPanel.tsx
@@ -1,0 +1,39 @@
+import { useDataStore } from '../../store/dataStore';
+
+const ReportedCommentsPanel = () => {
+  const { reportedComments, approveComment, hideComment, deleteComment } = useDataStore();
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Comentarios Reportados</h2>
+      <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-dark-lighter text-xs uppercase text-gray-400 border-b border-gray-800">
+                <th className="px-4 py-3 text-left">Autor</th>
+                <th className="px-4 py-3">Comentario</th>
+                <th className="px-4 py-3 text-center">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reportedComments.map(c => (
+                <tr key={c.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                  <td className="px-4 py-3">{c.author}</td>
+                  <td className="px-4 py-3">{c.content}</td>
+                  <td className="px-4 py-3 text-center space-x-2">
+                    <button onClick={() => approveComment(c.id)} className="text-green-500">Aprobar</button>
+                    <button onClick={() => hideComment(c.id)} className="text-yellow-500">Ocultar</button>
+                    <button onClick={() => deleteComment(c.id)} className="text-red-500">Borrar</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReportedCommentsPanel;

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -10,7 +10,8 @@ import  {
   Post,
   Standing,
   FAQ,
-  StoreItem
+  StoreItem,
+  Comment
 } from '../types';
 
 // Mock Clubs Data
@@ -650,6 +651,7 @@ export const newsItems: NewsItem[] = [
     type: 'announcement',
     image: 'https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
     date: '2025-01-15',
+    publishDate: '2025-01-15',
     author: 'Admin',
     featured: true
   },
@@ -660,6 +662,7 @@ export const newsItems: NewsItem[] = [
     type: 'announcement',
     image: 'https://images.unsplash.com/photo-1494178270175-e96de2971df9?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw0fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
     date: '2025-01-16',
+    publishDate: '2025-01-16',
     author: 'Admin',
     featured: false
   },
@@ -668,7 +671,9 @@ export const newsItems: NewsItem[] = [
     title: 'Diego López ficha por Rayo Digital FC',
     content: 'El delantero ha firmado un contrato de 3 temporadas tras el pago de 8.5 millones. "Estoy emocionado por este nuevo reto", declaró el jugador.',
     type: 'transfer',
+    image: 'https://via.placeholder.com/300x200.png?text=News',
     date: '2025-01-05',
+    publishDate: '2025-01-05',
     author: 'Admin',
     clubId: 'club1',
     playerId: 'player21',
@@ -679,7 +684,9 @@ export const newsItems: NewsItem[] = [
     title: 'Rayo Digital vence en el derbi',
     content: 'Los rojiblancos se impusieron 3-1 a Atlético Pixelado en un partido vibrante. Diego López, nuevo fichaje, marcó dos goles.',
     type: 'result',
+    image: 'https://via.placeholder.com/300x200.png?text=News',
     date: '2025-01-20',
+    publishDate: '2025-01-20',
     author: 'Admin',
     clubId: 'club1',
     tournamentId: 'tournament1',
@@ -690,7 +697,9 @@ export const newsItems: NewsItem[] = [
     title: 'Rumor: Neón FC tras una estrella de Binary Strikers',
     content: 'Según fuentes cercanas al club, los neonistas estarían dispuestos a pagar hasta 15 millones por un centrocampista de los Strikers.',
     type: 'rumor',
+    image: 'https://via.placeholder.com/300x200.png?text=News',
     date: '2025-01-22',
+    publishDate: '2025-01-22',
     author: 'Admin',
     clubId: 'club4',
     featured: false
@@ -700,11 +709,13 @@ export const newsItems: NewsItem[] = [
     title: 'DT de Glitchers 404: "Vamos a por el título"',
     content: '"Este año tenemos un equipo para luchar arriba. No renunciamos a nada y vamos partido a partido", declaró el técnico tras la victoria 2-0 ante Connection FC.',
     type: 'statement',
+    image: 'https://via.placeholder.com/300x200.png?text=News',
     date: '2025-01-23',
+    publishDate: '2025-01-23',
     author: 'Admin',
     clubId: 'club6',
     featured: false
-  } 
+  }
 ];
 
 // Blog posts
@@ -980,6 +991,22 @@ export const storeItems: StoreItem[] = [
     image: 'https://ui-avatars.com/api/?name=PF&background=ef4444&color=fff&size=128&bold=true',
     minLevel: 1,
     inStock: true
+  }
+];
+
+// Reported comments
+export const reportedComments: Comment[] = [
+  {
+    id: 'comment1',
+    author: 'Usuario1',
+    content: 'Este es un comentario ofensivo',
+    date: '2025-01-25'
+  },
+  {
+    id: 'comment2',
+    author: 'Usuario2',
+    content: 'Spam en la noticia',
+    date: '2025-01-26'
   }
 ];
  

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,6 +1,6 @@
 import  { useState } from 'react';
 import { Navigate, useNavigate, Link } from 'react-router-dom';
-import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash } from 'lucide-react';
+import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash, MessageCircle } from 'lucide-react';
 import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
@@ -11,6 +11,7 @@ import ConfirmDeleteModal from '../components/admin/ConfirmDeleteModal';
 import MarketAdminPanel from '../components/admin/MarketAdminPanel';
 import TournamentsAdminPanel from '../components/admin/TournamentsAdminPanel';
 import NewsAdminPanel from '../components/admin/NewsAdminPanel';
+import ReportedCommentsPanel from '../components/admin/ReportedCommentsPanel';
 import StatsAdminPanel from '../components/admin/StatsAdminPanel';
 import CalendarAdminPanel from '../components/admin/CalendarAdminPanel';
 import { User, Club, Player } from '../types';
@@ -135,6 +136,14 @@ const Admin = () => {
             >
               <FileText size={18} className="mr-3" />
               <span>Noticias</span>
+            </button>
+
+            <button
+              onClick={() => setActiveTab('comments')}
+              className={`w-full flex items-center p-3 rounded-md text-left transition-colors mb-1 ${activeTab === 'comments' ? 'bg-primary text-white' : 'hover:bg-dark-lighter text-gray-300'}`}
+            >
+              <MessageCircle size={18} className="mr-3" />
+              <span>Comentarios</span>
             </button>
             
             <button
@@ -614,6 +623,8 @@ const Admin = () => {
           {activeTab === 'tournaments' && <TournamentsAdminPanel />}
 
           {activeTab === 'news' && <NewsAdminPanel />}
+
+          {activeTab === 'comments' && <ReportedCommentsPanel />}
 
           {activeTab === 'stats' && <StatsAdminPanel />}
 

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -17,6 +17,7 @@ import {
   faqs,
   storeItems,
   posts,
+  reportedComments,
 } from '../data/mockData';
 import {
   Club,
@@ -30,7 +31,8 @@ import {
   MediaItem,
   FAQ,
   StoreItem,
-  Post
+  Post,
+  Comment
 } from '../types';
 
 interface DataState {
@@ -46,6 +48,7 @@ interface DataState {
   faqs: FAQ[];
   storeItems: StoreItem[];
   posts: Post[];
+  reportedComments: Comment[];
   marketStatus: boolean;
   
   updateClubs: (newClubs: Club[]) => void;
@@ -70,6 +73,9 @@ interface DataState {
   addNewsItem: (item: NewsItem) => void;
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
+  approveComment: (id: string) => void;
+  hideComment: (id: string) => void;
+  deleteComment: (id: string) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -84,6 +90,7 @@ export const useDataStore = create<DataState>((set) => ({
   faqs,
   storeItems,
   posts,
+  reportedComments,
   marketStatus,
   users: getUsers(),
   
@@ -168,6 +175,20 @@ export const useDataStore = create<DataState>((set) => ({
     newsItems: state.newsItems.filter(n => n.id !== id)
   })),
 
-  updateStandings: (newStandings) => set({ standings: newStandings })
+  updateStandings: (newStandings) => set({ standings: newStandings }),
+
+  approveComment: (id) => set((state) => ({
+    reportedComments: state.reportedComments.filter(c => c.id !== id)
+  })),
+
+  hideComment: (id) => set((state) => ({
+    reportedComments: state.reportedComments.map(c =>
+      c.id === id ? { ...c, hidden: true } : c
+    )
+  })),
+
+  deleteComment: (id) => set((state) => ({
+    reportedComments: state.reportedComments.filter(c => c.id !== id)
+  }))
 }));
  

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,8 +158,9 @@ export interface NewsItem {
   title: string;
   content: string;
   type: 'transfer' | 'rumor' | 'result' | 'announcement' | 'statement';
-  image?: string;
+  image: string;
   date: string;
+  publishDate: string;
   author: string;
   clubId?: string;
   playerId?: string;
@@ -204,6 +205,15 @@ export interface FAQ {
   question: string;
   answer: string;
   category: 'account' | 'tournament' | 'league' | 'market' | 'other';
+}
+
+// Comment types
+export interface Comment {
+  id: string;
+  author: string;
+  content: string;
+  date: string;
+  hidden?: boolean;
 }
 
 // Store item types


### PR DESCRIPTION
## Summary
- expand `NewsItem` with `image` and `publishDate`
- create `Comment` type and store `reportedComments`
- allow adding image and publish date when publishing news
- new `ReportedCommentsPanel` to moderate comments
- add comments tab in admin page
- seed mock data with publishDate and example reported comments

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854692dce5483339833fbbbc0842693