### PR TITLE
Fix dashboard types

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1027,7 +1027,7 @@ export const dtClub: DtClub = {
   id: 'club1',
   name: 'Rayo Digital FC',
   slug: 'rayo-digital-fc',
-  badge: clubs[0].logo,
+  logo: clubs[0].logo,
   formation: '4-3-3',
   budget: clubs[0].budget,
   players: players.filter(p => p.clubId === 'club1')

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -141,7 +141,7 @@ const DtDashboard = () => {
           />
           <div>
             <h1 className="text-2xl font-semibold">{club.name}</h1>
-            <p className="text-sm text-gray-400">{user.name}</p>
+            <p className="text-sm text-gray-400">{user.username}</p>
           </div>
         </Link>
         <div className="mt-4 flex flex-col items-center md:ml-auto md:mt-0 md:items-end">
@@ -200,7 +200,7 @@ const DtDashboard = () => {
           {nextMatch && (
             <Card>
               <div className="flex items-center gap-2">
-                {nextMatch.home === club.id ? (
+                {nextMatch.homeTeam === club.name ? (
                   <Home size={16} className="text-accent" />
                 ) : (
                   <Plane size={16} className="text-accent" />
@@ -208,7 +208,7 @@ const DtDashboard = () => {
                 <h2 className="font-semibold">Próximo partido</h2>
               </div>
               <p className="mt-2">
-                {nextMatch.rival} –{' '}
+                {nextMatch.homeTeam === club.name ? nextMatch.awayTeam : nextMatch.homeTeam} –{' '}
                 <span className="text-gray-400">{formatDate(nextMatch.date)}</span>
               </p>
               {countdown && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -262,7 +262,7 @@ export interface DtClub {
   id: string;
   name: string;
   slug: string;
-  badge: string;
+  logo: string;
   formation: string;
   budget: number;
   players: Player[];


### PR DESCRIPTION
## Summary
- use `logo` in DT types and mock data
- display `user.username` on DT dashboard
- compute next match details with `homeTeam` and `awayTeam`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855fbb751bc8333ae02f74408ff52ca