### PR TITLE
Add podium row colors to mini table

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -235,9 +235,17 @@ const DtDashboard = () => {
                   {miniTable.map(row => (
                     <tr
                       key={row.club}
-                      className={
+                      className={`${
                         row.club === club.id ? 'text-accent font-semibold' : ''
-                      }
+                      } ${
+                        row.pos === 1
+                          ? 'bg-yellow-500/20'
+                          : row.pos === 2
+                          ? 'bg-gray-400/20'
+                          : row.pos === 3
+                          ? 'bg-amber-600/20'
+                          : ''
+                      }`}
                     >
                       <td>{row.pos}</td>
                       <td>{row.name}</td>


### PR DESCRIPTION
## Summary
- highlight 1st, 2nd and 3rd rows in the dashboard mini table using gold, silver and bronze backgrounds

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68570068a1708333a147e761aed6e903