### PR TITLE
Handle empty announcements and reminders

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -17,7 +17,8 @@ import {
   Newspaper,
   Check,
   Trophy,
-  Calendar
+  Calendar,
+  Inbox
 } from 'lucide-react';
 
 import StatsCard from '../components/common/StatsCard';
@@ -318,14 +319,21 @@ const DtDashboard = () => {
           {/* Anuncios */}
           <Card>
             <h3 className="mb-3 font-semibold">Anuncios</h3>
-            <ul className="space-y-2 text-sm">
-              {events.slice(0, 3).map(ev => (
-                <li key={ev.id} className="flex items-center justify-between">
-                  <span>{ev.message}</span>
-                  <span className="text-xs text-gray-400">{formatDate(ev.date)}</span>
-                </li>
-              ))}
-            </ul>
+            {events.length === 0 ? (
+              <p className="flex items-center gap-2 text-sm text-gray-400">
+                <Inbox size={16} className="text-gray-400" />
+                No hay anuncios
+              </p>
+            ) : (
+              <ul className="space-y-2 text-sm">
+                {events.slice(0, 3).map(ev => (
+                  <li key={ev.id} className="flex items-center justify-between">
+                    <span>{ev.message}</span>
+                    <span className="text-xs text-gray-400">{formatDate(ev.date)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
           </Card>
 
           {/* Semáforo de mercado */}
@@ -349,7 +357,10 @@ const DtDashboard = () => {
           <Card>
             <h3 className="mb-3 font-semibold">Recordatorios</h3>
             {tasks.length === 0 ? (
-              <p className="text-sm text-gray-400">Todo al día ✔️</p>
+              <p className="flex items-center gap-2 text-sm text-gray-400">
+                <Inbox size={16} className="text-gray-400" />
+                No hay recordatorios
+              </p>
             ) : (
               <ul className="space-y-2 text-sm">
                 {tasks.map(t => (


### PR DESCRIPTION
## Summary
- add Inbox icon
- show message if announcement or reminder lists are empty

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68585222d9fc8333a4fcca6680db6361