### PR TITLE
Fix slug generation in Liga Master page

### DIFF
--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -163,8 +163,8 @@ const LigaMaster = () => {
                             </span>
                           </td>
                           <td className="p-4">
-                            <Link 
-                              to={`/liga-master/club/${club?.name.toLowerCase().replace(/\s+/g, '-')}`}
+                            <Link
+                              to={`/liga-master/club/${club?.name ? club.name.toLowerCase().replace(/\s+/g, '-') : ''}`}
                               className="flex items-center"
                             >
                               <img 
@@ -257,7 +257,7 @@ const LigaMaster = () => {
                 {clubs.map(club => (
                   <Link 
                     key={club.id} 
-                    to={`/liga-master/club/${club.name.toLowerCase().replace(/\s+/g, '-')}`}
+                    to={`/liga-master/club/${club.name ? club.name.toLowerCase().replace(/\s+/g, '-') : ''}`}
                     className="flex items-center p-3 rounded-lg hover:bg-gray-800 transition-colors"
                   >
                     <img 
@@ -390,4 +390,4 @@ const LigaMaster = () => {
 };
 
 export default LigaMaster;
- 
+


### PR DESCRIPTION
## Summary
- prevent runtime errors if club data is missing when linking to club pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68559ca347c883339d4ce3a3fb5f552b