### PR TITLE
Improve match card design

### DIFF
--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -121,7 +121,10 @@ const Fixtures = () => {
             const isExpanded = expandedMatches[match.id] || false;
             
             return (
-              <div key={match.id} className="card card-hover overflow-hidden">
+              <div
+                key={match.id}
+                className="card card-hover overflow-hidden bg-gradient-to-br from-dark to-gray-800 border border-gray-700"
+              >
                 <div className="p-4 border-b border-gray-800">
                   <div className="flex justify-between items-center">
                     <div className="text-sm text-gray-400">
@@ -144,21 +147,21 @@ const Fixtures = () => {
                 <div className="p-5">
                   <div className="flex items-center justify-between">
                     <div className="flex flex-col items-center w-2/5 sm:w-1/3">
-                      <img 
-                        src={homeClub?.logo} 
+                      <img
+                        src={homeClub?.logo}
                         alt={homeClub?.name}
-                        className="w-12 h-12 sm:w-16 sm:h-16 object-contain mb-2"
+                        className="w-16 h-16 sm:w-20 sm:h-20 object-contain mb-2"
                       />
                       <span className="font-medium text-center">{homeClub?.name}</span>
                     </div>
-                    
-                    <div className="flex flex-col items-center">
+
+                    <div className="flex flex-col items-center flex-1 text-center">
                       {match.status === 'finished' ? (
-                        <div className="text-2xl sm:text-3xl font-bold mb-1">
+                        <div className="text-3xl sm:text-4xl font-bold mb-1 neon-text-blue">
                           {match.homeScore} - {match.awayScore}
                         </div>
                       ) : (
-                        <div className="text-xl sm:text-2xl font-bold mb-1">VS</div>
+                        <div className="text-2xl sm:text-3xl font-bold mb-1 neon-text-blue">VS</div>
                       )}
                       
                       <button
@@ -180,10 +183,10 @@ const Fixtures = () => {
                     </div>
                     
                     <div className="flex flex-col items-center w-2/5 sm:w-1/3">
-                      <img 
-                        src={awayClub?.logo} 
+                      <img
+                        src={awayClub?.logo}
                         alt={awayClub?.name}
-                        className="w-12 h-12 sm:w-16 sm:h-16 object-contain mb-2"
+                        className="w-16 h-16 sm:w-20 sm:h-20 object-contain mb-2"
                       />
                       <span className="font-medium text-center">{awayClub?.name}</span>
                     </div>

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -207,30 +207,33 @@ const LigaMaster = () => {
                 {upcomingMatches.map((match) => {
                   const homeClub = clubs.find(c => c.name === match.homeTeam);
                   const awayClub = clubs.find(c => c.name === match.awayTeam);
-                  
+
                   return (
-                    <div key={match.id} className="p-4">
+                    <div
+                      key={match.id}
+                      className="p-4 bg-gradient-to-br from-dark to-gray-800 border border-gray-700 rounded-lg"
+                    >
                       <div className="text-sm text-gray-400 text-center mb-3">
                         {formatDate(match.date)} • Jornada {match.round}
                       </div>
                       
                       <div className="flex items-center justify-between">
                         <div className="flex flex-col items-center w-2/5">
-                          <img 
-                            src={homeClub?.logo} 
+                          <img
+                            src={homeClub?.logo}
                             alt={homeClub?.name}
-                            className="w-10 h-10 object-contain mb-1"
+                            className="w-16 h-16 object-contain mb-1"
                           />
                           <span className="font-medium text-center">{homeClub?.name}</span>
                         </div>
-                        <div className="flex-shrink-0 w-1/5 text-center">
-                          <span className="text-lg font-bold">VS</span>
+                        <div className="flex-shrink-0 flex-1 text-center">
+                          <span className="text-2xl font-bold neon-text-blue">VS</span>
                         </div>
                         <div className="flex flex-col items-center w-2/5">
-                          <img 
-                            src={awayClub?.logo} 
+                          <img
+                            src={awayClub?.logo}
                             alt={awayClub?.name}
-                            className="w-10 h-10 object-contain mb-1"
+                            className="w-16 h-16 object-contain mb-1"
                           />
                           <span className="font-medium text-center">{awayClub?.name}</span>
                         </div>


### PR DESCRIPTION
## Summary
- enlarge match logos and center scores
- add gradient backgrounds with neon text for score displays

## Testing
- `npm run lint`
- `npx ts-node tests/helpers.test.ts` *(fails: Unknown file extension '.ts')*

------
https://chatgpt.com/codex/tasks/task_e_6857597883d8833395ecfed6163c46d8