### PR TITLE
Fix slug link in TestMarket page

### DIFF
--- a/src/pages/TestMarket.tsx
+++ b/src/pages/TestMarket.tsx
@@ -193,7 +193,7 @@ const TestMarket = () => {
             <div>
               <h4 className="font-bold text-primary mb-2">3. Revisa la Plantilla de tu Club</h4>
               <p className="text-gray-300 text-sm">
-                Ve a <a href="/liga-master/club/neón-fc" className="text-primary hover:underline">/liga-master/club/neón-fc</a> para ver tu plantilla actual y las finanzas del club.
+                Ve a <a href="/liga-master/club/neon-fc" className="text-primary hover:underline">/liga-master/club/neon-fc</a> para ver tu plantilla actual y las finanzas del club.
               </p>
             </div>
             


### PR DESCRIPTION
## Summary
- correct slug for Neon FC link on TestMarket page

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc -p tsconfig.test.json` *(fails: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later)*

------
https://chatgpt.com/codex/tasks/task_e_6857430398f48333bc5a4f8386034c68