### PR TITLE
Add club slugs and fix badge reference

### DIFF
--- a/src/components/admin/NewClubModal.tsx
+++ b/src/components/admin/NewClubModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { X } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { Club } from '../../types';
+import { slugify } from '../../utils/helpers';
 
 interface Props {
   onClose: () => void;
@@ -25,6 +26,7 @@ const NewClubModal = ({ onClose }: Props) => {
     const newClub: Club = {
       id: `${Date.now()}`,
       name,
+      slug: slugify(name),
       logo: `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=3b82f6&color=fff&size=128`,
       foundedYear: new Date().getFullYear(),
       stadium: '',

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,8 +1,8 @@
-import  { 
-  Club, 
-  Player, 
-  Tournament, 
-  Match, 
+import  {
+  Club,
+  Player,
+  Tournament,
+  Match,
   Transfer,
   TransferOffer,
   NewsItem,
@@ -12,11 +12,13 @@ import  {
   FAQ,
   StoreItem
 } from '../types';
+import { slugify } from '../utils/helpers';
 
 // Mock Clubs Data
 export const clubs: Club[] = [
   {
     id: 'club1',
+    slug: slugify('Rayo Digital FC'),
     name: 'Rayo Digital FC',
     logo: 'https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -47,6 +49,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club2',
+    slug: slugify('Atlético Pixelado'),
     name: 'Atlético Pixelado',
     logo: 'https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -71,6 +74,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club3',
+    slug: slugify('Defensores del Lag'),
     name: 'Defensores del Lag',
     logo: 'https://ui-avatars.com/api/?name=DL&background=a855f7&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -88,6 +92,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club4',
+    slug: slugify('Neón FC'),
     name: 'Neón FC',
     logo: 'https://ui-avatars.com/api/?name=NFC&background=ec4899&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -112,6 +117,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club5',
+    slug: slugify('Haxball United'),
     name: 'Haxball United',
     logo: 'https://ui-avatars.com/api/?name=HU&background=f97316&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -129,6 +135,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club6',
+    slug: slugify('Glitchers 404'),
     name: 'Glitchers 404',
     logo: 'https://ui-avatars.com/api/?name=404&background=84cc16&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -153,6 +160,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club7',
+    slug: slugify('Cyber Warriors'),
     name: 'Cyber Warriors',
     logo: 'https://ui-avatars.com/api/?name=CW&background=06b6d4&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -170,6 +178,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club8',
+    slug: slugify('Binary Strikers'),
     name: 'Binary Strikers',
     logo: 'https://ui-avatars.com/api/?name=BS&background=7c3aed&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -187,6 +196,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club9',
+    slug: slugify('Connection FC'),
     name: 'Connection FC',
     logo: 'https://ui-avatars.com/api/?name=CFC&background=eab308&color=fff&size=128&bold=true',
     foundedYear: 2023,
@@ -204,6 +214,7 @@ export const clubs: Club[] = [
   },
   {
     id: 'club10',
+    slug: slugify('Pixel Galaxy'),
     name: 'Pixel Galaxy',
     logo: 'https://ui-avatars.com/api/?name=PG&background=14b8a6&color=fff&size=128&bold=true',
     foundedYear: 2023,

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -135,7 +135,7 @@ const DtDashboard = () => {
           className="flex items-center gap-3 hover:underline"
         >
           <img
-            src={club.badge}
+            src={club.logo}
             alt="Escudo"
             className="h-14 w-14 rounded-full"
           />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface User {
 export interface Club {
   id: string;
   name: string;
+  slug: string;
   logo: string;
   foundedYear: number;
   stadium: string;


### PR DESCRIPTION
## Summary
- define `slug` property for `Club`
- generate club slugs in `mockData`
- fix club badge reference on DT dashboard
- include slug when creating a new club

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a536783c8333a2ac08b252721245