### PR TITLE
Enhance DT dashboard with league snapshot and actions

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -571,7 +571,9 @@ export function generateStandings(tournamentId: string): Standing[] {
       goalsFor: 0,
       goalsAgainst: 0,
       points: 0,
-      form: []
+      form: [],
+      possession: 50,
+      cards: 0
     };
   });
   
@@ -648,7 +650,13 @@ export function generateStandings(tournamentId: string): Standing[] {
     // Sort alphabetically as last resort
     return a.clubName.localeCompare(b.clubName);
   });
-  
+
+  // Add synthetic stats
+  standingsArray.forEach(team => {
+    team.possession = 45 + Math.floor(Math.random() * 11);
+    team.cards = 5 + Math.floor(Math.random() * 20);
+  });
+
   return standingsArray;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -232,6 +232,8 @@ export interface Standing {
   goalsAgainst: number;
   points: number;
   form: string[];
+  possession: number;
+  cards: number;
 }
  
 // Activity log types


### PR DESCRIPTION
## Summary
- extend `Standing` data with possession and card counts
- generate synthetic stats for standings in `mockData`
- restructure DT dashboard page to include a mini ranking, market highlights, announcements, reminders, comparison chart, social feed and quick action buttons

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a618a0588333b274df492194adf2