### PR TITLE
Add aria labels to DtDashboard quick actions

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -337,16 +337,28 @@ const DtDashboard = () => {
 
           {/* Botones de acción rápida */}
           <div className="grid gap-3 sm:grid-cols-2">
-            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
+            <button
+              aria-label="Enviar oferta"
+              className="card-hover bg-accent px-4 py-2 font-semibold text-black"
+            >
               Enviar oferta
             </button>
-            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
+            <button
+              aria-label="Informe médico"
+              className="card-hover bg-accent px-4 py-2 font-semibold text-black"
+            >
               Informe médico
             </button>
-            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
+            <button
+              aria-label="Firmar juvenil"
+              className="card-hover bg-accent px-4 py-2 font-semibold text-black"
+            >
               Firmar juvenil
             </button>
-            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
+            <button
+              aria-label="Publicar declaración"
+              className="card-hover bg-accent px-4 py-2 font-semibold text-black"
+            >
               Publicar declaración
             </button>
           </div>


### PR DESCRIPTION
## Summary
- improve accessibility in quick action buttons by adding aria-labels

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685857c41aa88333beb01ff4944882b2