### PR TITLE
Add countdown bar widget

### DIFF
--- a/src/components/common/CountdownBar.tsx
+++ b/src/components/common/CountdownBar.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface CountdownBarProps {
+  date: string;
+}
+
+const CountdownBar = ({ date }: CountdownBarProps) => {
+  const [label, setLabel] = useState('');
+  const [progress, setProgress] = useState(0);
+  const start = useRef(0);
+
+  useEffect(() => {
+    const target = new Date(date).getTime();
+    start.current = target - Date.now();
+
+    const update = () => {
+      const diff = target - Date.now();
+      if (diff <= 0) {
+        setLabel('');
+        setProgress(100);
+        return;
+      }
+      const d = Math.floor(diff / 864e5);
+      const h = Math.floor((diff % 864e5) / 36e5);
+      setLabel(`Faltan ${d} d ${h} h`);
+      setProgress(100 - (diff / start.current) * 100);
+    };
+
+    update();
+    const id = setInterval(update, 6e4);
+    return () => clearInterval(id);
+  }, [date]);
+
+  const near = progress >= 90;
+  const color = progress > 50 ? 'bg-green-500' : 'bg-yellow-500';
+
+  return (
+    <div className="mt-1 flex items-center gap-2">
+      <div className="h-2 flex-1 rounded bg-zinc-800">
+        <div
+          className={`h-full rounded ${color} transition-[width] duration-1000 ease-linear ${near ? 'animate-pulse' : ''}`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <span className="w-24 text-right text-xs text-gray-400">{label}</span>
+    </div>
+  );
+};
+
+export default CountdownBar;

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -6,7 +6,6 @@
    ======================================= */
 
 import { Link } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import {
   Users,
   Layout,
@@ -55,27 +54,8 @@ const Card = ({
 );
 
 import ProgressBar from '../components/common/ProgressBar';
+import CountdownBar from '../components/common/CountdownBar';
 
-/* Cuenta regresiva utilitaria */
-const useCountdown = (date: string) => {
-  const [out, setOut] = useState('');
-  useEffect(() => {
-    const fn = () => {
-      const diff = new Date(date).getTime() - Date.now();
-      if (diff <= 0) {
-        setOut('');
-        return;
-      }
-      const d = Math.floor(diff / 864e5);
-      const h = Math.floor((diff % 864e5) / 36e5);
-      setOut(`Faltan ${d} d ${h} h`);
-    };
-    fn();
-    const id = setInterval(fn, 6e4);
-    return () => clearInterval(id);
-  }, [date]);
-  return out;
-};
 
 /* ---------- componente principal ---------- */
 
@@ -93,7 +73,6 @@ const DtDashboard = () => {
   } = useDataStore();
 
   const nextMatch = fixtures.find(f => !f.played);
-  const countdown = useCountdown(nextMatch?.date || '');
 
   if (!user || !club) return <p>Cargando…</p>;
 
@@ -183,9 +162,7 @@ const DtDashboard = () => {
                 {nextMatch.homeTeam === club.name ? nextMatch.awayTeam : nextMatch.homeTeam} –{' '}
                 <span className="text-gray-400">{formatDate(nextMatch.date)}</span>
               </p>
-              {countdown && (
-                <p className="mt-1 text-xs text-gray-400">{countdown}</p>
-              )}
+              <CountdownBar date={nextMatch.date} />
               <Link
                 to="/liga-master/fixture"
                 className="mt-3 inline-flex items-center gap-1 text-accent hover:underline"


### PR DESCRIPTION
## Summary
- add CountdownBar component
- show CountdownBar in DT dashboard for next match
- clean up unused countdown hook

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find ESLint module)*

------
https://chatgpt.com/codex/tasks/task_e_68585222a5388333886ec29099a18157