### PR TITLE
Replace admin dashboard divs with Card component

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface CardProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+
+const Card = ({ children, onClick, className = '' }: CardProps) => (
+  <div
+    onClick={onClick}
+    className={`hover-card rounded-lg bg-zinc-900 p-4 shadow transition-transform hover:shadow-neon/40 ${className}`.trim()}
+  >
+    {children}
+  </div>
+);
+
+export default Card;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -18,6 +18,7 @@ import CommentsAdminPanel from '../components/admin/CommentsAdminPanel';
 import { User, Club, Player } from '../types';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
+import Card from '../components/common/Card';
 
 const Admin = () => {
   const [activeTab, setActiveTab] = useState('dashboard');
@@ -204,54 +205,34 @@ const Admin = () => {
               <h2 className="text-2xl font-bold mb-6">Dashboard</h2>
               
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-                <div className="bg-dark-light rounded-lg p-6 border border-gray-800 flex flex-col">
+                <Card className="p-6 flex flex-col cursor-pointer" onClick={() => setActiveTab('users')}>
                   <p className="text-gray-400 text-sm mb-1">Nuevos usuarios</p>
                   <h3 className="text-2xl font-bold">{newUsersCount}</h3>
-                  <button
-                    className="btn-primary mt-3"
-                    onClick={() => setActiveTab('users')}
-                  >
-                    Ver usuarios
-                  </button>
-                </div>
+                  <button className="btn-primary mt-3">Ver usuarios</button>
+                </Card>
 
-                <div className="bg-dark-light rounded-lg p-6 border border-gray-800 flex flex-col">
+                <Card className="p-6 flex flex-col cursor-pointer" onClick={() => setActiveTab('clubs')}>
                   <p className="text-gray-400 text-sm mb-1">Clubes activos</p>
                   <h3 className="text-2xl font-bold">{activeClubsCount}</h3>
-                  <button
-                    className="btn-primary mt-3"
-                    onClick={() => setActiveTab('clubs')}
-                  >
-                    Ver clubes
-                  </button>
-                </div>
+                  <button className="btn-primary mt-3">Ver clubes</button>
+                </Card>
 
-                <div className="bg-dark-light rounded-lg p-6 border border-gray-800 flex flex-col">
+                <Card className="p-6 flex flex-col cursor-pointer" onClick={() => setActiveTab('market')}>
                   <p className="text-gray-400 text-sm mb-1">Transferencias hoy</p>
                   <h3 className="text-2xl font-bold">{transfersTodayCount}</h3>
-                  <button
-                    className="btn-primary mt-3"
-                    onClick={() => setActiveTab('market')}
-                  >
-                    Ver mercado
-                  </button>
-                </div>
+                  <button className="btn-primary mt-3">Ver mercado</button>
+                </Card>
 
-                <div className="bg-dark-light rounded-lg p-6 border border-gray-800 flex flex-col">
+                <Card className="p-6 flex flex-col cursor-pointer" onClick={() => setActiveTab('tournaments')}>
                   <p className="text-gray-400 text-sm mb-1">Torneos activos</p>
                   <h3 className="text-2xl font-bold">{activeTournamentsCount}</h3>
-                  <button
-                    className="btn-primary mt-3"
-                    onClick={() => setActiveTab('tournaments')}
-                  >
-                    Ver torneos
-                  </button>
-                </div>
+                  <button className="btn-primary mt-3">Ver torneos</button>
+                </Card>
               </div>
               
               <div className="mb-8">
                 <h3 className="text-xl font-bold mb-4">Actividad reciente</h3>
-                <div className="bg-dark-light rounded-lg border border-gray-800 overflow-hidden">
+                <Card className="overflow-hidden">
                   <div className="p-4 border-b border-gray-800">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center">
@@ -296,13 +277,13 @@ const Admin = () => {
                       <span className="text-xs text-gray-400">Hace 1 día</span>
                     </div>
                   </div>
-                </div>
+                </Card>
               </div>
-              
+
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <div>
                   <h3 className="text-xl font-bold mb-4">Estado del sistema</h3>
-                  <div className="bg-dark-light rounded-lg border border-gray-800 p-4">
+                  <Card className="p-4">
                     <div className="space-y-4">
                       <div className="flex items-center justify-between">
                         <span className="text-gray-400">Mercado de fichajes</span>
@@ -336,12 +317,12 @@ const Admin = () => {
                         </button>
                       </div>
                     </div>
-                  </div>
+                  </Card>
                 </div>
-                
+
                 <div>
                   <h3 className="text-xl font-bold mb-4">Acciones rápidas</h3>
-                  <div className="bg-dark-light rounded-lg border border-gray-800 p-4">
+                  <Card className="p-4">
                     <div className="grid grid-cols-2 gap-4">
                       <button
                         className="btn-outline py-3 flex flex-col items-center justify-center"
@@ -391,7 +372,7 @@ const Admin = () => {
                         <span className="text-sm">Configuración</span>
                       </button>
                     </div>
-                  </div>
+                  </Card>
                 </div>
               </div>
             </div>

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -22,6 +22,7 @@ import {
 
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
+import Card from '../components/common/Card';
 import {
   getMiniTable,
   formatCurrency,
@@ -34,22 +35,6 @@ import {
 } from '../utils/helpers';
 
 /* ---------- componentes pequeños reutilizados ---------- */
-
-/* sombra y escala homogéneas para TODAS las tarjetas */
-const Card = ({
-  children,
-  onClick
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-}) => (
-  <div
-    onClick={onClick}
-    className="hover-card cursor-pointer rounded-lg bg-zinc-900 p-4 shadow transition-transform hover:shadow-neon/40"
-  >
-    {children}
-  </div>
-);
 
 /* Progress bar con transición suave */
 const ProgressBar = ({


### PR DESCRIPTION
## Summary
- create reusable `Card` component
- switch DtDashboard to use shared `Card`
- wrap Admin dashboard sections in `Card`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857006918c083338440bd7f082f0fd1