### PR TITLE
Disable offer button when market closed

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -58,6 +58,8 @@ const DtDashboard = () => {
     events
   } = useDataStore();
 
+  const marketOpen = useDataStore(state => state.market.open);
+
   const nextMatch = fixtures.find(f => !f.played);
 
   if (!user || !club) return <p>Cargando…</p>;
@@ -337,7 +339,10 @@ const DtDashboard = () => {
 
           {/* Botones de acción rápida */}
           <div className="grid gap-3 sm:grid-cols-2">
-            <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">
+            <button
+              className={`card-hover bg-accent px-4 py-2 font-semibold text-black ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
+              disabled={!marketOpen}
+            >
               Enviar oferta
             </button>
             <button className="card-hover bg-accent px-4 py-2 font-semibold text-black">


### PR DESCRIPTION
## Summary
- make DT dashboard aware of `market.open`
- disable "Enviar oferta" when market is closed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685857c5e5148333a70b933e29896142