### PR TITLE
Configure path aliases

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
-@tailwind  base;
+/* tailwindcss v4 */
+@tailwind base;
 @tailwind components;
 @tailwind utilities;
 

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -20,10 +20,10 @@ import {
   Calendar
 } from 'lucide-react';
 
-import { useAuthStore } from '../store/authStore';
-import { useDataStore } from '../store/dataStore';
-import Card from '../components/common/Card';
-import { DtFixture, NewsItem } from '../types';
+import { useAuthStore } from '@/store/authStore';
+import { useDataStore } from '@/store/dataStore';
+import Card from '@/components/common/Card';
+import { DtFixture, NewsItem } from '@/types';
 import {
   getMiniTable,
   formatCurrency,
@@ -33,7 +33,7 @@ import {
   goalsDiff,
   yellowDiff,
   possessionDiff
-} from '../utils/helpers';
+} from '@/utils/helpers';
 
 /* ---------- componentes pequeños reutilizados ---------- */
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,6 +8,10 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    },
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
+import { fileURLToPath, URL } from 'node:url';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
   optimizeDeps: {
     include: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- add `baseUrl` and `paths` in `tsconfig.app.json`
- configure alias in `vite.config.ts`
- update imports in `DtDashboard` to use alias
- document Tailwind CSS usage in `index.css`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68573002e0a8833395899e3926c95340