### PR TITLE
Implement transfer table and activity log in admin panel

### DIFF
--- a/src/components/admin/MarketAdminPanel.tsx
+++ b/src/components/admin/MarketAdminPanel.tsx
@@ -1,16 +1,36 @@
 import { useDataStore } from '../../store/dataStore';
+import { useActivityStore } from '../../store/activityStore';
+import { useState } from 'react';
 
 const MarketAdminPanel = () => {
-  const { marketStatus, updateMarketStatus } = useDataStore();
+  const { marketStatus, updateMarketStatus, transfers, removeTransfer } = useDataStore();
+  const { addActivity } = useActivityStore();
+
+  const [playerFilter, setPlayerFilter] = useState('');
+  const [clubFilter, setClubFilter] = useState('');
 
   const toggleMarket = () => {
     updateMarketStatus(!marketStatus);
+    addActivity(`Mercado ${!marketStatus ? 'abierto' : 'cerrado'}`);
+  };
+
+  const filteredTransfers = transfers.filter(t => {
+    const matchPlayer = t.playerName.toLowerCase().includes(playerFilter.toLowerCase());
+    const matchClub =
+      t.fromClub.toLowerCase().includes(clubFilter.toLowerCase()) ||
+      t.toClub.toLowerCase().includes(clubFilter.toLowerCase());
+    return matchPlayer && matchClub;
+  });
+
+  const handleAnnul = (id: string) => {
+    removeTransfer(id);
+    addActivity(`Transferencia anulada ${id}`);
   };
 
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">Gestión de Mercado</h2>
-      <div className="bg-dark-light rounded-lg border border-gray-800 p-6 space-y-4">
+      <div className="bg-dark-light rounded-lg border border-gray-800 p-6 space-y-4 mb-6">
         <div className="flex items-center justify-between">
           <span className="text-gray-400">Estado actual</span>
           <span className={`font-bold ${marketStatus ? 'text-neon-green' : 'text-neon-red'}`}>{marketStatus ? 'Abierto' : 'Cerrado'}</span>
@@ -18,6 +38,51 @@ const MarketAdminPanel = () => {
         <button className="btn-primary" onClick={toggleMarket}>
           {marketStatus ? 'Cerrar Mercado' : 'Abrir Mercado'}
         </button>
+      </div>
+
+      <div className="bg-dark-light rounded-lg border border-gray-800 p-6">
+        <div className="flex gap-4 mb-4">
+          <input
+            className="input flex-1"
+            placeholder="Filtrar por jugador"
+            value={playerFilter}
+            onChange={e => setPlayerFilter(e.target.value)}
+          />
+          <input
+            className="input flex-1"
+            placeholder="Filtrar por club"
+            value={clubFilter}
+            onChange={e => setClubFilter(e.target.value)}
+          />
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-gray-800">
+                <th className="p-2">Fecha</th>
+                <th className="p-2">Jugador</th>
+                <th className="p-2">Clubes</th>
+                <th className="p-2">Monto</th>
+                <th className="p-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTransfers.map(t => (
+                <tr key={t.id} className="border-b border-gray-800 last:border-0">
+                  <td className="p-2">{new Date(t.date).toLocaleDateString()}</td>
+                  <td className="p-2">{t.playerName}</td>
+                  <td className="p-2">{t.fromClub} → {t.toClub}</td>
+                  <td className="p-2">{t.fee.toLocaleString()}</td>
+                  <td className="p-2">
+                    <button className="btn-outline" onClick={() => handleAnnul(t.id)}>
+                      Anular
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/store/activityStore.ts
+++ b/src/store/activityStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+export interface Activity {
+  id: string;
+  message: string;
+  date: string;
+}
+
+interface ActivityState {
+  activities: Activity[];
+  addActivity: (message: string) => void;
+}
+
+export const useActivityStore = create<ActivityState>(set => ({
+  activities: [],
+  addActivity: (message) =>
+    set(state => ({
+      activities: [
+        { id: `act${Date.now()}`, message, date: new Date().toISOString() },
+        ...state.activities
+      ]
+    }))
+}));
+

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -57,6 +57,7 @@ interface DataState {
   addOffer: (offer: TransferOffer) => void;
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
   addTransfer: (transfer: Transfer) => void;
+  removeTransfer: (id: string) => void;
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
@@ -112,6 +113,11 @@ export const useDataStore = create<DataState>((set) => ({
   addTransfer: (transfer) => set((state) => ({
     transfers: [transfer, ...state.transfers]
   })),
+
+  removeTransfer: (id) =>
+    set((state) => ({
+      transfers: state.transfers.filter(t => t.id !== id)
+    })),
 
   addUser: (user) => set((state) => ({
     users: [...state.users, user]


### PR DESCRIPTION
## Summary
- fetch transfers in `MarketAdminPanel`
- list transfers in a filterable table
- allow cancelling transfers
- log market actions in a new activity store
- expose `removeTransfer` function in the data store

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854692cd52083339195c7529faf5af6