### PR TITLE
Add glow effect to dashboard header

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -141,7 +141,7 @@ const DtDashboard = () => {
             className="h-14 w-14 rounded-full"
           />
           <div>
-            <h1 className="text-2xl font-semibold">{club.name}</h1>
+              <h1 className="text-2xl font-semibold neon-text-blue drop-shadow-md">{club.name}</h1>
             <p className="text-sm text-gray-400">{user.username}</p>
           </div>
         </Link>


### PR DESCRIPTION
## Summary
- add neon-blue glow to the club name on DtDashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68570063557483338ebb223aa9a9eabc