### PR TITLE
Add QuickNavCards navigation component across club pages

### DIFF
--- a/src/components/club/QuickNavCards.tsx
+++ b/src/components/club/QuickNavCards.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom';
+import { Users, Layout, DollarSign, TrendingUp } from 'lucide-react';
+import { formatCurrency } from '../../utils/helpers';
+
+interface QuickNavCardsProps {
+  clubSlug: string;
+  playersCount: number;
+  formation: string;
+  budget: number;
+  marketOpen: boolean;
+}
+
+const QuickNavCards = ({
+  clubSlug,
+  playersCount,
+  formation,
+  budget,
+  marketOpen
+}: QuickNavCardsProps) => (
+  <section className="mb-8 grid grid-cols-1 gap-6 md:gap-8 sm:grid-cols-2 lg:grid-cols-4">
+    <Link
+      to={`/liga-master/club/${clubSlug}/plantilla`}
+      className="card card-hover p-4 focus:outline-none focus:ring-2 focus:ring-accent"
+      aria-label="Plantilla del club"
+      tabIndex={0}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-gray-400 text-sm mb-2">Plantilla</p>
+          <p className="text-xl font-bold">{playersCount} jugadores</p>
+        </div>
+        <div className="bg-gray-800 p-3 rounded-lg ml-4">
+          <Users size={20} className="text-purple-400" />
+        </div>
+      </div>
+    </Link>
+
+    <Link
+      to="/liga-master/tacticas"
+      className="card card-hover p-4 focus:outline-none focus:ring-2 focus:ring-accent"
+      aria-label="Tácticas del club"
+      tabIndex={0}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-gray-400 text-sm mb-2">Táctica</p>
+          <p className="text-xl font-bold">{formation}</p>
+        </div>
+        <div className="bg-gray-800 p-3 rounded-lg ml-4">
+          <Layout size={20} className="text-blue-400" />
+        </div>
+      </div>
+    </Link>
+
+    <Link
+      to={`/liga-master/club/${clubSlug}/finanzas`}
+      className="card card-hover p-4 focus:outline-none focus:ring-2 focus:ring-accent"
+      aria-label="Finanzas del club"
+      tabIndex={0}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-gray-400 text-sm mb-2">Finanzas</p>
+          <p className="text-xl font-bold">{formatCurrency(budget)}</p>
+        </div>
+        <div className="bg-gray-800 p-3 rounded-lg ml-4">
+          <DollarSign size={20} className="text-green-400" />
+        </div>
+      </div>
+    </Link>
+
+    <Link
+      to="/liga-master/mercado"
+      className="card card-hover p-4 focus:outline-none focus:ring-2 focus:ring-accent"
+      aria-label="Estado del mercado"
+      tabIndex={0}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-gray-400 text-sm mb-2">Mercado</p>
+          <p className="text-xl font-bold">{marketOpen ? 'Abierto' : 'Cerrado'}</p>
+        </div>
+        <div className="bg-gray-800 p-3 rounded-lg ml-4">
+          <TrendingUp size={20} className="text-yellow-400" />
+        </div>
+      </div>
+    </Link>
+  </section>
+);
+
+export default QuickNavCards;

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -3,14 +3,17 @@ import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } f
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 import { formatCurrency, formatDate } from '../utils/helpers';
+import QuickNavCards from '../components/club/QuickNavCards';
 
 const ClubFinances = () => {
   const { clubName } = useParams<{ clubName: string }>();
 
-  const { clubs, transfers } = useDataStore();
+  const { clubs, transfers, players, marketStatus } = useDataStore();
   
   // Find club by slug
   const club = clubs.find(c => c.slug === clubName);
+
+  const clubPlayers = club ? players.filter(p => p.clubId === club.id) : [];
   
   if (!club) {
     return (
@@ -77,7 +80,15 @@ const ClubFinances = () => {
               </p>
             </div>
           </div>
-          
+
+          <QuickNavCards
+            clubSlug={club.slug}
+            playersCount={clubPlayers.length}
+            formation={(club as any).formation || '4-4-2'}
+            budget={club.budget}
+            marketOpen={marketStatus}
+          />
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="card p-6">
               <div className="flex justify-between items-start mb-4">

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -4,18 +4,21 @@ import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 import { formatCurrency } from '../utils/helpers';
 import { useState } from 'react';
+import QuickNavCards from '../components/club/QuickNavCards';
 
 const ClubSquad = () => {
   const { clubName, clubId } = useParams<{ clubName?: string; clubId?: string }>();
   const [sortBy, setSortBy] = useState('overall');
   const [sortOrder, setSortOrder] = useState('desc');
 
-  const { clubs, players } = useDataStore();
+  const { clubs, players, marketStatus } = useDataStore();
   
   // Find club by slug
   const club = clubId
     ? clubs.find(c => c.id === clubId)
     : clubs.find(c => c.slug === clubName);
+
+  const formation = (club as any).formation || '4-4-2';
   
   if (!club) {
     return (
@@ -99,7 +102,15 @@ const ClubSquad = () => {
               </p>
             </div>
           </div>
-          
+
+          <QuickNavCards
+            clubSlug={club.slug}
+            playersCount={clubPlayers.length}
+            formation={formation}
+            budget={club.budget}
+            marketOpen={marketStatus}
+          />
+
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
             <div className="bg-dark-light rounded-lg p-4 flex flex-col items-center">
               <Users size={24} className="text-primary mb-2" />

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -7,10 +7,6 @@
 
 import { Link } from 'react-router-dom';
 import {
-  Users,
-  Layout,
-  DollarSign,
-  TrendingUp,
   Home,
   Plane,
   Check,
@@ -19,7 +15,7 @@ import {
   Inbox
 } from 'lucide-react';
 
-import StatsCard from '../components/common/StatsCard';
+import QuickNavCards from '../components/club/QuickNavCards';
 import Card from '../components/common/Card';
 
 import { useAuthStore } from '../store/authStore';
@@ -106,28 +102,13 @@ const DtDashboard = () => {
       </header>
 
       {/* ---------- TARJETAS RÁPIDAS ---------- */}
-      <section className="mb-8 grid grid-cols-1 gap-6 md:gap-8 sm:grid-cols-2 lg:grid-cols-4">
-        <StatsCard
-          title="Plantilla"
-          value={`${club.players.length} jugadores`}
-          icon={<Users size={20} className="text-purple-400" />}
-        />
-        <StatsCard
-          title="Táctica"
-          value={club.formation}
-          icon={<Layout size={20} className="text-blue-400" />}
-        />
-        <StatsCard
-          title="Finanzas"
-          value={formatCurrency(club.budget)}
-          icon={<DollarSign size={20} className="text-green-400" />}
-        />
-        <StatsCard
-          title="Mercado"
-          value={market.open ? 'Abierto' : 'Cerrado'}
-          icon={<TrendingUp size={20} className="text-yellow-400" />}
-        />
-      </section>
+      <QuickNavCards
+        clubSlug={club.slug}
+        playersCount={club.players.length}
+        formation={club.formation}
+        budget={club.budget}
+        marketOpen={market.open}
+      />
 
       {/* ---------- CUERPO PRINCIPAL ---------- */}
       <main className="grid grid-cols-1 gap-8 lg:grid-cols-3">

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -1,12 +1,15 @@
 import  { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Search, Filter, ChevronDown, ChevronUp } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
+import { useAuthStore } from '../store/authStore';
 import { Player } from '../types';
 import PageHeader from '../components/common/PageHeader';
 import OfferModal from '../components/market/OfferModal';
 import OffersPanel from '../components/market/OffersPanel';
 import Card from '../components/common/Card';
 import { formatCurrency, getPositionColor, getFormIcon } from '../utils/helpers';
+import QuickNavCards from '../components/club/QuickNavCards';
 
 const Market = () => {
   const [searchQuery, setSearchQuery] = useState('');
@@ -17,7 +20,8 @@ const Market = () => {
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
   const [activeTab, setActiveTab] = useState<'players' | 'offers'>('players');
   
-  const { players, clubs, marketStatus } = useDataStore();
+  const { players, clubs, marketStatus, club, market } = useDataStore();
+  const { user } = useAuthStore();
   
   // Filter players
   const transferListedPlayers = players.filter(p => p.transferListed);
@@ -87,6 +91,28 @@ const Market = () => {
       />
       
       <div className="container mx-auto px-4 py-8">
+        <header className="mb-6 flex flex-col items-center gap-4 md:flex-row">
+          <Link to={`/liga-master/club/${club.slug}`} className="flex items-center gap-3 hover:underline">
+            <img src={club.logo} alt="Escudo" className="h-14 w-14 rounded-full" />
+            <div>
+              <h1 className="text-2xl font-semibold">{club.name}</h1>
+              <p className="text-sm text-gray-400">{user?.username}</p>
+            </div>
+          </Link>
+          <div className="mt-4 flex flex-col items-center md:ml-auto md:mt-0 md:items-end">
+            <span className="text-xs text-gray-400">Presupuesto</span>
+            <span className="text-lg font-semibold text-accent">{formatCurrency(club.budget)}</span>
+          </div>
+        </header>
+
+        <QuickNavCards
+          clubSlug={club.slug}
+          playersCount={club.players.length}
+          formation={club.formation}
+          budget={club.budget}
+          marketOpen={market.open}
+        />
+
         {/* Market status */}
         <div className="mb-6">
           {marketStatus ? (

--- a/src/pages/Tacticas.tsx
+++ b/src/pages/Tacticas.tsx
@@ -1,10 +1,49 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import PageHeader from '../components/common/PageHeader';
+import { useDataStore } from '../store/dataStore';
+import { useAuthStore } from '../store/authStore';
+import { formatCurrency } from '../utils/helpers';
+import QuickNavCards from '../components/club/QuickNavCards';
 
 const Tacticas = () => {
+  const { user } = useAuthStore();
+  const { club, market } = useDataStore();
+
+  if (!user || !club) return <p>Cargando…</p>;
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold">Tácticas</h1>
-    </div>
+    <>
+      <PageHeader
+        title="Tácticas"
+        subtitle="Configura la estrategia y la formación de tu equipo."
+      />
+      <div className="container mx-auto px-4 py-8">
+        <header className="mb-6 flex flex-col items-center gap-4 md:flex-row">
+          <Link to={`/liga-master/club/${club.slug}`} className="flex items-center gap-3 hover:underline">
+            <img src={club.logo} alt="Escudo" className="h-14 w-14 rounded-full" />
+            <div>
+              <h1 className="text-2xl font-semibold">{club.name}</h1>
+              <p className="text-sm text-gray-400">{user.username}</p>
+            </div>
+          </Link>
+          <div className="mt-4 flex flex-col items-center md:ml-auto md:mt-0 md:items-end">
+            <span className="text-xs text-gray-400">Presupuesto</span>
+            <span className="text-lg font-semibold text-accent">{formatCurrency(club.budget)}</span>
+          </div>
+        </header>
+
+        <QuickNavCards
+          clubSlug={club.slug}
+          playersCount={club.players.length}
+          formation={club.formation}
+          budget={club.budget}
+          marketOpen={market.open}
+        />
+
+        <h1 className="text-2xl font-bold">Tácticas</h1>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- create `QuickNavCards` component
- use the component on DtDashboard
- insert QuickNavCards below each club header on squad, finances, tactics and market pages

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c9f4b2f88333b806e91d52525514