### PR TITLE
Remove outdated npm test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@ npm run preview
 ```
 ## Tests
 
-Run the TypeScript tests using `tsx`:
-
-```bash
-npm test
-```
+Testing has not been configured yet. Once Cypress or another test framework is
+added, instructions for running tests will be documented here.
 
 
 ## Admin Panel


### PR DESCRIPTION
## Summary
- README's test section references `npm test` but no test script exists
- Remove the incorrect instructions and clarify that tests will be documented once configured

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859c6cbd70083339764284f6d8ccfdb