### PR TITLE
Add user management filters

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,6 +1,6 @@
 import  { useState } from 'react';
 import { Navigate, useNavigate, Link } from 'react-router-dom';
-import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash, Activity } from 'lucide-react';
+import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash, Activity, Search, ExternalLink } from 'lucide-react';
 import NewUserModal from '../components/admin/NewUserModal';
 import NewClubModal from '../components/admin/NewClubModal';
 import NewPlayerModal from '../components/admin/NewPlayerModal';
@@ -29,6 +29,8 @@ const Admin = () => {
   const [userToDelete, setUserToDelete] = useState(null as User | null);
   const [clubToDelete, setClubToDelete] = useState(null as Club | null);
   const [playerToDelete, setPlayerToDelete] = useState(null as Player | null);
+  const [userSearch, setUserSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<'all' | User['role']>('all');
   const {
     clubs,
     players,
@@ -60,6 +62,15 @@ const Admin = () => {
     t => t.date === now.toISOString().slice(0, 10)
   ).length;
   const activeTournamentsCount = tournaments.filter(t => t.status === 'active').length;
+
+  const filteredUsers = users.filter(u => {
+    const search = userSearch.toLowerCase();
+    const matchSearch =
+      u.username.toLowerCase().includes(search) ||
+      u.email.toLowerCase().includes(search);
+    const matchRole = roleFilter === 'all' || u.role === roleFilter;
+    return matchSearch && matchRole;
+  });
 
   // Redirect if not admin
   if (!isAuthenticated || user?.role !== 'admin') {
@@ -382,6 +393,32 @@ const Admin = () => {
                   Nuevo usuario
                 </button>
               </div>
+
+              <div className="flex flex-col md:flex-row gap-4 mb-6">
+                <div className="relative flex-1">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <Search size={18} className="text-gray-400" />
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="Buscar usuarios..."
+                    className="input pl-10 w-full"
+                    value={userSearch}
+                    onChange={e => setUserSearch(e.target.value)}
+                  />
+                </div>
+
+                <select
+                  className="input w-full md:w-48"
+                  value={roleFilter}
+                  onChange={e => setRoleFilter(e.target.value as 'all' | User['role'])}
+                >
+                  <option value="all">Todos los roles</option>
+                  <option value="user">Usuario</option>
+                  <option value="dt">DT</option>
+                  <option value="admin">Admin</option>
+                </select>
+              </div>
               
               <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
                 <div className="overflow-x-auto">
@@ -397,7 +434,7 @@ const Admin = () => {
                       </tr>
                     </thead>
                     <tbody>
-                      {users.map((u) => {
+                      {filteredUsers.map((u) => {
                         const roleClasses =
                           u.role === 'admin'
                             ? 'bg-neon-red/20 text-neon-red'
@@ -418,7 +455,8 @@ const Admin = () => {
                         return (
                           <tr
                             key={u.id}
-                            className="border-b border-gray-800 hover:bg-dark-lighter"
+                            className="border-b border-gray-800 hover:bg-dark-lighter cursor-pointer"
+                            onClick={() => setEditingUser(u)}
                           >
                             <td className="px-4 py-3">
                               <div className="flex items-center">
@@ -445,15 +483,28 @@ const Admin = () => {
                             </td>
                             <td className="px-4 py-3 text-center">
                               <div className="flex justify-center space-x-2">
+                                <Link
+                                  to={`/usuarios/${u.username}`}
+                                  onClick={e => e.stopPropagation()}
+                                  className="p-1 text-gray-400 hover:text-primary"
+                                >
+                                  <ExternalLink size={16} />
+                                </Link>
                                 <button
                                   className="p-1 text-gray-400 hover:text-primary"
-                                  onClick={() => setEditingUser(u)}
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    setEditingUser(u);
+                                  }}
                                 >
                                   <Edit size={16} />
                                 </button>
                                 <button
                                   className="p-1 text-gray-400 hover:text-red-500"
-                                  onClick={() => setUserToDelete(u)}
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    setUserToDelete(u);
+                                  }}
                                 >
                                   <Trash size={16} />
                                 </button>


### PR DESCRIPTION
## Summary
- search users and filter by role in admin panel
- allow clicking user rows to open edit modal
- link to each user's public profile

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68547089c0908333b965c70d56f43b66