### PR TITLE
Fix path alias config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.app.json",
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
## Summary
- extend root tsconfig from tsconfig.app so editors recognize path aliases

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685732d3daa48333b8f996b0f8b98a73