### PR TITLE
Add PageHeader to DT dashboard

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -22,6 +22,7 @@ import {
 
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
+import PageHeader from '../components/common/PageHeader';
 import {
   getMiniTable,
   formatCurrency,
@@ -128,6 +129,11 @@ const DtDashboard = () => {
 
   return (
     <>
+      <PageHeader
+        title="Tablero del DT"
+        subtitle="Vista general del club y próximas actividades."
+        image="https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0"
+      />
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* ---------- ENCABEZADO ---------- */}
       <header className="mb-6 flex flex-col items-center gap-4 md:flex-row">


### PR DESCRIPTION
## Summary
- add PageHeader import in the DT dashboard page
- include a header with title and subtitle before the dashboard content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68575976a78c83339a3ff91876b1684d