### PR TITLE
Add DT sidebar navigation

### DIFF
--- a/src/components/club/DtSidebar.tsx
+++ b/src/components/club/DtSidebar.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Menu } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+
+const DtSidebar = () => {
+  const { club } = useDataStore();
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const links = [
+    { to: `/liga-master/club/${club.slug}/plantilla`, label: 'Plantilla' },
+    { to: '/liga-master/tacticas', label: 'Tácticas' },
+    { to: `/liga-master/club/${club.slug}/finanzas`, label: 'Finanzas' },
+    { to: '/liga-master/mercado', label: 'Mercado' },
+    { to: '/liga-master/fixture', label: 'Fixture' },
+    { to: '/liga-master/analisis', label: 'Análisis' }
+  ];
+
+  const handleNav = (to: string) => {
+    navigate(to);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        aria-label="Abrir menú"
+        className="md:hidden p-2 text-white z-50"
+        onClick={() => setOpen(!open)}
+      >
+        <Menu size={24} />
+      </button>
+
+      <div
+        onClick={() => setOpen(false)}
+        className={`fixed inset-0 bg-black/50 transition-opacity md:hidden z-40 ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+      />
+
+      <aside
+        className={`fixed md:static top-0 left-0 z-50 w-56 h-full bg-dark-light border-r border-gray-800 p-4 transform transition-transform ${
+          open ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
+        }`}
+      >
+        <nav className="space-y-2 mt-8 md:mt-0">
+          {links.map(link => (
+            <Link
+              key={link.to}
+              to={link.to}
+              onClick={() => handleNav(link.to)}
+              className="block rounded px-3 py-2 card-hover hover:bg-dark-lighter"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+    </>
+  );
+};
+
+export default DtSidebar;

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } f
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 import { formatCurrency, formatDate } from '../utils/helpers';
+import DtSidebar from '../components/club/DtSidebar';
 
 const ClubFinances = () => {
   const { clubName } = useParams<{ clubName: string }>();
@@ -48,12 +49,14 @@ const ClubFinances = () => {
   const totalBalance = totalIncome - totalExpenses;
   
   return (
-    <div>
-      <PageHeader 
-        title={`Finanzas de ${club.name}`} 
+    <div className="flex">
+      <DtSidebar />
+      <div className="flex-1">
+        <PageHeader
+        title={`Finanzas de ${club.name}`}
         subtitle="Presupuesto, transacciones y balance económico del club."
       />
-      
+
       <div className="container mx-auto px-4 py-8">
         <div className="mb-6">
           <Link

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -4,6 +4,7 @@ import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 import { formatCurrency } from '../utils/helpers';
 import { useState } from 'react';
+import DtSidebar from '../components/club/DtSidebar';
 
 const ClubSquad = () => {
   const { clubName, clubId } = useParams<{ clubName?: string; clubId?: string }>();
@@ -70,12 +71,14 @@ const ClubSquad = () => {
   };
   
   return (
-    <div>
-      <PageHeader 
-        title={`Plantilla de ${club.name}`} 
+    <div className="flex">
+      <DtSidebar />
+      <div className="flex-1">
+        <PageHeader
+        title={`Plantilla de ${club.name}`}
         subtitle="Jugadores, estadísticas y formación táctica del club."
       />
-      
+
       <div className="container mx-auto px-4 py-8">
         <div className="mb-6">
           <Link

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -21,6 +21,7 @@ import {
 
 import StatsCard from '../components/common/StatsCard';
 import Card from '../components/common/Card';
+import DtSidebar from '../components/club/DtSidebar';
 
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
@@ -74,13 +75,15 @@ const DtDashboard = () => {
   ];
 
   return (
-    <>
-      <PageHeader
+    <div className="flex">
+      <DtSidebar />
+      <div className="flex-1">
+        <PageHeader
         title="Tablero del DT"
         subtitle="Vista general del club y próximas actividades."
         image="https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0"
-      />
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        />
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* ---------- ENCABEZADO ---------- */}
       <header className="mb-6 flex flex-col items-center gap-4 md:flex-row">
         <Link
@@ -307,8 +310,9 @@ const DtDashboard = () => {
 
       {/* margen extra antes del footer general */}
       <div className="mb-8" />
+        </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -6,6 +6,7 @@ import PageHeader from '../components/common/PageHeader';
 import OfferModal from '../components/market/OfferModal';
 import OffersPanel from '../components/market/OffersPanel';
 import Card from '../components/common/Card';
+import DtSidebar from '../components/club/DtSidebar';
 import { formatCurrency, getPositionColor, getFormIcon } from '../utils/helpers';
 
 const Market = () => {
@@ -79,14 +80,16 @@ const Market = () => {
   };
   
   return (
-    <div>
-      <PageHeader 
-        title="Mercado de Fichajes" 
+    <div className="flex">
+      <DtSidebar />
+      <div className="flex-1">
+        <PageHeader
+        title="Mercado de Fichajes"
         subtitle="Compra y vende jugadores para mejorar tu equipo."
         image="https://images.unsplash.com/photo-1494178270175-e96de2971df9?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw0fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0"
-      />
-      
-      <div className="container mx-auto px-4 py-8">
+        />
+
+        <div className="container mx-auto px-4 py-8">
         {/* Market status */}
         <div className="mb-6">
           {marketStatus ? (
@@ -311,11 +314,13 @@ const Market = () => {
       
       {/* Offer modal */}
       {selectedPlayer && (
-        <OfferModal 
-          player={selectedPlayer} 
-          onClose={() => setSelectedPlayer(null)} 
+        <OfferModal
+          player={selectedPlayer}
+          onClose={() => setSelectedPlayer(null)}
         />
       )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/Tacticas.tsx
+++ b/src/pages/Tacticas.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import DtSidebar from '../components/club/DtSidebar';
 
 const Tacticas = () => {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold">Tácticas</h1>
+    <div className="flex">
+      <DtSidebar />
+      <div className="flex-1">
+        <div className="container mx-auto px-4 py-8">
+          <h1 className="text-2xl font-bold">Tácticas</h1>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add new `DtSidebar` component for club pages
- integrate sidebar into DT dashboard, squad, tactics, finances and market pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c9f3e0308333a04b8ac33f1e4089