### PR TITLE
Improve focus styles for interactive elements

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -7,7 +7,13 @@ interface CardProps {
 }
 
 const Card = ({ children, onClick, className = '' }: CardProps) => (
-  <div onClick={onClick} className={`card card-hover ${className}`.trim()}>
+  <div
+    onClick={onClick}
+    tabIndex={onClick ? 0 : undefined}
+    className={`card card-hover ${
+      onClick ? 'cursor-pointer focus:outline-none focus:ring-primary' : ''
+    } ${className}`.trim()}
+  >
     {children}
   </div>
 );

--- a/src/pages/dt-dashboard/QuickActions.tsx
+++ b/src/pages/dt-dashboard/QuickActions.tsx
@@ -7,7 +7,9 @@ interface QuickActionsProps {
 const QuickActions = ({ marketOpen }: QuickActionsProps) => (
   <div className="grid gap-3 sm:grid-cols-2">
     <button
-      className={`card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
+      className={`card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 focus:outline-none focus:ring-primary ${
+        marketOpen ? 'cursor-pointer' : 'opacity-50 cursor-not-allowed'
+      }`}
       disabled={!marketOpen}
     >
       <Banknote size={16} />
@@ -15,21 +17,21 @@ const QuickActions = ({ marketOpen }: QuickActionsProps) => (
     </button>
     <button
       aria-label="Informe médico"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 cursor-pointer focus:outline-none focus:ring-primary"
     >
       <Stethoscope size={16} />
       <span>Informe médico</span>
     </button>
     <button
       aria-label="Firmar juvenil"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 cursor-pointer focus:outline-none focus:ring-primary"
     >
       <UserPlus size={16} />
       <span>Firmar juvenil</span>
     </button>
     <button
       aria-label="Publicar declaración"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 cursor-pointer focus:outline-none focus:ring-primary"
     >
       <Megaphone size={16} />
       <span>Publicar declaración</span>


### PR DESCRIPTION
## Summary
- ensure interactive `Card` can be focused and shows pointer cursor
- add pointer and focus ring styles to `QuickActions` buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858c9f263048333946b8ee984f9f643