### PR TITLE
Add Liga Master pages for feed and tactics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,9 @@ const HallOfFame = lazy(() => import('./pages/HallOfFame'));
 const Rankings = lazy(() => import('./pages/Rankings'));
 const Fixtures = lazy(() => import('./pages/Fixtures'));
 const DtDashboard = lazy(() => import('./pages/DtDashboard'));
+const Feed = lazy(() => import('./pages/Feed'));
+const Tacticas = lazy(() => import('./pages/Tacticas'));
+const Analisis = lazy(() => import('./pages/Analisis'));
 
 function App() {
   return (
@@ -40,17 +43,20 @@ function App() {
           <Route path="dt-dashboard" element={<DtDashboard />} />
           
           {/* Liga Master routes */}
-          <Route path="liga-master">
-            <Route index element={<LigaMaster />} />
-            <Route path="mercado" element={<Market />} />
-            <Route path="club/:clubName" element={<ClubProfile />} />
-          <Route path="club/:clubName/plantilla" element={<ClubSquad />} />
-          <Route path="clubes/:clubId/plantilla" element={<ClubSquad />} />
-          <Route path="club/:clubName/finanzas" element={<ClubFinances />} />
-            <Route path="hall-of-fame" element={<HallOfFame />} />
-            <Route path="rankings" element={<Rankings />} />
-            <Route path="fixture" element={<Fixtures />} />
-          </Route>
+        <Route path="liga-master">
+          <Route index element={<LigaMaster />} />
+          <Route path="mercado" element={<Market />} />
+          <Route path="club/:clubName" element={<ClubProfile />} />
+         <Route path="club/:clubName/plantilla" element={<ClubSquad />} />
+         <Route path="clubes/:clubId/plantilla" element={<ClubSquad />} />
+         <Route path="club/:clubName/finanzas" element={<ClubFinances />} />
+          <Route path="hall-of-fame" element={<HallOfFame />} />
+          <Route path="rankings" element={<Rankings />} />
+          <Route path="fixture" element={<Fixtures />} />
+          <Route path="feed" element={<Feed />} />
+          <Route path="tacticas" element={<Tacticas />} />
+          <Route path="analisis" element={<Analisis />} />
+        </Route>
           
           {/* Tournaments routes */}
           <Route path="torneos">

--- a/src/pages/Analisis.tsx
+++ b/src/pages/Analisis.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Analisis = () => {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold">Análisis</h1>
+    </div>
+  );
+};
+
+export default Analisis;

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Feed = () => {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold">Feed</h1>
+    </div>
+  );
+};
+
+export default Feed;

--- a/src/pages/Tacticas.tsx
+++ b/src/pages/Tacticas.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Tacticas = () => {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold">Tácticas</h1>
+    </div>
+  );
+};
+
+export default Tacticas;

--- a/src/pages/UserPanel.tsx
+++ b/src/pages/UserPanel.tsx
@@ -383,7 +383,7 @@ const UserPanel = () => {
                     </a>
                     
                     <a
-                      href={`/liga-master/club/${userClub.slug}/tacticas`}
+                      href="/liga-master/tacticas"
                       className="p-4 bg-dark rounded-lg hover:bg-gray-800 transition-colors flex flex-col items-center text-center"
                     >
                       <Clipboard size={24} className="text-primary mb-2" />


### PR DESCRIPTION
## Summary
- add placeholder pages for Tácticas, Análisis and Feed
- route new pages under `/liga-master`
- adjust UserPanel quick links
- run lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68562564faf0833388e164e847d8424d