### PR TITLE
Move slugify function to its own utility

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -18,7 +18,7 @@ import  {
   DtTask,
   DtEvent
 } from '../types';
-import { slugify } from '../utils/helpers';
+import { slugify } from '../utils/slugify';
 
 // Mock Clubs Data
 export const clubs: Club[] = [

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -2,7 +2,7 @@ import  { useParams, Link } from 'react-router-dom';
 import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
-import { formatCurrency, formatDate, slugify } from '../utils/helpers';
+import { formatCurrency, formatDate } from '../utils/helpers';
 
 const ClubFinances = () => {
   const { clubName } = useParams<{ clubName: string }>();

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -12,7 +12,7 @@ import {
 import PageHeader from '../components/common/PageHeader';
 import StatsCard from '../components/common/StatsCard';
 import { useDataStore } from '../store/dataStore';
-import { formatDate, formatCurrency, getMatchResult, slugify } from '../utils/helpers';
+import { formatDate, formatCurrency, getMatchResult } from '../utils/helpers';
 
 const ClubProfile = () => {
   const { clubName } = useParams<{ clubName: string }>();

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -2,7 +2,7 @@ import  { useParams, Link } from 'react-router-dom';
 import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
-import { formatCurrency, slugify } from '../utils/helpers';
+import { formatCurrency } from '../utils/helpers';
 import { useState } from 'react';
 
 const ClubSquad = () => {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,6 @@
-import { Match, Standing, Player } from '../types';
+import { Match, Standing } from '../types';
 import { leagueStandings, players } from '../data/mockData';
+export { slugify } from './slugify';
 
 //  Format currency
 export const formatCurrency = (amount: number): string => {
@@ -91,20 +92,6 @@ export const getMatchResult = (match: Match, teamName: string): 'win' | 'loss' |
   }
   
   return null;
-};
-
-// Slugify string
-export const slugify = (text: string): string => {
-  return text
-    .toString()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^\w-]+/g, '')
-    .replace(/--+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '');
 };
 
 // Calculate level from XP
@@ -199,11 +186,11 @@ const computeDiff = (
   const team = leagueStandings.find(t => t.clubId === clubId);
   if (!team) return { label, diff: 0 };
 
-  const avg =
-    leagueStandings.reduce((sum, s) => sum + (s as any)[field], 0) /
+const avg =
+    leagueStandings.reduce((sum, s) => sum + s[field], 0) /
     leagueStandings.length;
 
-  return { label, diff: Math.round((team as any)[field] - avg) };
+  return { label, diff: Math.round(team[field] - avg) };
 };
 
 export const goalsDiff = (clubId: string): LeagueDiff =>

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,14 @@
+export const slugify = (text: string): string => {
+  return text
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w-]+/g, '')
+    .replace(/--+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+};
+
+export default slugify;


### PR DESCRIPTION
## Summary
- create `src/utils/slugify.ts` with the slugify function
- re-export slugify from `helpers.ts`
- update imports in `mockData.ts` and remove unused imports
- clean up unused variables and improve typing in `helpers`
- remove unused slugify imports from pages
- run lint and build to verify

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6856017781348333b19baeeeb6d4add0