### PR TITLE
Enhance Liga Master DT dashboard aesthetics

### DIFF
--- a/src/components/common/StatsCard.tsx
+++ b/src/components/common/StatsCard.tsx
@@ -8,9 +8,11 @@ interface  StatsCardProps {
   trend?: 'up' | 'down' | 'neutral';
   trendValue?: string;
   progress?: number;
+  className?: string;
+  iconClassName?: string;
 }
 
-const StatsCard = ({ title, value, icon, trend, trendValue, progress }: StatsCardProps) => {
+const StatsCard = ({ title, value, icon, trend, trendValue, progress, className = '', iconClassName = '' }: StatsCardProps) => {
   const renderTrend = () => {
     if (!trend || !trendValue) return null;
     
@@ -42,7 +44,7 @@ const StatsCard = ({ title, value, icon, trend, trendValue, progress }: StatsCar
   };
   
   return (
-    <div className="card p-4">
+    <div className={`card p-4 ${className}`.trim()}>
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <p className="text-gray-400 text-sm mb-2">{title}</p>
@@ -54,7 +56,7 @@ const StatsCard = ({ title, value, icon, trend, trendValue, progress }: StatsCar
             </div>
           )}
         </div>
-        <div className="bg-gray-800 p-3 rounded-lg ml-4">
+        <div className={`bg-gray-800 p-3 rounded-lg ml-4 ${iconClassName}`.trim()}>
           {icon}
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,14 @@ body {
     background-size: 400% 400%;
     animation: gradient 15s ease infinite;
   }
+
+  .esports-card {
+    @apply bg-gradient-to-br from-dark via-gray-800 to-black shadow-neon transition-all hover:-translate-y-1 hover:shadow-neon;
+  }
+
+  .esports-btn {
+    @apply shadow-neon transition-transform hover:-translate-y-1 hover:shadow-neon;
+  }
   
   @keyframes gradient {
     0% {

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -80,7 +80,7 @@ const DtDashboard = () => {
         subtitle="Vista general del club y próximas actividades."
         image="https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0"
       />
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 animated-bg rounded-lg">
       {/* ---------- ENCABEZADO ---------- */}
       <header className="mb-6 flex flex-col items-center gap-4 md:flex-row">
         <Link
@@ -111,21 +111,29 @@ const DtDashboard = () => {
           title="Plantilla"
           value={`${club.players.length} jugadores`}
           icon={<Users size={20} className="text-purple-400" />}
+          className="esports-card"
+          iconClassName="animate-pulse-slow"
         />
         <StatsCard
           title="Táctica"
           value={club.formation}
           icon={<Layout size={20} className="text-blue-400" />}
+          className="esports-card"
+          iconClassName="animate-pulse-slow"
         />
         <StatsCard
           title="Finanzas"
           value={formatCurrency(club.budget)}
           icon={<DollarSign size={20} className="text-green-400" />}
+          className="esports-card"
+          iconClassName="animate-pulse-slow"
         />
         <StatsCard
           title="Mercado"
           value={market.open ? 'Abierto' : 'Cerrado'}
           icon={<TrendingUp size={20} className="text-yellow-400" />}
+          className="esports-card"
+          iconClassName="animate-pulse-slow"
         />
       </section>
 
@@ -135,7 +143,7 @@ const DtDashboard = () => {
         <div className="space-y-8 lg:col-span-2">
           {/* Próximo partido */}
           {nextMatch && (
-            <Card className="p-4">
+            <Card className="p-4 esports-card">
               <div className="flex items-center gap-2">
                 {nextMatch.homeTeam === club.name ? (
                   <Home size={16} className="text-accent" />
@@ -162,7 +170,7 @@ const DtDashboard = () => {
           {/* Mini-tabla + Streak + Performer */}
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {/* Mini tabla de posiciones */}
-            <Card className="p-4">
+            <Card className="p-4 esports-card">
               <h3 className="mb-3 font-semibold">Posiciones</h3>
               <table className="w-full text-sm">
                 <tbody>
@@ -193,7 +201,7 @@ const DtDashboard = () => {
             </Card>
 
             {/* Comparativa + Jugador en forma */}
-            <Card className="p-4">
+            <Card className="p-4 esports-card">
               <h3 className="mb-3 font-semibold">Comparativa con la liga</h3>
               <ul className="space-y-2 text-sm">
                 {bullets.map(b => (
@@ -244,7 +252,7 @@ const DtDashboard = () => {
         {/* === COLUMNA DERECHA (1/3) === */}
         <div className="space-y-8">
           {/* Anuncios */}
-          <Card className="p-4">
+          <Card className="p-4 esports-card">
             <h3 className="mb-3 font-semibold">Anuncios</h3>
             {events.length === 0 ? (
               <p className="flex items-center gap-2 text-sm text-gray-400">
@@ -264,7 +272,7 @@ const DtDashboard = () => {
           </Card>
 
           {/* Semáforo de mercado */}
-          <Card className="p-4">
+          <Card className="p-4 esports-card">
             <h3 className="mb-3 font-semibold">Mercado</h3>
             <div className="flex items-center gap-2">
               <span
@@ -281,7 +289,7 @@ const DtDashboard = () => {
           </Card>
 
           {/* Recordatorios pendientes */}
-          <Card className="p-4">
+          <Card className="p-4 esports-card">
             <h3 className="mb-3 font-semibold">Recordatorios</h3>
             {tasks.length === 0 ? (
               <p className="flex items-center gap-2 text-sm text-gray-400">

--- a/src/pages/dt-dashboard/QuickActions.tsx
+++ b/src/pages/dt-dashboard/QuickActions.tsx
@@ -7,7 +7,7 @@ interface QuickActionsProps {
 const QuickActions = ({ marketOpen }: QuickActionsProps) => (
   <div className="grid gap-3 sm:grid-cols-2">
     <button
-      className={`card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
+      className={`card-hover esports-btn bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
       disabled={!marketOpen}
     >
       <Banknote size={16} />
@@ -15,21 +15,21 @@ const QuickActions = ({ marketOpen }: QuickActionsProps) => (
     </button>
     <button
       aria-label="Informe médico"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      className="card-hover esports-btn bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
     >
       <Stethoscope size={16} />
       <span>Informe médico</span>
     </button>
     <button
       aria-label="Firmar juvenil"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      className="card-hover esports-btn bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
     >
       <UserPlus size={16} />
       <span>Firmar juvenil</span>
     </button>
     <button
       aria-label="Publicar declaración"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      className="card-hover esports-btn bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
     >
       <Megaphone size={16} />
       <span>Publicar declaración</span>


### PR DESCRIPTION
## Summary
- add new esports styling utilities
- support custom classes in `StatsCard`
- apply animated background and neon styles in DT dashboard
- highlight quick actions with esports buttons

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858b4a914dc8333bc0669016195e699