### PR TITLE
Add publish date and image support to news items

### DIFF
--- a/src/components/Home/LatestNews.tsx
+++ b/src/components/Home/LatestNews.tsx
@@ -33,8 +33,11 @@ const LatestNews = () => {
                   {formatNewsType(news.type)}
                 </span>
                 <span className="text-gray-400 text-sm">
-                  {formatDate(news.date)}
+                  {formatDate(news.publishDate)}
                 </span>
+                {new Date(news.publishDate) > new Date() && (
+                  <span className="badge bg-yellow-500/20 text-yellow-400">Programado</span>
+                )}
               </div>
               
               <h3 className="font-medium mb-1">

--- a/src/components/admin/NewsAdminPanel.tsx
+++ b/src/components/admin/NewsAdminPanel.tsx
@@ -6,6 +6,8 @@ const NewsAdminPanel = () => {
   const { newsItems, addNewsItem, removeNewsItem } = useDataStore();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [publishDate, setPublishDate] = useState('');
   const [type, setType] = useState<'transfer' | 'rumor' | 'result' | 'announcement' | 'statement'>('announcement');
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -16,13 +18,16 @@ const NewsAdminPanel = () => {
       title,
       content,
       type,
-      date: new Date().toISOString(),
+      imageUrl: imageUrl || undefined,
+      publishDate: publishDate || new Date().toISOString(),
       author: 'Admin',
       featured: false
     };
     addNewsItem(item);
     setTitle('');
     setContent('');
+    setImageUrl('');
+    setPublishDate('');
   };
 
   return (
@@ -55,6 +60,19 @@ const NewsAdminPanel = () => {
             <option value="rumor">Rumor</option>
             <option value="statement">Declaración</option>
           </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">URL de imagen</label>
+          <input className="input w-full" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Fecha y hora de publicación</label>
+          <input
+            type="datetime-local"
+            className="input w-full"
+            value={publishDate}
+            onChange={e => setPublishDate(e.target.value)}
+          />
         </div>
         <button type="submit" className="btn-primary w-full">Publicar</button>
       </form>

--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -117,7 +117,7 @@ const WinnerModal = ({ tournament, onClose }: WinnerModalProps) => {
 };
 
 const TournamentsAdminPanel = () => {
-  const { tournaments, addTournament, updateTournaments } = useDataStore();
+  const { tournaments, addTournament } = useDataStore();
   const [name, setName] = useState('');
   const [type, setType] = useState<'league' | 'cup' | 'friendly'>('league');
   const [startDate, setStartDate] = useState('');

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -652,8 +652,8 @@ export const newsItems: NewsItem[] = [
     title: 'Comienza la Liga Master 2025',
     content: 'La temporada 2025 de La Virtual Zone ha arrancado oficialmente. 10 clubes compiten por el título en una liga que promete emociones hasta la última jornada.',
     type: 'announcement',
-    image: 'https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
-    date: '2025-01-15',
+    imageUrl: 'https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
+    publishDate: '2025-01-15',
     author: 'Admin',
     featured: true
   },
@@ -662,8 +662,8 @@ export const newsItems: NewsItem[] = [
     title: 'El mercado de fichajes está abierto',
     content: 'Desde hoy los clubes pueden realizar ofertas por jugadores de otros equipos. El mercado permanecerá abierto hasta el 15 de febrero.',
     type: 'announcement',
-    image: 'https://images.unsplash.com/photo-1494178270175-e96de2971df9?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw0fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
-    date: '2025-01-16',
+    imageUrl: 'https://images.unsplash.com/photo-1494178270175-e96de2971df9?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw0fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
+    publishDate: '2025-01-16',
     author: 'Admin',
     featured: false
   },
@@ -672,7 +672,7 @@ export const newsItems: NewsItem[] = [
     title: 'Diego López ficha por Rayo Digital FC',
     content: 'El delantero ha firmado un contrato de 3 temporadas tras el pago de 8.5 millones. "Estoy emocionado por este nuevo reto", declaró el jugador.',
     type: 'transfer',
-    date: '2025-01-05',
+    publishDate: '2025-01-05',
     author: 'Admin',
     clubId: 'club1',
     playerId: 'player21',
@@ -683,7 +683,7 @@ export const newsItems: NewsItem[] = [
     title: 'Rayo Digital vence en el derbi',
     content: 'Los rojiblancos se impusieron 3-1 a Atlético Pixelado en un partido vibrante. Diego López, nuevo fichaje, marcó dos goles.',
     type: 'result',
-    date: '2025-01-20',
+    publishDate: '2025-01-20',
     author: 'Admin',
     clubId: 'club1',
     tournamentId: 'tournament1',
@@ -694,7 +694,7 @@ export const newsItems: NewsItem[] = [
     title: 'Rumor: Neón FC tras una estrella de Binary Strikers',
     content: 'Según fuentes cercanas al club, los neonistas estarían dispuestos a pagar hasta 15 millones por un centrocampista de los Strikers.',
     type: 'rumor',
-    date: '2025-01-22',
+    publishDate: '2025-01-22',
     author: 'Admin',
     clubId: 'club4',
     featured: false
@@ -704,11 +704,11 @@ export const newsItems: NewsItem[] = [
     title: 'DT de Glitchers 404: "Vamos a por el título"',
     content: '"Este año tenemos un equipo para luchar arriba. No renunciamos a nada y vamos partido a partido", declaró el técnico tras la victoria 2-0 ante Connection FC.',
     type: 'statement',
-    date: '2025-01-23',
+    publishDate: '2025-01-23',
     author: 'Admin',
     clubId: 'club6',
     featured: false
-  } 
+  }
 ];
 
 // Blog posts

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -159,8 +159,8 @@ export interface NewsItem {
   title: string;
   content: string;
   type: 'transfer' | 'rumor' | 'result' | 'announcement' | 'statement';
-  image?: string;
-  date: string;
+  imageUrl?: string;
+  publishDate: string;
   author: string;
   clubId?: string;
   playerId?: string;


### PR DESCRIPTION
## Summary
- extend `NewsItem` type with `imageUrl` and `publishDate`
- update mock data to include new fields
- enhance admin panel form to capture image URL and publish date
- show scheduled tag on future news items
- remove unused variable causing ESLint failure

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854708be30c8333896aa414e9d04cad