### PR TITLE
Add DT dashboard type fields

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1036,7 +1036,13 @@ export const dtClub: DtClub = {
 export const dtFixtures: DtFixture[] = tournaments[0].matches
   .filter(m => m.homeTeam === dtClub.name || m.awayTeam === dtClub.name)
   .slice(0, 6)
-  .map(m => ({ ...m, played: m.status === 'finished' }));
+  .map(m => ({
+    ...m,
+    home: m.homeTeam === dtClub.name,
+    rival: m.homeTeam === dtClub.name ? m.awayTeam : m.homeTeam,
+    matchday: m.round,
+    played: m.status === 'finished'
+  }));
 
 export const dtMarket: DtMarket = { open: true };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@
 export interface User {
   id: string;
   username: string;
+  /** Display name */
+  name: string;
   email: string;
   role: 'user' | 'dt' | 'admin';
   avatar: string;
@@ -310,12 +312,18 @@ export interface DtClub {
   name: string;
   slug: string;
   logo: string;
+  /** Optional badge image */
+  badge?: string;
   formation: string;
   budget: number;
   players: Player[];
+  captain?: string;
 }
 
 export interface DtFixture extends Match {
+  home: boolean;
+  rival: string;
+  matchday: number;
   played: boolean;
 }
 


### PR DESCRIPTION
## Summary
- extend `User` type with `name`
- allow clubs to include optional badge and captain info
- expose fixture meta fields
- populate fixture data accordingly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857504c2ef48333aa0acf7b99eb4f52