### PR TITLE
Unify card hover style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,11 +107,3 @@ body {
   }
 }
 
-/* tarjeta con interacción unificada */
-.hover-card {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.hover-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 0 6px rgba(0, 224, 255, 0.45);
-}

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -48,7 +48,7 @@ const Card = ({
 }) => (
   <div
     onClick={onClick}
-    className="hover-card cursor-pointer rounded-lg bg-zinc-900 p-4 shadow transition-transform hover:shadow-neon/40"
+    className="card-hover cursor-pointer rounded-lg bg-zinc-900 p-4 shadow transition-transform hover:shadow-neon/40"
   >
     {children}
   </div>
@@ -364,16 +364,16 @@ const DtDashboard = () => {
 
           {/* Botones de acción rápida */}
           <div className="grid gap-3 sm:grid-cols-2">
-            <button className="hover-card bg-accent px-4 py-2 font-semibold text-black">
+            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
               Enviar oferta
             </button>
-            <button className="hover-card bg-accent px-4 py-2 font-semibold text-black">
+            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
               Informe médico
             </button>
-            <button className="hover-card bg-accent px-4 py-2 font-semibold text-black">
+            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
               Firmar juvenil
             </button>
-            <button className="hover-card bg-accent px-4 py-2 font-semibold text-black">
+            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
               Publicar declaración
             </button>
           </div>


### PR DESCRIPTION
## Summary
- remove unused `.hover-card` class from index.css
- use `.card-hover` consistently in DtDashboard

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685760fdb3d883338aa92c483f1efddc