### PR TITLE
Add reusable Card component

### DIFF
--- a/src/components/Home/FeaturedTournaments.tsx
+++ b/src/components/Home/FeaturedTournaments.tsx
@@ -2,6 +2,7 @@ import  { Link } from 'react-router-dom';
 import { Trophy, Calendar, Award, Users } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate } from '../../utils/helpers';
+import Card from '../common/Card';
 
 const FeaturedTournaments = () => {
   const { tournaments } = useDataStore();
@@ -36,7 +37,7 @@ const FeaturedTournaments = () => {
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {tournaments.map((tournament) => (
-          <div key={tournament.id} className="card card-hover">
+          <Card key={tournament.id}>
             <div className="relative h-40 overflow-hidden">
               {/* Background gradient */}
               <div 
@@ -122,7 +123,7 @@ const FeaturedTournaments = () => {
                 Ver Detalles
               </Link>
             </div>
-          </div>
+          </Card>
         ))}
       </div>
     </div>

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface CardProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+
+const Card = ({ children, onClick, className = '' }: CardProps) => (
+  <div onClick={onClick} className={`card card-hover ${className}`.trim()}>
+    {children}
+  </div>
+);
+
+export default Card;

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -5,6 +5,7 @@ import { useDataStore } from '../../store/dataStore';
 import { processTransfer } from '../../utils/transferService';
 import { TransferOffer } from '../../types';
 import { formatCurrency, formatDate, getStatusBadge } from '../../utils/helpers';
+import Card from '../common/Card';
 
 const OffersPanel = () => {
   const [expandedOffers, setExpandedOffers] = useState<Record<string, boolean>>({});
@@ -98,7 +99,7 @@ const OffersPanel = () => {
       )}
       
       {filteredOffers.map(offer => (
-        <div key={offer.id} className="card card-hover overflow-hidden">
+        <Card key={offer.id} className="overflow-hidden">
           <div className="p-4 cursor-pointer" onClick={() => toggleOfferDetails(offer.id)}>
             <div className="flex justify-between items-center">
               <div className="flex items-center space-x-3">
@@ -194,7 +195,7 @@ const OffersPanel = () => {
               )}
             </div>
           )}
-        </div>
+        </Card>
       ))}
     </div>
   );

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 
 import StatsCard from '../components/common/StatsCard';
+import Card from '../components/common/Card';
 
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
@@ -37,22 +38,6 @@ import {
 } from '../utils/helpers';
 
 /* ---------- componentes pequeños reutilizados ---------- */
-
-/* sombra y escala homogéneas para TODAS las tarjetas */
-const Card = ({
-  children,
-  onClick
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-}) => (
-  <div
-    onClick={onClick}
-    className="card-hover cursor-pointer rounded-lg bg-zinc-900 p-4 shadow transition-transform hover:shadow-neon/40"
-  >
-    {children}
-  </div>
-);
 
 import ProgressBar from '../components/common/ProgressBar';
 
@@ -170,7 +155,7 @@ const DtDashboard = () => {
         <div className="space-y-8 lg:col-span-2">
           {/* Próximo partido */}
           {nextMatch && (
-            <Card>
+            <Card className="p-4">
               <div className="flex items-center gap-2">
                 {nextMatch.homeTeam === club.name ? (
                   <Home size={16} className="text-accent" />
@@ -199,7 +184,7 @@ const DtDashboard = () => {
           {/* Mini-tabla + Streak + Performer */}
           <div className="grid gap-6 md:grid-cols-2">
             {/* Mini tabla de posiciones */}
-            <Card>
+            <Card className="p-4">
               <h3 className="mb-3 font-semibold">Posiciones</h3>
               <table className="w-full text-sm">
                 <tbody>
@@ -230,7 +215,7 @@ const DtDashboard = () => {
             </Card>
 
             {/* Comparativa + Jugador en forma */}
-            <Card>
+            <Card className="p-4">
               <h3 className="mb-3 font-semibold">Comparativa con la liga</h3>
               <ul className="space-y-2 text-sm">
                 {bullets.map(b => (
@@ -272,7 +257,7 @@ const DtDashboard = () => {
           </div>
 
           {/* Objetivos de temporada */}
-          <Card>
+          <Card className="p-4">
             <h3 className="mb-4 font-semibold">Objetivos de temporada</h3>
             <div className="space-y-4">
               <div>
@@ -287,7 +272,7 @@ const DtDashboard = () => {
           </Card>
 
           {/* Últimas noticias */}
-          <Card>
+          <Card className="p-4">
             <div className="mb-4 flex items-center justify-between">
               <h3 className="font-semibold">Últimas noticias</h3>
               <Link
@@ -316,7 +301,7 @@ const DtDashboard = () => {
         {/* === COLUMNA DERECHA (1/3) === */}
         <div className="space-y-8">
           {/* Anuncios */}
-          <Card>
+          <Card className="p-4">
             <h3 className="mb-3 font-semibold">Anuncios</h3>
             <ul className="space-y-2 text-sm">
               {events.slice(0, 3).map(ev => (
@@ -329,7 +314,7 @@ const DtDashboard = () => {
           </Card>
 
           {/* Semáforo de mercado */}
-          <Card>
+          <Card className="p-4">
             <h3 className="mb-3 font-semibold">Mercado</h3>
             <div className="flex items-center gap-2">
               <span
@@ -346,7 +331,7 @@ const DtDashboard = () => {
           </Card>
 
           {/* Recordatorios pendientes */}
-          <Card>
+          <Card className="p-4">
             <h3 className="mb-3 font-semibold">Recordatorios</h3>
             {tasks.length === 0 ? (
               <p className="text-sm text-gray-400">Todo al día ✔️</p>

--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -2,6 +2,7 @@ import  { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronLeft, ChevronUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
+import Card from '../components/common/Card';
 import { useDataStore } from '../store/dataStore';
 import { formatDate } from '../utils/helpers';
 
@@ -121,9 +122,9 @@ const Fixtures = () => {
             const isExpanded = expandedMatches[match.id] || false;
             
             return (
-              <div
+              <Card
                 key={match.id}
-                className="card card-hover overflow-hidden bg-gradient-to-br from-dark to-gray-800 border border-gray-700"
+                className="overflow-hidden bg-gradient-to-br from-dark to-gray-800 border border-gray-700"
               >
                 <div className="p-4 border-b border-gray-800">
                   <div className="flex justify-between items-center">
@@ -231,8 +232,8 @@ const Fixtures = () => {
                     )}
                   </div>
                 )}
-              </div>
-            );
+                </Card>
+              );
           })}
           
           {roundMatches.length === 0 && (

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -5,6 +5,7 @@ import { Player } from '../types';
 import PageHeader from '../components/common/PageHeader';
 import OfferModal from '../components/market/OfferModal';
 import OffersPanel from '../components/market/OffersPanel';
+import Card from '../components/common/Card';
 import { formatCurrency, getPositionColor, getFormIcon } from '../utils/helpers';
 
 const Market = () => {
@@ -217,7 +218,7 @@ const Market = () => {
             {/* Players grid */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {sortedPlayers.map(player => (
-                <div key={player.id} className="card card-hover">
+                <Card key={player.id} className="overflow-hidden">
                   <div className="p-4 border-b border-gray-700">
                     <div className="flex items-center">
                       <img 
@@ -292,7 +293,7 @@ const Market = () => {
                       Hacer Oferta
                     </button>
                   </div>
-                </div>
+                </Card>
               ))}
               
               {filteredPlayers.length === 0 && (


### PR DESCRIPTION
## Summary
- add a common `<Card>` component
- refactor dashboard and other pages to use `<Card>`
- switch market, fixtures, featured tournaments, and offers panel to use the shared component

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68585222b1608333ab06d50ddd17cea7