### PR TITLE
Add user status editing in admin

### DIFF
--- a/src/components/admin/EditUserModal.tsx
+++ b/src/components/admin/EditUserModal.tsx
@@ -13,10 +13,11 @@ const EditUserModal = ({ user, onClose }: Props) => {
   const [username, setUsername] = useState(user.username);
   const [email, setEmail] = useState(user.email);
   const [role, setRole] = useState<User['role']>(user.role);
+  const [status, setStatus] = useState<User['status']>(user.status);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    updateUserEntry({ ...user, username, email, role });
+    updateUserEntry({ ...user, username, email, role, status });
     onClose();
   };
 
@@ -43,6 +44,18 @@ const EditUserModal = ({ user, onClose }: Props) => {
               <option value="user">Usuario</option>
               <option value="dt">DT</option>
               <option value="admin">Admin</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Estado</label>
+            <select
+              className="input w-full"
+              value={status}
+              onChange={e => setStatus(e.target.value as User['status'])}
+            >
+              <option value="active">Activo</option>
+              <option value="suspended">Suspendido</option>
+              <option value="banned">Baneado</option>
             </select>
           </div>
           <button type="submit" className="btn-primary w-full">Guardar</button>

--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -117,7 +117,7 @@ const WinnerModal = ({ tournament, onClose }: WinnerModalProps) => {
 };
 
 const TournamentsAdminPanel = () => {
-  const { tournaments, addTournament, updateTournaments } = useDataStore();
+  const { tournaments, addTournament } = useDataStore();
   const [name, setName] = useState('');
   const [type, setType] = useState<'league' | 'cup' | 'friendly'>('league');
   const [startDate, setStartDate] = useState('');

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -410,6 +410,24 @@ const Admin = () => {
                             : u.role === 'dt'
                             ? 'DT'
                             : 'Usuario';
+                        const statusClasses =
+                          u.status === 'active'
+                            ? 'bg-green-500/20 text-green-500'
+                            : u.status === 'suspended'
+                            ? 'bg-yellow-500/20 text-yellow-400'
+                            : 'bg-red-500/20 text-red-400';
+                        const dotColor =
+                          u.status === 'active'
+                            ? 'bg-green-500'
+                            : u.status === 'suspended'
+                            ? 'bg-yellow-500'
+                            : 'bg-red-500';
+                        const statusLabel =
+                          u.status === 'active'
+                            ? 'Activo'
+                            : u.status === 'suspended'
+                            ? 'Suspendido'
+                            : 'Baneado';
                         const clubName =
                           clubs.find(c => c.id === u.clubId)?.name ||
                           u.club ||
@@ -438,9 +456,11 @@ const Admin = () => {
                             </td>
                             <td className="px-4 py-3 text-center">{clubName}</td>
                             <td className="px-4 py-3 text-center">
-                              <span className="inline-flex items-center px-2 py-1 bg-green-500/20 text-green-500 text-xs rounded-full">
-                                <span className="w-1.5 h-1.5 bg-green-500 rounded-full mr-1"></span>
-                                Activo
+                              <span
+                                className={`inline-flex items-center px-2 py-1 text-xs rounded-full ${statusClasses}`}
+                              >
+                                <span className={`w-1.5 h-1.5 rounded-full mr-1 ${dotColor}`}></span>
+                                {statusLabel}
                               </span>
                             </td>
                             <td className="px-4 py-3 text-center">

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -148,14 +148,23 @@ export const useDataStore = create<DataState>((set) => ({
     set((state) => {
       const prev = state.users.find(u => u.id === user.id);
       persistUser(user);
+      const current = useAuthStore.getState().user?.id || 'system';
       if (prev && prev.role !== user.role) {
-        const current = useAuthStore.getState().user?.id || 'system';
         useActivityLogStore
           .getState()
           .addLog(
             'role_change',
             current,
             `Rol de ${prev.username} cambiado a ${user.role}`
+          );
+      }
+      if (prev && prev.status !== user.status) {
+        useActivityLogStore
+          .getState()
+          .addLog(
+            'status_change',
+            current,
+            `Estado de ${prev.username} cambiado a ${user.status}`
           );
       }
       return {


### PR DESCRIPTION
## Summary
- allow editing user status in EditUserModal
- persist status updates and log them in data store
- show actual status in admin user table
- fix lint issue in TournamentsAdminPanel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854708aaf408333bf27dbb816189bac