### PR TITLE
Fix counts on admin dashboard

### DIFF
--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -117,7 +117,7 @@ const WinnerModal = ({ tournament, onClose }: WinnerModalProps) => {
 };
 
 const TournamentsAdminPanel = () => {
-  const { tournaments, addTournament, updateTournaments } = useDataStore();
+  const { tournaments, addTournament } = useDataStore();
   const [name, setName] = useState('');
   const [type, setType] = useState<'league' | 'cup' | 'friendly'>('league');
   const [startDate, setStartDate] = useState('');

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import  { useState, useMemo } from 'react';
 import { Navigate, useNavigate, Link } from 'react-router-dom';
 import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash, Activity } from 'lucide-react';
 import NewUserModal from '../components/admin/NewUserModal';
@@ -45,20 +45,24 @@ const Admin = () => {
   const navigate = useNavigate();
 
   // Stats for dashboard
-  const now = new Date();
-  const weekAgo = new Date(now);
-  weekAgo.setDate(now.getDate() - 7);
-
-  const newUsersCount = users.filter(u => {
-    const date =
-      u.joinDate || (u as unknown as { createdAt?: string }).createdAt;
-    return date ? new Date(date) >= weekAgo : false;
-  }).length;
+  const newUsersCount = useMemo(() => {
+    const today = new Date().toDateString();
+    return users.filter(u => {
+      const date =
+        u.joinDate || (u as unknown as { createdAt?: string }).createdAt;
+      return date ? new Date(date).toDateString() === today : false;
+    }).length;
+  }, [users]);
 
   const activeClubsCount = clubs.length;
-  const transfersTodayCount = transfers.filter(
-    t => t.date === now.toISOString().slice(0, 10)
-  ).length;
+
+  const transfersTodayCount = useMemo(() => {
+    const today = new Date().toDateString();
+    return transfers.filter(t => {
+      const date = new Date(t.date).toDateString();
+      return date === today;
+    }).length;
+  }, [transfers]);
   const activeTournamentsCount = tournaments.filter(t => t.status === 'active').length;
 
   // Redirect if not admin


### PR DESCRIPTION
## Summary
- update new user and transfer count logic for dashboard
- fix unused variable warning in `TournamentsAdminPanel`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685470888568833386d9638a8dd3d49f