### PR TITLE
Add morale to Club data and new DT dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const ClubFinances = lazy(() => import('./pages/ClubFinances'));
 const HallOfFame = lazy(() => import('./pages/HallOfFame'));
 const Rankings = lazy(() => import('./pages/Rankings'));
 const Fixtures = lazy(() => import('./pages/Fixtures'));
+const DtDashboard = lazy(() => import('./pages/DtDashboard'));
 
 function App() {
   return (
@@ -36,6 +37,7 @@ function App() {
           <Route path="login" element={<Login />} />
           <Route path="registro" element={<Register />} />
           <Route path="usuario" element={<UserPanel />} />
+          <Route path="dt-dashboard" element={<DtDashboard />} />
           
           {/* Liga Master routes */}
           <Route path="liga-master">

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -122,9 +122,22 @@ const Navbar = () => {
                       >
                         <div className="flex items-center">
                           <User size={16} className="mr-2" />
-                          <span>Mi Perfil</span>
-                        </div>
-                      </Link>
+                      <span>Mi Perfil</span>
+                    </div>
+                  </Link>
+
+                  {user?.role === 'dt' && (
+                    <Link
+                      to="/dt-dashboard"
+                      className="text-gray-300 hover:bg-gray-700 hover:text-white block px-4 py-2 text-sm"
+                      onClick={() => setUserMenuOpen(false)}
+                    >
+                      <div className="flex items-center">
+                        <Trophy size={16} className="mr-2" />
+                        <span>Mi Club</span>
+                      </div>
+                    </Link>
+                  )}
                       
                       {user?.role === 'admin' && (
                         <Link
@@ -267,6 +280,16 @@ const Navbar = () => {
                 >
                   Mi Perfil
                 </Link>
+
+                {user?.role === 'dt' && (
+                  <Link
+                    to="/dt-dashboard"
+                    className="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Mi Club
+                  </Link>
+                )}
                 
                 {user?.role === 'admin' && (
                   <Link

--- a/src/components/admin/NewClubModal.tsx
+++ b/src/components/admin/NewClubModal.tsx
@@ -36,7 +36,8 @@ const NewClubModal = ({ onClose }: Props) => {
       description: '',
       titles: [],
       reputation: 50,
-      fanBase: 0
+      fanBase: 0,
+      morale: 50
     };
 
     addClub(newClub);

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -42,7 +42,8 @@ export const clubs: Club[] = [
       }
     ],
     reputation: 85,
-    fanBase: 10000
+    fanBase: 10000,
+    morale: 75
   },
   {
     id: 'club2',
@@ -65,7 +66,8 @@ export const clubs: Club[] = [
       }
     ],
     reputation: 80,
-    fanBase: 8500
+    fanBase: 8500,
+    morale: 70
   },
   {
     id: 'club3',
@@ -81,7 +83,8 @@ export const clubs: Club[] = [
     description: 'Conocido por su sólida defensa y juego táctico. Difícil de vencer en casa.',
     titles: [],
     reputation: 75,
-    fanBase: 7200
+    fanBase: 7200,
+    morale: 65
   },
   {
     id: 'club4',
@@ -104,7 +107,8 @@ export const clubs: Club[] = [
       }
     ],
     reputation: 83,
-    fanBase: 9500
+    fanBase: 9500,
+    morale: 80
   },
   {
     id: 'club5',
@@ -120,7 +124,8 @@ export const clubs: Club[] = [
     description: 'Club que combina tradición y modernidad. Juego equilibrado y sólido en todas las líneas.',
     titles: [],
     reputation: 77,
-    fanBase: 8000
+    fanBase: 8000,
+    morale: 68
   },
   {
     id: 'club6',
@@ -143,7 +148,8 @@ export const clubs: Club[] = [
       }
     ],
     reputation: 76,
-    fanBase: 7500
+    fanBase: 7500,
+    morale: 72
   },
   {
     id: 'club7',
@@ -159,7 +165,8 @@ export const clubs: Club[] = [
     description: 'Club con filosofía de toque y posesión extrema. Especialistas en dominar el centro del campo.',
     titles: [],
     reputation: 78,
-    fanBase: 7800
+    fanBase: 7800,
+    morale: 77
   },
   {
     id: 'club8',
@@ -175,7 +182,8 @@ export const clubs: Club[] = [
     description: 'Equipo de juego vertical y directo. Especializado en transiciones rápidas y ataques por banda.',
     titles: [],
     reputation: 79,
-    fanBase: 8200
+    fanBase: 8200,
+    morale: 74
   },
   {
     id: 'club9',
@@ -191,7 +199,8 @@ export const clubs: Club[] = [
     description: 'Club que espera al rival y aprovecha los espacios. Especialista en contragolpes letales.',
     titles: [],
     reputation: 74,
-    fanBase: 7000
+    fanBase: 7000,
+    morale: 60
   },
   {
     id: 'club10',
@@ -214,7 +223,8 @@ export const clubs: Club[] = [
       }
     ],
     reputation: 82,
-    fanBase: 9000
+    fanBase: 9000,
+    morale: 85
   }
 ];
 

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -256,12 +256,21 @@ const ClubProfile = () => {
                             <span className="text-gray-400">Reputación</span>
                             <div className="flex">
                               {Array.from({ length: 5 }).map((_, i) => (
-                                <Star 
+                                <Star
                                   key={i}
                                   size={16}
                                   className={i < Math.round(club.reputation / 20) ? "text-yellow-400" : "text-gray-700"}
                                 />
                               ))}
+                            </div>
+                          </div>
+                          <div className="flex justify-between items-center">
+                            <span className="text-gray-400">Moral</span>
+                            <div className="w-32 h-2 bg-gray-800 rounded-full overflow-hidden">
+                              <div
+                                className="h-full bg-green-500"
+                                style={{ width: `${club.morale ?? 0}%` }}
+                              ></div>
                             </div>
                           </div>
                         </div>

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -1,0 +1,52 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../store/authStore';
+import { useDataStore } from '../store/dataStore';
+
+const DtDashboard = () => {
+  const { user, isAuthenticated } = useAuthStore();
+  const { clubs } = useDataStore();
+
+  if (!isAuthenticated || !user) {
+    return <Navigate to="/login" />;
+  }
+
+  if (user.role !== 'dt' || !user.club) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        Necesitas ser DT de un club para acceder a esta sección.
+      </div>
+    );
+  }
+
+  const club = clubs.find(c => c.name === user.club);
+
+  if (!club) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        Club no encontrado.
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 pt-24">
+      <div className="card p-6 flex items-center mb-6">
+        <img src={club.logo} alt={club.name} className="w-16 h-16 mr-4" />
+        <div className="flex-1">
+          <h2 className="text-xl font-bold mb-2">{club.name}</h2>
+          <div className="h-3 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-green-500"
+              style={{ width: `${club.morale}%` }}
+            ></div>
+          </div>
+          <div className="text-xs text-gray-400 mt-1">
+            Moral del equipo: {club.morale}%
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DtDashboard;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export interface Club {
   titles: Title[];
   reputation: number;
   fanBase: number;
+  morale: number;
 }
 
 export interface Title {


### PR DESCRIPTION
## Summary
- extend `Club` interface with `morale`
- include morale for each club in mock data
- set default morale in the new club modal
- create `DtDashboard` page showing morale bar
- expose the DT dashboard through routing and navbar links
- show morale info in `ClubProfile`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685482d138948333a47a9bfa364c91c2