### PR TITLE
Add sample datasets and pages

### DIFF
--- a/src/data/financeHistory.json
+++ b/src/data/financeHistory.json
@@ -1,0 +1,4 @@
+[
+  {"season":"2024/25","initialBudget":30000000,"spentOnTransfers":5000000,"earnedFromSales":3500000},
+  {"season":"2023/24","initialBudget":25000000,"spentOnTransfers":4000000,"earnedFromSales":2000000}
+]

--- a/src/data/fixtures.json
+++ b/src/data/fixtures.json
@@ -1,0 +1,5 @@
+[
+  {"id":"f1","date":"2025-02-12","opponent":"Neón FC","location":"home","competition":"Liga Master - Jornada 1"},
+  {"id":"f2","date":"2025-02-19","opponent":"Glitchers 404","location":"away","competition":"Liga Master - Jornada 2"},
+  {"id":"f3","date":"2025-03-01","opponent":"Pixel Galaxy","location":"home","competition":"Copa PES - Octavos"}
+]

--- a/src/data/players.json
+++ b/src/data/players.json
@@ -1,0 +1,7 @@
+[
+  {"id":"p1","name":"Carlos Pérez","age":25,"position":"ST","nationality":"España","overall":80},
+  {"id":"p2","name":"Diego Morales","age":22,"position":"CM","nationality":"Argentina","overall":78},
+  {"id":"p3","name":"Andrés Silva","age":27,"position":"CB","nationality":"Uruguay","overall":82},
+  {"id":"p4","name":"Luís Gomes","age":23,"position":"LB","nationality":"Brasil","overall":79},
+  {"id":"p5","name":"Miguel Torres","age":21,"position":"GK","nationality":"México","overall":77}
+]

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -1,8 +1,51 @@
-const Calendario = () => (
-  <div className="container mx-auto px-4 py-8">
-    <h1 className="text-2xl font-bold">Calendario</h1>
-    <p className="text-gray-400">Próximamente</p>
-  </div>
-);
+import { useEffect, useState } from 'react';
+import PageHeader from '../components/common/PageHeader';
+import fixturesData from '../data/fixtures.json';
+import { VZ_FIXTURES_KEY } from '../utils/storageKeys';
+import { formatDate } from '../utils/helpers';
+
+interface Fixture {
+  id: string;
+  date: string;
+  opponent: string;
+  location: string;
+  competition: string;
+}
+
+const Calendario = () => {
+  const [fixtures, setFixtures] = useState<Fixture[]>([]);
+
+  useEffect(() => {
+    const json = localStorage.getItem(VZ_FIXTURES_KEY);
+    if (json) {
+      setFixtures(JSON.parse(json));
+    } else {
+      localStorage.setItem(VZ_FIXTURES_KEY, JSON.stringify(fixturesData));
+      setFixtures(fixturesData as Fixture[]);
+    }
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        title="Calendario"
+        subtitle="Próximos partidos y eventos programados."
+      />
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        {fixtures.map(match => (
+          <div key={match.id} className="card p-4 flex justify-between items-center">
+            <div>
+              <h3 className="font-bold">{match.competition}</h3>
+              <p className="text-sm text-gray-400">
+                {formatDate(match.date)} • {match.location === 'home' ? 'Local' : 'Visitante'}
+              </p>
+            </div>
+            <span className="text-primary font-medium">{match.opponent}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 export default Calendario;

--- a/src/pages/Finanzas.tsx
+++ b/src/pages/Finanzas.tsx
@@ -1,8 +1,71 @@
-const Finanzas = () => (
-  <div className="container mx-auto px-4 py-8">
-    <h1 className="text-2xl font-bold">Finanzas</h1>
-    <p className="text-gray-400">Próximamente</p>
-  </div>
-);
+import { useEffect, useState } from 'react';
+import PageHeader from '../components/common/PageHeader';
+import financeData from '../data/financeHistory.json';
+import { VZ_FINANCE_HISTORY_KEY } from '../utils/storageKeys';
+import { formatCurrency } from '../utils/helpers';
+
+interface FinanceEntry {
+  season: string;
+  initialBudget: number;
+  spentOnTransfers: number;
+  earnedFromSales: number;
+}
+
+const Finanzas = () => {
+  const [history, setHistory] = useState<FinanceEntry[]>([]);
+
+  useEffect(() => {
+    const json = localStorage.getItem(VZ_FINANCE_HISTORY_KEY);
+    if (json) {
+      setHistory(JSON.parse(json));
+    } else {
+      localStorage.setItem(VZ_FINANCE_HISTORY_KEY, JSON.stringify(financeData));
+      setHistory(financeData as FinanceEntry[]);
+    }
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        title="Historial Financiero"
+        subtitle="Presupuesto y movimientos de transferencias por temporada."
+      />
+      <div className="container mx-auto px-4 py-8">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="text-gray-400 text-xs uppercase border-b border-gray-800">
+                <th className="px-4 py-2">Temporada</th>
+                <th className="px-4 py-2">Presupuesto</th>
+                <th className="px-4 py-2">Gastos</th>
+                <th className="px-4 py-2">Ingresos</th>
+                <th className="px-4 py-2">Balance</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map(entry => {
+                const balance = entry.earnedFromSales - entry.spentOnTransfers;
+                return (
+                  <tr key={entry.season} className="border-b border-gray-800 hover:bg-dark-lighter">
+                    <td className="px-4 py-2 font-medium">{entry.season}</td>
+                    <td className="px-4 py-2">{formatCurrency(entry.initialBudget)}</td>
+                    <td className="px-4 py-2 text-red-500">-{formatCurrency(entry.spentOnTransfers)}</td>
+                    <td className="px-4 py-2 text-green-500">+{formatCurrency(entry.earnedFromSales)}</td>
+                    <td
+                      className={`px-4 py-2 font-semibold ${balance >= 0 ? 'text-green-500' : 'text-red-500'}`}
+                    >
+                      {balance >= 0 ? '+' : ''}
+                      {formatCurrency(balance)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default Finanzas;

--- a/src/pages/Plantilla.tsx
+++ b/src/pages/Plantilla.tsx
@@ -1,8 +1,55 @@
-const Plantilla = () => (
-  <div className="container mx-auto px-4 py-8">
-    <h1 className="text-2xl font-bold">Plantilla</h1>
-    <p className="text-gray-400">Próximamente</p>
-  </div>
-);
+import { useEffect, useState } from 'react';
+import PageHeader from '../components/common/PageHeader';
+import playersData from '../data/players.json';
+import { VZ_PLAYERS_KEY } from '../utils/storageKeys';
+
+interface SquadPlayer {
+  id: string;
+  name: string;
+  age: number;
+  position: string;
+  nationality: string;
+  overall: number;
+}
+
+const Plantilla = () => {
+  const [players, setPlayers] = useState<SquadPlayer[]>([]);
+
+  useEffect(() => {
+    const json = localStorage.getItem(VZ_PLAYERS_KEY);
+    if (json) {
+      setPlayers(JSON.parse(json));
+    } else {
+      localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(playersData));
+      setPlayers(playersData as SquadPlayer[]);
+    }
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        title="Plantilla"
+        subtitle="Jugadores registrados en tu plantilla."
+      />
+      <div className="container mx-auto px-4 py-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {players.map(player => (
+            <div key={player.id} className="card p-4 flex justify-between">
+              <div>
+                <h3 className="font-bold">{player.name}</h3>
+                <p className="text-sm text-gray-400">
+                  {player.position} • {player.nationality} • {player.age} años
+                </p>
+              </div>
+              <span className="text-sm text-gray-300 font-bold">
+                {player.overall}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default Plantilla;

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,3 +1,6 @@
 export const VZ_USERS_KEY = 'vz_users';
 export const VZ_CURRENT_USER_KEY = 'vz_current_user';
 export const VZ_COMMENTS_KEY = 'vz_comments';
+export const VZ_PLAYERS_KEY = 'vz_players';
+export const VZ_FINANCE_HISTORY_KEY = 'vz_finance_history';
+export const VZ_FIXTURES_KEY = 'vz_fixtures';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,6 +9,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "module": "CommonJS",
     "outDir": "tests/build"
   },


### PR DESCRIPTION
## Summary
- add `players.json`, `financeHistory.json` and `fixtures.json`
- show data from the JSON files in Plantilla, Finanzas and Calendario pages
- persist these datasets in `localStorage`
- enable JSON imports in tsconfig

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859c6ccb54483339c7ece25f611f583