### PR TITLE
Fix tests and TypeScript issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "build": "tsc && vite build",
       "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
       "preview": "vite preview",
-      "test": "tsc -p tsconfig.test.json && node tests/build/helpers.test.js"
+      "test": "tsc -p tsconfig.test.json && node --experimental-specifier-resolution=node tests/build/tests/helpers.test.js"
    },
    "dependencies": {
       "lucide-react": "^0.244.0",

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -18,7 +18,7 @@ import  {
   DtTask,
   DtEvent
 } from '../types';
-import { slugify } from '../utils/slugify';
+import { slugify } from '../utils/slugify.js';
 
 // Mock Clubs Data
 export const clubs: Club[] = [

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -15,7 +15,7 @@ const hashPassword = (pwd: string): string => {
 // Mock test users
 const TEST_PASSWORD = hashPassword('password');
 
-const TEST_USERS = [
+const TEST_USERS: User[] = [
   {
     id: '1',
     username: 'admin',
@@ -23,15 +23,14 @@ const TEST_USERS = [
     role: 'admin',
     level: 10,
     xp: 1000,
-    avatar: 'https://ui-avatars.com/api/?name=Admin&background=9f65fd&color=fff&size=128&bold=true',
+    avatar:
+      'https://ui-avatars.com/api/?name=Admin&background=9f65fd&color=fff&size=128&bold=true',
     joinDate: new Date().toISOString(),
     status: 'active',
-    achievements: ['founder'],
-    following: {
-      users: [],
-      clubs: [],
-      players: []
-    },
+    notifications: true,
+    lastLogin: new Date().toISOString(),
+    followers: 0,
+    following: 0,
     password: TEST_PASSWORD
   },
   {
@@ -41,14 +40,14 @@ const TEST_USERS = [
     role: 'user',
     level: 1,
     xp: 0,
+    avatar:
+      'https://ui-avatars.com/api/?name=Usuario&background=111827&color=fff&size=128',
     joinDate: new Date().toISOString(),
     status: 'active',
-    achievements: [],
-    following: {
-      users: [],
-      clubs: [],
-      players: []
-    },
+    notifications: true,
+    lastLogin: new Date().toISOString(),
+    followers: 0,
+    following: 0,
     password: TEST_PASSWORD
   },
   {
@@ -60,15 +59,14 @@ const TEST_USERS = [
     xp: 500,
     club: 'Neón FC',
     clubId: 'club4',
-    avatar: 'https://ui-avatars.com/api/?name=Coach&background=00b3ff&color=fff&size=128&bold=true',
+    avatar:
+      'https://ui-avatars.com/api/?name=Coach&background=00b3ff&color=fff&size=128&bold=true',
     joinDate: new Date().toISOString(),
     status: 'active',
-    achievements: ['first_win', 'first_transfer'],
-    following: {
-      users: [],
-      clubs: ['Rayo Digital FC'],
-      players: []
-    },
+    notifications: true,
+    lastLogin: new Date().toISOString(),
+    followers: 0,
+    following: 0,
     password: TEST_PASSWORD
   }
 ];
@@ -185,7 +183,7 @@ export const addUser = (
     )}&background=111827&color=fff&size=128`,
     xp: 0,
     clubId,
-    createdAt: new Date().toISOString(),
+    joinDate: new Date().toISOString(),
     status: 'active',
     notifications: true,
     lastLogin: new Date().toISOString(),

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 import { Match, Standing } from '../types';
-import { leagueStandings, players } from '../data/mockData';
-export { slugify } from './slugify';
+import { leagueStandings, players } from '../data/mockData.js';
+export { slugify } from './slugify.js';
 
 //  Format currency
 export const formatCurrency = (amount: number): string => {
@@ -180,14 +180,14 @@ export interface LeagueDiff {
 
 const computeDiff = (
   clubId: string,
-  field: keyof Standing,
+  field: 'goalsFor' | 'possession' | 'cards',
   label: string
 ): LeagueDiff => {
   const team = leagueStandings.find(t => t.clubId === clubId);
   if (!team) return { label, diff: 0 };
 
-const avg =
-    leagueStandings.reduce((sum, s) => sum + s[field], 0) /
+  const avg =
+    leagueStandings.reduce((sum, s) => sum + (s[field] as number), 0) /
     leagueStandings.length;
 
   return { label, diff: Math.round(team[field] - avg) };

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,5 +1,12 @@
-import { getMiniTable, calcStreak, getTopPerformer, goalsDiff, possessionDiff, yellowDiff } from '../src/utils/helpers.ts';
-import { leagueStandings, tournaments } from '../src/data/mockData.ts';
+import {
+  getMiniTable,
+  calcStreak,
+  getTopPerformer,
+  goalsDiff,
+  possessionDiff,
+  yellowDiff
+} from '../src/utils/helpers.js';
+import { leagueStandings, tournaments } from '../src/data/mockData.js';
 
 const mini = getMiniTable('club1', leagueStandings);
 console.log('mini', mini.length === 5);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "allowImportingTsExtensions": false,
-    "module": "CommonJS",
+    "module": "ES2022",
     "moduleResolution": "node",
     "outDir": "tests/build"
   },


### PR DESCRIPTION
## Summary
- update mock test users to satisfy `User` interface
- use correct property names when adding a user
- refine helper imports for Node's ESM execution
- narrow `computeDiff` field types
- update test imports and npm script
- compile tests as ES2022 modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685709bbf0588333b8afc0279e66c24e