### PR TITLE
Enable DTs to toggle league view

### DIFF
--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -1,4 +1,5 @@
 import  { Link } from 'react-router-dom';
+import { useState } from 'react';
 import DtDashboard from './DtDashboard';
 import { useAuthStore } from '../store/authStore';
 import { 
@@ -19,9 +20,20 @@ import { formatDate, formatCurrency } from '../utils/helpers';
 const LigaMaster = () => {
   const { user } = useAuthStore();
   const { clubs, tournaments, players, standings, marketStatus } = useDataStore();
+  const isDtWithClub = user?.role === 'dt' && (user.club || user.clubId);
+  const [showLeague, setShowLeague] = useState(!isDtWithClub);
 
-  if (user?.role === 'dt' && (user.club || user.clubId)) {
-    return <DtDashboard />;
+  if (isDtWithClub && !showLeague) {
+    return (
+      <>
+        <div className="container mx-auto px-4 pt-4 flex justify-end">
+          <button className="btn-secondary" onClick={() => setShowLeague(true)}>
+            Ver Liga
+          </button>
+        </div>
+        <DtDashboard />
+      </>
+    );
   }
   
   // Get active tournament (Liga Master)
@@ -50,8 +62,15 @@ const topScorers = [...players]
   
   return (
     <div>
-      <PageHeader 
-        title="Liga Master 2025" 
+      {isDtWithClub && (
+        <div className="container mx-auto px-4 pt-4 flex justify-end">
+          <button className="btn-secondary" onClick={() => setShowLeague(false)}>
+            Ver Tablero
+          </button>
+        </div>
+      )}
+      <PageHeader
+        title="Liga Master 2025"
         subtitle="La competición principal de La Virtual Zone. Liga regular con enfrentamientos ida y vuelta entre los 10 equipos participantes."
         image="https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0"
       />


### PR DESCRIPTION
## Summary
- add state to LigaMaster so DTs can view league even with a club
- show a "Ver Liga"/"Ver Tablero" button to swap between DtDashboard and the league view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858c1dbc8c483339c7d27e27735b3d9