### PR TITLE
Add pollCounts state for poll results

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -31,17 +31,22 @@ const DtDashboard = () => {
     'Revisa el informe médico de tu delantero lesionado'
   ]);
   const options = ['Jugador 1', 'Jugador 2', 'Jugador 3'];
-  const [{ voted, results }, setPoll] = useState({
-    voted: false,
-    results: [36, 45, 19]
+  const [pollCounts, setPollCounts] = useState([36, 45, 19]);
+  const [{ voted, results }, setPoll] = useState(() => {
+    const total = pollCounts.reduce((a, b) => a + b, 0);
+    return {
+      voted: false,
+      results: pollCounts.map(c => Math.round((c / total) * 100))
+    };
   });
   const vote = (index: number) => {
-    setPoll(prev => {
-      const counts = [...prev.results];
+    setPollCounts(prev => {
+      const counts = [...prev];
       counts[index] += 1;
       const total = counts.reduce((a, b) => a + b, 0);
       const percentages = counts.map(c => Math.round((c / total) * 100));
-      return { voted: true, results: percentages };
+      setPoll({ voted: true, results: percentages });
+      return counts;
     });
   };
   const handleComplete = (index: number) => {


### PR DESCRIPTION
## Summary
- add `pollCounts` for tracking raw vote counts
- calculate initial vote percentages from `pollCounts`
- update `vote` to increment `pollCounts` and recompute percentages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855978ad19c8333943a67f37f2b82d2