### PR TITLE
Add DT dashboard data to store

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,8 +1,8 @@
-import  { 
-  Club, 
-  Player, 
-  Tournament, 
-  Match, 
+import  {
+  Club,
+  Player,
+  Tournament,
+  Match,
   Transfer,
   TransferOffer,
   NewsItem,
@@ -10,7 +10,13 @@ import  {
   Post,
   Standing,
   FAQ,
-  StoreItem
+  StoreItem,
+  DtClub,
+  DtFixture,
+  DtMarket,
+  DtObjectives,
+  DtTask,
+  DtEvent
 } from '../types';
 
 // Mock Clubs Data
@@ -1004,4 +1010,37 @@ export const storeItems: StoreItem[] = [
     inStock: true
   }
 ];
+
+// --- Datos para el tablero del DT ---
+export const dtClub: DtClub = {
+  id: 'club1',
+  name: 'Rayo Digital FC',
+  slug: 'rayo-digital-fc',
+  badge: clubs[0].logo,
+  formation: '4-3-3',
+  budget: clubs[0].budget,
+  players: players.filter(p => p.clubId === 'club1')
+};
+
+export const dtFixtures: DtFixture[] = tournaments[0].matches
+  .filter(m => m.homeTeam === dtClub.name || m.awayTeam === dtClub.name)
+  .slice(0, 6)
+  .map(m => ({ ...m, played: m.status === 'finished' }));
+
+export const dtMarket: DtMarket = { open: true };
+
+export const dtObjectives: DtObjectives = { position: 50, fairplay: 70 };
+
+export const dtTasks: DtTask[] = [
+  { id: 'task1', text: 'Actualizar tácticas' },
+  { id: 'task2', text: 'Revisar informe médico' }
+];
+
+export const dtEvents: DtEvent[] = [
+  { id: 'event1', message: 'Fin de mercado el 15 de febrero', date: '2025-02-15' },
+  { id: 'event2', message: 'Reunión de liga', date: '2025-02-05' }
+];
+
+export const dtNews: NewsItem[] = newsItems.slice(0, 5);
+export const dtPositions: Standing[] = leagueStandings;
  

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -19,6 +19,14 @@ import {
   faqs,
   storeItems,
   posts,
+  dtClub,
+  dtFixtures,
+  dtMarket,
+  dtObjectives,
+  dtTasks,
+  dtEvents,
+  dtNews,
+  dtPositions
 } from '../data/mockData';
 import {
   Club,
@@ -32,7 +40,13 @@ import {
   MediaItem,
   FAQ,
   StoreItem,
-  Post
+  Post,
+  DtClub,
+  DtFixture,
+  DtMarket,
+  DtObjectives,
+  DtTask,
+  DtEvent
 } from '../types';
 
 interface DataState {
@@ -49,6 +63,15 @@ interface DataState {
   storeItems: StoreItem[];
   posts: Post[];
   marketStatus: boolean;
+  // DT dashboard fields
+  club: DtClub;
+  fixtures: DtFixture[];
+  market: DtMarket;
+  objectives: DtObjectives;
+  tasks: DtTask[];
+  events: DtEvent[];
+  news: NewsItem[];
+  positions: Standing[];
   
   updateClubs: (newClubs: Club[]) => void;
   updatePlayers: (newPlayers: Player[]) => void;
@@ -88,6 +111,14 @@ export const useDataStore = create<DataState>((set) => ({
   storeItems,
   posts,
   marketStatus,
+  club: dtClub,
+  fixtures: dtFixtures,
+  market: dtMarket,
+  objectives: dtObjectives,
+  tasks: dtTasks,
+  events: dtEvents,
+  news: dtNews,
+  positions: dtPositions,
   users: getUsers(),
   
   updateClubs: (newClubs) => set({ clubs: newClubs }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -255,3 +255,38 @@ export interface Comment {
   reported: boolean;
   hidden: boolean;
 }
+
+// --- DT dashboard specific types ---
+export interface DtClub {
+  id: string;
+  name: string;
+  slug: string;
+  badge: string;
+  formation: string;
+  budget: number;
+  players: Player[];
+}
+
+export interface DtFixture extends Match {
+  played: boolean;
+}
+
+export interface DtMarket {
+  open: boolean;
+}
+
+export interface DtObjectives {
+  position: number | null;
+  fairplay: number | null;
+}
+
+export interface DtTask {
+  id: string;
+  text: string;
+}
+
+export interface DtEvent {
+  id: string;
+  message: string;
+  date: string;
+}


### PR DESCRIPTION
## Summary
- add DT dashboard data types
- provide mock DT data
- expose DT data in Zustand store

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a531d4b48333a65359406f4c92af