### PR TITLE
Fix types and cleanup

### DIFF
--- a/src/components/admin/TournamentsAdminPanel.tsx
+++ b/src/components/admin/TournamentsAdminPanel.tsx
@@ -19,13 +19,13 @@ const MatchResultModal = ({ tournament, onClose }: ResultModalProps) => {
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!matchId) return;
-    const updated = tournaments.map(t => {
+    const updated = tournaments.map<Tournament>(t => {
       if (t.id !== tournament.id) return t;
       const matches = t.matches.map(m =>
         m.id === matchId ? { ...m, homeScore: home, awayScore: away, status: 'finished' } : m
       );
       const resultMatch = matches.find(m => m.id === matchId) as Match;
-      return { ...t, matches, results: [...(t.results || []), resultMatch] };
+      return { ...t, matches, results: [...(t.results || []), resultMatch] } as Tournament;
     });
     updateTournaments(updated);
     onClose();
@@ -83,8 +83,8 @@ const WinnerModal = ({ tournament, onClose }: WinnerModalProps) => {
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!winner) return;
-    const updated = tournaments.map(t =>
-      t.id === tournament.id ? { ...t, winner, status: 'finished' } : t
+    const updated = tournaments.map<Tournament>(t =>
+      t.id === tournament.id ? ({ ...t, winner, status: 'finished' } as Tournament) : t
     );
     updateTournaments(updated);
     onClose();

--- a/src/pages/Analisis.tsx
+++ b/src/pages/Analisis.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 const Analisis = () => {
   return (

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 const Feed = () => {
   return (

--- a/src/pages/HallOfFame.tsx
+++ b/src/pages/HallOfFame.tsx
@@ -2,6 +2,7 @@ import  { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Award, ChevronLeft, Star, Shield, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
+import { slugify } from '../utils/slugify';
 
 const HallOfFame = () => {
   const [activeSection, setActiveSection] = useState('clubs');
@@ -11,6 +12,7 @@ const HallOfFame = () => {
     {
       id: '1',
       name: 'Rayo Digital FC',
+      slug: slugify('Rayo Digital FC'),
       logo: 'https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true',
       manager: 'admin',
       foundedYear: 2023,
@@ -24,6 +26,7 @@ const HallOfFame = () => {
     {
       id: '2',
       name: 'Neón FC',
+      slug: slugify('Neón FC'),
       logo: 'https://ui-avatars.com/api/?name=NFC&background=ec4899&color=fff&size=128&bold=true',
       manager: 'DT Neon',
       foundedYear: 2023,
@@ -36,6 +39,7 @@ const HallOfFame = () => {
     {
       id: '3',
       name: 'Glitchers 404',
+      slug: slugify('Glitchers 404'),
       logo: 'https://ui-avatars.com/api/?name=404&background=84cc16&color=fff&size=128&bold=true',
       manager: 'DT Glitch',
       foundedYear: 2023,

--- a/src/pages/Tacticas.tsx
+++ b/src/pages/Tacticas.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 const Tacticas = () => {
   return (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,11 +10,21 @@ export interface User {
   club?: string;
   clubId?: string;
   joinDate?: string;
+  /** Registration date */
+  createdAt?: string;
   status: 'active' | 'suspended' | 'banned';
   notifications: boolean;
   lastLogin: string;
   followers: number;
-  following: number;
+  /**
+   * Structure containing the clubs and users this user follows. Older
+   * mock data only stored a count, so these properties are optional.
+   */
+  following: {
+    clubs: string[];
+    users: string[];
+    players?: string[];
+  } | number;
   password?: string;
 }
 
@@ -28,7 +38,11 @@ export interface Club {
   stadium: string;
   budget: number;
   manager: string;
+  /** Style of play. Some components refer to this field as `style`. */
   playStyle: string;
+  style?: 'possession' | 'counter' | 'offensive' | 'defensive' | 'balanced';
+  /** Some views use `dt` as an alias for manager */
+  dt?: string;
   primaryColor: string;
   secondaryColor: string;
   description: string;
@@ -36,6 +50,16 @@ export interface Club {
   reputation: number;
   fanBase: number;
   morale: number;
+  /** Current season statistics used in some views */
+  season?: number;
+  wins?: number;
+  draws?: number;
+  losses?: number;
+  goalsFor?: number;
+  goalsAgainst?: number;
+  points?: number;
+  /** Optional squad information for panels that list players */
+  players?: Player[];
 }
 
 export interface Title {
@@ -88,10 +112,33 @@ export interface Tournament {
   id: string;
   name: string;
   type: 'league' | 'cup' | 'friendly';
+  /**
+   * Optional slug used in routes. Some pages expect this field so we
+   * include it here to avoid type errors when the data does not provide it.
+   */
+  slug?: string;
+  /**
+   * Optional banner or cover image used in tournament listings.
+   */
+  image?: string;
+  /**
+   * Alias used by some views instead of `type`. It may contain additional
+   * values like `playoff` so keep it flexible.
+   */
+  format?: 'league' | 'cup' | 'friendly' | 'playoff';
   logo: string;
   startDate: string;
   endDate: string;
-  status: 'upcoming' | 'active' | 'finished';
+  /**
+   * Tournament status. Older data only includes `upcoming`, `active` and
+   * `finished`, but UI components also reference `open` and `ongoing`.
+   */
+  status: 'upcoming' | 'active' | 'finished' | 'open' | 'ongoing';
+  /**
+   * List of participating club names. Not every tournament provides this
+   * information so it is optional.
+   */
+  participants?: string[];
   teams: string[];
   rounds: number;
   matches: Match[];


### PR DESCRIPTION
## Summary
- extend data models for clubs, tournaments, and users
- update admin panel helpers with explicit generics
- add slugs for Hall of Fame mock clubs
- remove unused React imports

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc -p tsconfig.app.json` *(fails: several TS errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68573e16fb1883338cbc5cd3d7712960