### PR TITLE
Improve helper tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+tests/build

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -7,14 +7,15 @@ import {
   yellowDiff
 } from '../src/utils/helpers.js';
 import { leagueStandings, tournaments } from '../src/data/mockData.js';
+import * as assert from 'node:assert/strict';
 
 const mini = getMiniTable('club1', leagueStandings);
-console.log('mini', mini.length === 5);
+assert.strictEqual(mini.length, 5);
 
 const fixtures = tournaments.find(t => t.id === 'tournament1')?.matches ?? [];
-console.log('streak', calcStreak('club1', fixtures).length <= 5);
+assert.ok(calcStreak('club1', fixtures).length <= 5);
 
-console.log('performer', getTopPerformer('club1') !== null);
-console.log('goals', typeof goalsDiff('club1').diff === 'number');
-console.log('possession', typeof possessionDiff('club1').diff === 'number');
-console.log('cards', typeof yellowDiff('club1').diff === 'number');
+assert.ok(getTopPerformer('club1') !== null);
+assert.strictEqual(typeof goalsDiff('club1').diff, 'number');
+assert.strictEqual(typeof possessionDiff('club1').diff, 'number');
+assert.strictEqual(typeof yellowDiff('club1').diff, 'number');


### PR DESCRIPTION
## Summary
- assert helper outputs using `node:assert`
- ignore compiled test output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685726900cec8333a71b995e36ddf8bf