### PR TITLE
Improve DtDashboard grid responsiveness

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -106,7 +106,7 @@ const DtDashboard = () => {
       </header>
 
       {/* ---------- TARJETAS RÁPIDAS ---------- */}
-      <section className="mb-8 grid gap-6 md:gap-8 sm:grid-cols-2 lg:grid-cols-4">
+      <section className="mb-8 grid grid-cols-1 gap-6 md:gap-8 sm:grid-cols-2 lg:grid-cols-4">
         <StatsCard
           title="Plantilla"
           value={`${club.players.length} jugadores`}
@@ -130,7 +130,7 @@ const DtDashboard = () => {
       </section>
 
       {/* ---------- CUERPO PRINCIPAL ---------- */}
-      <main className="grid gap-8 lg:grid-cols-3">
+      <main className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         {/* === COLUMNA IZQUIERDA (2/3) === */}
         <div className="space-y-8 lg:col-span-2">
           {/* Próximo partido */}
@@ -160,7 +160,7 @@ const DtDashboard = () => {
           )}
 
           {/* Mini-tabla + Streak + Performer */}
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {/* Mini tabla de posiciones */}
             <Card className="p-4">
               <h3 className="mb-3 font-semibold">Posiciones</h3>
@@ -336,7 +336,7 @@ const DtDashboard = () => {
           </Card>
 
           {/* Botones de acción rápida */}
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
               Enviar oferta
             </button>


### PR DESCRIPTION
## Summary
- tweak dashboard grid classes for consistent stacking on small screens
- ensure quick stats, mini table, and action buttons use responsive layouts

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685857c2502483338075a6d29ca73aea