### PR TITLE
Use Node asserts for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run preview
 ```
 ## Tests
 
-Run the TypeScript tests using `tsx`:
+Run the test suite with `tsx`:
 
 ```bash
 npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
             "globals": "^13.20.0",
             "postcss": "^8.4.24",
             "tailwindcss": "^3.3.2",
+            "tsx": "^4.20.3",
             "typescript": "^5.0.2",
             "typescript-eslint": "^8.34.1",
             "vite": "^6.3.5"
@@ -1987,6 +1988,21 @@
          "dev": true,
          "license": "ISC"
       },
+      "node_modules/fsevents": {
+         "version": "2.3.3",
+         "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+         "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+         "dev": true,
+         "hasInstallScript": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ],
+         "engines": {
+            "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+         }
+      },
       "node_modules/function-bind": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2005,6 +2021,19 @@
          "license": "MIT",
          "engines": {
             "node": ">=6.9.0"
+         }
+      },
+      "node_modules/get-tsconfig": {
+         "version": "4.10.1",
+         "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+         "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "resolve-pkg-maps": "^1.0.0"
+         },
+         "funding": {
+            "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
          }
       },
       "node_modules/glob": {
@@ -3093,6 +3122,16 @@
             "node": ">=4"
          }
       },
+      "node_modules/resolve-pkg-maps": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+         "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+         "dev": true,
+         "license": "MIT",
+         "funding": {
+            "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+         }
+      },
       "node_modules/reusify": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3636,6 +3675,26 @@
          },
          "peerDependencies": {
             "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+         }
+      },
+      "node_modules/tsx": {
+         "version": "4.20.3",
+         "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+         "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "esbuild": "~0.25.0",
+            "get-tsconfig": "^4.7.5"
+         },
+         "bin": {
+            "tsx": "dist/cli.mjs"
+         },
+         "engines": {
+            "node": ">=18.0.0"
+         },
+         "optionalDependencies": {
+            "fsevents": "~2.3.3"
          }
       },
       "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
       "dev": "vite",
       "build": "tsc && vite build",
       "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
-      "preview": "vite preview"
+      "preview": "vite preview",
+      "test": "tsx tests/helpers.test.ts"
    },
    "dependencies": {
       "lucide-react": "^0.244.0",
@@ -31,6 +32,7 @@
       "globals": "^13.20.0",
       "postcss": "^8.4.24",
       "tailwindcss": "^3.3.2",
+      "tsx": "^4.20.3",
       "typescript": "^5.0.2",
       "typescript-eslint": "^8.34.1",
       "vite": "^6.3.5"

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,13 +1,24 @@
-import { getMiniTable, calcStreak, getTopPerformer, goalsDiff, possessionDiff, yellowDiff } from '../src/utils/helpers.ts';
+import assert from 'node:assert/strict';
+import {
+  getMiniTable,
+  calcStreak,
+  getTopPerformer,
+  goalsDiff,
+  possessionDiff,
+  yellowDiff,
+} from '../src/utils/helpers.ts';
 import { leagueStandings, tournaments } from '../src/data/mockData.ts';
 
-const mini = getMiniTable('club1', leagueStandings);
-console.log('mini', mini.length === 5);
-
 const fixtures = tournaments.find(t => t.id === 'tournament1')?.matches ?? [];
-console.log('streak', calcStreak('club1', fixtures).length <= 5);
 
-console.log('performer', getTopPerformer('club1') !== null);
-console.log('goals', typeof goalsDiff('club1').diff === 'number');
-console.log('possession', typeof possessionDiff('club1').diff === 'number');
-console.log('cards', typeof yellowDiff('club1').diff === 'number');
+const mini = getMiniTable('club1', leagueStandings);
+assert.strictEqual(mini.length, 5, 'mini table should have 5 entries');
+
+assert.ok(calcStreak('club1', fixtures).length <= 5, 'streak should contain at most 5 matches');
+
+assert.ok(getTopPerformer('club1') !== null, 'top performer should not be null');
+assert.strictEqual(typeof goalsDiff('club1').diff, 'number', 'goals diff should be a number');
+assert.strictEqual(typeof possessionDiff('club1').diff, 'number', 'possession diff should be a number');
+assert.strictEqual(typeof yellowDiff('club1').diff, 'number', 'yellow diff should be a number');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- replace console logging with assert-based checks
- run tests with `tsx`
- document how to run tests with `tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858c1dbeae48333a658836e2a5e277b