### PR TITLE
Add persistent state hook

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,5 @@
-import  { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
+import usePersistentState from '../utils/usePersistentState';
 import { Navigate, useNavigate, Link } from 'react-router-dom';
 import { Settings, Users, Trophy, ShoppingCart, Calendar, FileText, Clipboard, BarChart, Edit, Plus, Trash, Activity, Search, ExternalLink, MessageSquare } from 'lucide-react';
 import NewUserModal from '../components/admin/NewUserModal';
@@ -20,7 +21,7 @@ import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
 
 const Admin = () => {
-  const [activeTab, setActiveTab] = useState('dashboard');
+  const [activeTab, setActiveTab] = usePersistentState('admin_tab', 'dashboard');
   const [showUserModal, setShowUserModal] = useState(false);
   const [showClubModal, setShowClubModal] = useState(false);
   const [showPlayerModal, setShowPlayerModal] = useState(false);

--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -1,13 +1,14 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronLeft, ChevronUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import Card from '../components/common/Card';
 import { useDataStore } from '../store/dataStore';
 import { formatDate } from '../utils/helpers';
+import usePersistentState from '../utils/usePersistentState';
 
 const Fixtures = () => {
-  const [selectedRound, setSelectedRound] = useState<number | null>(null);
+  const [selectedRound, setSelectedRound] = usePersistentState<number | null>('fixtures_round', null);
   const [expandedMatches, setExpandedMatches] = useState<Record<string, boolean>>({});
   
   const { tournaments, clubs } = useDataStore();

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -1,4 +1,5 @@
-import  { useState } from 'react';
+import { useState } from 'react';
+import usePersistentState from '../utils/usePersistentState';
 import { Search, Filter, ChevronDown, ChevronUp } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
 import { Player } from '../types';
@@ -15,7 +16,7 @@ const Market = () => {
   const [ratingSort, setRatingSort] = useState<'asc' | 'desc' | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
-  const [activeTab, setActiveTab] = useState<'players' | 'offers'>('players');
+  const [activeTab, setActiveTab] = usePersistentState<'players' | 'offers'>('market_tab', 'players');
   
   const { players, clubs, marketStatus } = useDataStore();
   

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -2,10 +2,10 @@ import  { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, Calendar, Users, ChevronRight, Filter } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
-import { useState } from 'react';
+import usePersistentState from '../utils/usePersistentState';
 
 const Tournaments = () => {
-  const [filter, setFilter] = useState('all'); // 'all', 'ongoing', 'open', 'finished'
+  const [filter, setFilter] = usePersistentState<'all' | 'ongoing' | 'open' | 'finished'>('tournaments_filter', 'all');
 
   const { tournaments } = useDataStore();
   

--- a/src/utils/usePersistentState.ts
+++ b/src/utils/usePersistentState.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, Dispatch, SetStateAction } from 'react';
+
+const PREFIX = 'vz_';
+
+function getInitialValue<T>(key: string, defaultValue: T): T {
+  if (typeof window === 'undefined') {
+    return defaultValue;
+  }
+
+  try {
+    const stored = localStorage.getItem(PREFIX + key);
+    if (stored !== null) {
+      return JSON.parse(stored) as T;
+    }
+  } catch {
+    // ignore parsing errors
+  }
+
+  return defaultValue;
+}
+
+export default function usePersistentState<T>(
+  key: string,
+  defaultValue: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => getInitialValue(key, defaultValue));
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(PREFIX + key, JSON.stringify(state));
+    } catch {
+      // ignore write errors
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
## Summary
- add `usePersistentState` hook for generic localStorage syncing
- persist UI states in admin, fixtures, market and tournaments pages

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6859c6cd79708333b8ac6ae560e9e92d