### PR TITLE
Pulish final fixes for DT dashboard

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   --neon-blue: #00b3ff;
   --neon-green: #00ff8f;
   --neon-yellow: #ffe600;
+  --accent: #00e0ff;
 }
 
 body {

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -7,7 +7,8 @@ import {
   TrendingUp,
   Home,
   Plane,
-  Newspaper
+  Newspaper,
+  Check
 } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
@@ -15,6 +16,13 @@ import { formatCurrency, formatDate, slugify } from '../utils/helpers';
 
 const DtDashboard = () => {
   const [countdown, setCountdown] = useState('');
+  const [reminders, setReminders] = useState<string[]>([
+    'Confirma tu alineación antes del viernes',
+    'Revisa el informe médico de tu delantero lesionado'
+  ]);
+  const handleComplete = (index: number) => {
+    setReminders(prev => prev.filter((_, i) => i !== index));
+  };
   const { user, isAuthenticated } = useAuthStore();
   const { clubs, players, standings, tournaments, newsItems, marketStatus, transfers } = useDataStore();
 
@@ -89,10 +97,6 @@ const DtDashboard = () => {
     .sort((a, b) => new Date(b.publishDate).getTime() - new Date(a.publishDate).getTime())
     .slice(0, 2);
 
-  const reminders = [
-    'Confirma tu alineación antes del viernes',
-    'Revisa el informe médico de tu delantero lesionado'
-  ];
 
   const leagueAvgGoals = standings.reduce((sum, s) => sum + s.goalsFor, 0) / standings.length;
   const leagueAvgPossession = standings.reduce((sum, s) => sum + s.possession, 0) / standings.length;
@@ -110,7 +114,12 @@ const DtDashboard = () => {
   return (
     <>
       <div className="container mx-auto px-4 py-8 space-y-8">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <a
+        href={`/liga-master/club/${slug}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 hover:opacity-90"
+      >
         <div className="flex items-center">
           <img src={club.logo} alt={club.name} className="w-14 h-14 mr-3" />
           <h1 className="text-2xl font-bold">{club.name}</h1>
@@ -119,12 +128,12 @@ const DtDashboard = () => {
           <p className="text-gray-400">DT: {club.manager}</p>
           <p className="text-gray-400">Presupuesto: {formatCurrency(club.budget)}</p>
         </div>
-      </div>
+      </a>
 
       {morale !== undefined ? (
         <div className="h-2 bg-dark rounded-full overflow-hidden">
           <div
-            className="h-full bg-primary transition-all duration-500"
+            className="h-full bg-accent transition-all duration-500"
             style={{ width: `${morale}%` }}
           ></div>
         </div>
@@ -135,9 +144,9 @@ const DtDashboard = () => {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <Link
           to={`/liga-master/club/${slug}/plantilla`}
-          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--primary)] transition-shadow focus:outline-none focus:ring-2 focus:ring-primary"
+          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--accent)] transition-shadow focus:outline-none focus:ring-2 focus:ring-accent"
         >
-          <Users className="text-primary mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
+          <Users className="text-accent mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
           <p className="text-gray-400 text-sm font-medium mb-1">Plantilla</p>
           <p className="text-lg font-medium mb-2">{clubPlayers.length} jugadores</p>
           {captain && (
@@ -146,25 +155,25 @@ const DtDashboard = () => {
         </Link>
         <Link
           to={`/liga-master/club/${slug}/tacticas`}
-          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--primary)] transition-shadow focus:outline-none focus:ring-2 focus:ring-primary"
+          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--accent)] transition-shadow focus:outline-none focus:ring-2 focus:ring-accent"
         >
-          <Layout className="text-neon-blue mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
+          <Layout className="text-accent mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
           <p className="text-gray-400 text-sm font-medium mb-1">Táctica</p>
           <p className="text-lg font-medium">{formation}</p>
         </Link>
         <Link
           to={`/liga-master/club/${slug}/finanzas`}
-          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--primary)] transition-shadow focus:outline-none focus:ring-2 focus:ring-primary"
+          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--accent)] transition-shadow focus:outline-none focus:ring-2 focus:ring-accent"
         >
-          <DollarSign className="text-neon-green mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
+          <DollarSign className="text-accent mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
           <p className="text-gray-400 text-sm font-medium mb-1">Finanzas</p>
           <p className="text-lg font-medium">{formatCurrency(club.budget)}</p>
         </Link>
         <Link
           to="/liga-master/mercado"
-          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--primary)] transition-shadow focus:outline-none focus:ring-2 focus:ring-primary"
+          className="card card-hover p-6 text-center hover:shadow-[0_0_10px_var(--accent)] transition-shadow focus:outline-none focus:ring-2 focus:ring-accent"
         >
-          <TrendingUp className="text-neon-yellow mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
+          <TrendingUp className="text-accent mb-3 w-8 h-8 max-[359px]:w-5 max-[359px]:h-5" />
           <p className="text-gray-400 text-sm font-medium mb-1">Mercado</p>
           <p className="text-lg font-medium">{marketStatus ? 'Abierto' : 'Cerrado'}</p>
         </Link>
@@ -174,7 +183,7 @@ const DtDashboard = () => {
         <div className="card p-6 mb-8">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-bold">Próximo Partido</h2>
-            <Link to="/liga-master/fixture" className="text-primary text-sm hover:text-primary-light focus:outline-none focus:ring-2 focus:ring-primary">
+            <Link to="/liga-master/fixture" className="text-accent text-sm hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent">
               Calendario
             </Link>
           </div>
@@ -193,9 +202,9 @@ const DtDashboard = () => {
               )}
               <div className="flex items-center justify-center mt-1">
                 {nextMatch.homeTeam === club.name ? (
-                  <Home size={16} className="text-primary mr-1" />
+                  <Home size={16} className="text-accent mr-1" />
                 ) : (
-                  <Plane size={16} className="text-primary mr-1" />
+                  <Plane size={16} className="text-accent mr-1" />
                 )}
                 <span>{nextMatch.homeTeam === club.name ? 'Local' : 'Visitante'}</span>
               </div>
@@ -211,7 +220,7 @@ const DtDashboard = () => {
         </div>
       )}
 
-      <div className="grid lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 max-[359px]:grid-cols-1">
         <div className="lg:col-span-2 space-y-6">
           {standing && (
             <div className="card p-4 overflow-x-auto">
@@ -226,13 +235,13 @@ const DtDashboard = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {miniRanking.map((team, idx) => {
+                  {miniRanking.map(team => {
                     const clubRow = clubs.find(c => c.id === team.clubId);
                     const pos = standings.indexOf(team) + 1;
                     return (
                       <tr
                         key={team.clubId}
-                        className={`border-b border-gray-800 last:border-0 ${team.clubId === club.id ? 'bg-primary/20' : ''}`}
+                        className={`border-b border-gray-800 last:border-0 ${team.clubId === club.id ? 'bg-accent/20' : ''}`}
                       >
                         <td className="p-2">{pos}</td>
                         <td className="p-2 flex items-center space-x-2">
@@ -250,7 +259,7 @@ const DtDashboard = () => {
           )}
 
           {standing && (
-            <div className="card p-6">
+            <div className="card p-6 lg:mt-6">
               <h2 className="text-lg font-bold mb-4">Comparativa con la liga</h2>
               <div className="space-y-4">
                 {[
@@ -264,11 +273,11 @@ const DtDashboard = () => {
                       <p className="text-sm mb-1">{stat.label}</p>
                       <div className="relative h-3 bg-gray-700 rounded">
                         <div
-                          className="absolute top-0 left-0 h-3 bg-primary rounded"
+                          className="absolute top-0 left-0 h-3 bg-accent rounded"
                           style={{ width: `${(stat.club / maxVal) * 100}%` }}
                         ></div>
                         <div
-                          className="absolute top-0 left-0 h-3 bg-gray-500 rounded opacity-50"
+                          className="absolute top-0 left-0 h-3 bg-gray-500/40 rounded"
                           style={{ width: `${(stat.league / maxVal) * 100}%` }}
                         ></div>
                       </div>
@@ -290,7 +299,7 @@ const DtDashboard = () => {
                 {statements.map(s => (
                   <li key={s.id} className="flex justify-between items-center">
                     <span className="font-medium">{s.title}</span>
-                    <Link to={`/blog/${s.id}`} className="text-primary text-sm">Leer</Link>
+                    <Link to={`/blog/${s.id}`} className="text-accent text-sm">Leer</Link>
                   </li>
                 ))}
               </ul>
@@ -304,7 +313,7 @@ const DtDashboard = () => {
             <ul className="space-y-2 text-sm">
               {topTransfers.map(t => (
                 <li key={t.id} className="flex justify-between">
-                  <span>{t.playerName} → {t.toClub}</span>
+                  <span>{t.playerName} {t.fromClub} → {t.toClub}</span>
                   <span>{formatCurrency(t.fee)}</span>
                 </li>
               ))}
@@ -312,7 +321,7 @@ const DtDashboard = () => {
           </div>
 
           {announcements.length > 0 && (
-            <div className="card p-6">
+            <div className="card card-hover p-6 hover:shadow-[0_0_10px_var(--accent)] transition-shadow">
               <h2 className="text-lg font-bold mb-4">Anuncios</h2>
               <ul className="space-y-2 text-sm">
                 {announcements.map(a => (
@@ -325,16 +334,24 @@ const DtDashboard = () => {
             </div>
           )}
 
-          <div className="card p-6">
+          <div className="card card-hover p-6 hover:shadow-[0_0_10px_var(--accent)] transition-shadow">
             <h2 className="text-lg font-bold mb-4">Recordatorios</h2>
             {reminders.length > 0 ? (
-              <ul className="list-disc ml-5 space-y-1 text-sm">
+              <ul className="space-y-1 text-sm">
                 {reminders.map((r, i) => (
-                  <li key={i}>{r}</li>
+                  <li key={i} className="flex items-center justify-between">
+                    <span>{r}</span>
+                    <button
+                      onClick={() => handleComplete(i)}
+                      className="text-accent hover:text-white"
+                    >
+                      <Check size={16} />
+                    </button>
+                  </li>
                 ))}
               </ul>
             ) : (
-              <p className="text-gray-400 text-sm">Todo en orden</p>
+              <p className="text-gray-400 text-sm">Todo al día ✔️</p>
             )}
           </div>
 
@@ -353,7 +370,7 @@ const DtDashboard = () => {
         <div className="card p-6 mt-12">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-bold">Últimas Noticias</h2>
-            <Link to="/liga-master/feed" className="text-primary text-sm hover:text-primary-light focus:outline-none focus:ring-2 focus:ring-primary">
+            <Link to="/liga-master/feed" className="text-accent text-sm hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent">
               Ver todo
             </Link>
           </div>
@@ -361,7 +378,7 @@ const DtDashboard = () => {
             {latestNews.map(item => (
               <li key={item.id} className="flex items-center justify-between">
                 <div className="flex items-center">
-                  <Newspaper size={16} className="text-primary mr-2" />
+                  <Newspaper size={16} className="text-accent mr-2" />
                   <span>{item.title}</span>
                 </div>
                 <span className="text-xs text-gray-400">{formatDate(item.publishDate)}</span>
@@ -373,10 +390,10 @@ const DtDashboard = () => {
     </div>
     <footer className="text-gray-400 text-sm mt-8">
       <div className="flex justify-center gap-4 sm:grid sm:grid-cols-2 sm:w-1/2 sm:mx-auto lg:grid lg:grid-cols-2 lg:w-1/2 lg:mx-auto">
-        <Link to="/reglamento" className="focus:outline-none focus:ring-2 focus:ring-primary">Reglamento</Link>
-        <Link to="/liga-master/hall-of-fame" className="focus:outline-none focus:ring-2 focus:ring-primary">Salón de la Fama</Link>
-        <Link to="/pretemporada" className="focus:outline-none focus:ring-2 focus:ring-primary">Pretemporada</Link>
-        <Link to="/ayuda" className="focus:outline-none focus:ring-2 focus:ring-primary">Ayuda</Link>
+        <Link to="/reglamento" className="focus:outline-none focus:ring-2 focus:ring-accent">Reglamento</Link>
+        <Link to="/liga-master/hall-of-fame" className="focus:outline-none focus:ring-2 focus:ring-accent">Salón de la Fama</Link>
+        <Link to="/pretemporada" className="focus:outline-none focus:ring-2 focus:ring-accent">Pretemporada</Link>
+        <Link to="/ayuda" className="focus:outline-none focus:ring-2 focus:ring-accent">Ayuda</Link>
       </div>
     </footer>
   </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ export default {
         'neon-blue': 'var(--neon-blue)',
         'neon-green': 'var(--neon-green)',
         'neon-yellow': 'var(--neon-yellow)',
+        accent: 'var(--accent)',
         dark: '#1a1a24',
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- adjust positions grid to better wrap on narrow screens
- align performance chart with side announcements block
- display transfers with arrow between clubs
- improve bar chart contrast
- highlight announcement and reminder panels on hover

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854acffdc7483338838f71455fda324