### PR TITLE
Add clubId to DT test user

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -59,6 +59,7 @@ const TEST_USERS = [
     level: 5,
     xp: 500,
     club: 'Neón FC',
+    clubId: 'club4',
     avatar: 'https://ui-avatars.com/api/?name=Coach&background=00b3ff&color=fff&size=128&bold=true',
     joinDate: new Date().toISOString(),
     status: 'active',


### PR DESCRIPTION
## Summary
- update TEST_USERS with `clubId` for the entrenador user

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855a532c564833390055d5f9e4e6c46