### PR TITLE
Add FinanzasPage with finance widgets

### DIFF
--- a/src/components/finanzas/BudgetPanel.tsx
+++ b/src/components/finanzas/BudgetPanel.tsx
@@ -1,0 +1,40 @@
+import StatsCard from '../common/StatsCard';
+import { Wallet, BadgeDollarSign, PiggyBank } from 'lucide-react';
+import { formatCurrency } from '../../utils/helpers';
+
+interface Props {
+  transferBudget: number;
+  wageBudget: number;
+  balance: number;
+  prevBalance?: number;
+}
+
+const BudgetPanel = ({ transferBudget, wageBudget, balance, prevBalance = 0 }: Props) => {
+  const trend: 'up' | 'down' | 'neutral' =
+    balance > prevBalance ? 'up' : balance < prevBalance ? 'down' : 'neutral';
+  const trendValue = formatCurrency(Math.abs(balance - prevBalance));
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <StatsCard
+        title="Presupuesto de Fichajes"
+        value={formatCurrency(transferBudget)}
+        icon={<BadgeDollarSign size={24} className="text-green-400" />}
+      />
+      <StatsCard
+        title="Presupuesto Salarial"
+        value={formatCurrency(wageBudget)}
+        icon={<Wallet size={24} className="text-yellow-400" />}
+      />
+      <StatsCard
+        title="Balance Actual"
+        value={formatCurrency(balance)}
+        icon={<PiggyBank size={24} className="text-primary" />}
+        trend={trend}
+        trendValue={trendValue}
+      />
+    </div>
+  );
+};
+
+export default BudgetPanel;

--- a/src/components/finanzas/IncomeVsExpensesChart.tsx
+++ b/src/components/finanzas/IncomeVsExpensesChart.tsx
@@ -1,0 +1,37 @@
+interface DataPoint {
+  month: string;
+  income: number;
+  expenses: number;
+}
+
+interface Props {
+  data: DataPoint[];
+}
+
+const IncomeVsExpensesChart = ({ data }: Props) => {
+  const max = Math.max(
+    ...data.map(d => Math.max(d.income, d.expenses))
+  );
+
+  return (
+    <div className="h-56 flex items-end space-x-2">
+      {data.map(d => (
+        <div key={d.month} className="flex-1 text-center">
+          <div className="flex items-end justify-center h-full space-x-1">
+            <div
+              className="bg-green-500/70 w-3"
+              style={{ height: `${(d.income / max) * 100}%` }}
+            ></div>
+            <div
+              className="bg-red-500/70 w-3"
+              style={{ height: `${(d.expenses / max) * 100}%` }}
+            ></div>
+          </div>
+          <div className="mt-1 text-xs text-gray-400">{d.month}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default IncomeVsExpensesChart;

--- a/src/components/finanzas/RequestFundsModal.tsx
+++ b/src/components/finanzas/RequestFundsModal.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface Props {
+  onClose: () => void;
+}
+
+const RequestFundsModal = ({ onClose }: Props) => {
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSent(true);
+    setTimeout(onClose, 1500);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-6">
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        {sent ? (
+          <div className="text-center">
+            <p className="font-semibold mb-2">Solicitud enviada</p>
+            <p className="text-sm text-gray-400">Tu directiva revisará la petición.</p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <h3 className="text-xl font-bold">Solicitar Fondos</h3>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Cantidad</label>
+              <input type="number" className="input w-full" required />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Motivo</label>
+              <textarea className="input w-full" rows={3} required></textarea>
+            </div>
+            <button type="submit" className="btn-primary w-full">Enviar Solicitud</button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RequestFundsModal;

--- a/src/components/finanzas/SeasonEndProjection.tsx
+++ b/src/components/finanzas/SeasonEndProjection.tsx
@@ -1,0 +1,27 @@
+interface DataPoint {
+  month: string;
+  income: number;
+  expenses: number;
+}
+
+interface Props {
+  data: DataPoint[];
+  currentBalance: number;
+}
+
+const SeasonEndProjection = ({ data, currentBalance }: Props) => {
+  const totalIncome = data.reduce((sum, d) => sum + d.income, 0);
+  const totalExpenses = data.reduce((sum, d) => sum + d.expenses, 0);
+  const avgMonthly = (totalIncome - totalExpenses) / data.length;
+  const projection = Math.round(currentBalance + avgMonthly * (12 - data.length));
+
+  return (
+    <div className="card p-4 text-center">
+      <h4 className="font-bold mb-2">Saldo fin de temporada</h4>
+      <p className="text-2xl font-bold">{projection.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' })}</p>
+      <p className="text-sm text-gray-400">Proyección basada en rendimiento actual</p>
+    </div>
+  );
+};
+
+export default SeasonEndProjection;

--- a/src/components/finanzas/TransferHistoryTable.tsx
+++ b/src/components/finanzas/TransferHistoryTable.tsx
@@ -1,0 +1,55 @@
+import { ArrowUp } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { formatCurrency, formatDate } from '../../utils/helpers';
+
+const TransferHistoryTable = () => {
+  const { transfers } = useDataStore();
+  const recent = [...transfers].slice(0, 5);
+
+  return (
+    <div className="card overflow-hidden">
+      <div className="p-4 bg-dark-lighter border-b border-gray-800">
+        <h4 className="font-bold">Últimos Traspasos</h4>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-gray-400 text-xs uppercase">
+              <th className="px-4 py-2 text-left">Jugador</th>
+              <th className="px-4 py-2 text-center">Tipo</th>
+              <th className="px-4 py-2 text-center">Origen</th>
+              <th className="px-4 py-2 text-center">Destino</th>
+              <th className="px-4 py-2 text-center">Valor</th>
+              <th className="px-4 py-2 text-center">Fecha</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recent.map(t => (
+              <tr key={t.id} className="border-b border-gray-800 hover:bg-dark-lighter">
+                <td className="px-4 py-2">{t.playerName}</td>
+                <td className="px-4 py-2 text-center">
+                  <span className="inline-flex items-center text-red-500">
+                    <ArrowUp size={14} className="mr-1" />Salida
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-center">{t.fromClub}</td>
+                <td className="px-4 py-2 text-center">{t.toClub}</td>
+                <td className="px-4 py-2 text-center font-medium">-{formatCurrency(t.fee)}</td>
+                <td className="px-4 py-2 text-center">{formatDate(t.date)}</td>
+              </tr>
+            ))}
+            {recent.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-gray-400">
+                  Sin traspasos
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default TransferHistoryTable;

--- a/src/data/financeHistory.json
+++ b/src/data/financeHistory.json
@@ -1,0 +1,8 @@
+[
+  { "month": "Jan", "income": 1200000, "expenses": 1000000 },
+  { "month": "Feb", "income": 1100000, "expenses": 1150000 },
+  { "month": "Mar", "income": 1300000, "expenses": 900000 },
+  { "month": "Apr", "income": 1250000, "expenses": 950000 },
+  { "month": "May", "income": 1400000, "expenses": 1000000 },
+  { "month": "Jun", "income": 1350000, "expenses": 1200000 }
+]

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+function usePersistentState<T>(key: string, defaultValue: T): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof localStorage === 'undefined') return defaultValue;
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) as T : defaultValue;
+  });
+
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // ignore write errors
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+export default usePersistentState;

--- a/src/pages/FinanzasPage.tsx
+++ b/src/pages/FinanzasPage.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import PageHeader from '../components/common/PageHeader';
+import BudgetPanel from '../components/finanzas/BudgetPanel';
+import IncomeVsExpensesChart from '../components/finanzas/IncomeVsExpensesChart';
+import TransferHistoryTable from '../components/finanzas/TransferHistoryTable';
+import SeasonEndProjection from '../components/finanzas/SeasonEndProjection';
+import RequestFundsModal from '../components/finanzas/RequestFundsModal';
+import financeData from '../data/financeHistory.json';
+import usePersistentState from '../hooks/usePersistentState';
+
+interface FinanceEntry {
+  month: string;
+  income: number;
+  expenses: number;
+}
+
+const FinanzasPage = () => {
+  const [history] = usePersistentState<FinanceEntry[]>('vz_finance_history', financeData as FinanceEntry[]);
+  const [showModal, setShowModal] = useState(false);
+
+  const transferBudget = 20000000;
+  const wageBudget = 5000000;
+  const balance = history.reduce((sum, h) => sum + h.income - h.expenses, 0);
+
+  const prevBalance = balance - (history[history.length - 1].income - history[history.length - 1].expenses);
+
+  return (
+    <div>
+      <PageHeader
+        title="Finanzas del Club"
+        subtitle="Resumen económico y proyecciones de la temporada"
+      />
+      <div className="container mx-auto px-4 py-8 space-y-8">
+        <BudgetPanel
+          transferBudget={transferBudget}
+          wageBudget={wageBudget}
+          balance={balance}
+          prevBalance={prevBalance}
+        />
+
+        <div className="card p-4">
+          <h3 className="font-bold mb-4">Ingresos vs Gastos</h3>
+          <IncomeVsExpensesChart data={history} />
+        </div>
+
+        <SeasonEndProjection data={history} currentBalance={balance} />
+
+        <TransferHistoryTable />
+
+        <button className="btn-primary" onClick={() => setShowModal(true)}>
+          Solicitar Fondos Extra
+        </button>
+      </div>
+      {showModal && <RequestFundsModal onClose={() => setShowModal(false)} />}
+    </div>
+  );
+};
+
+export default FinanzasPage;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,6 +8,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- add BudgetPanel, charts and tables for finances
- persist finance history with `usePersistentState`
- create decorative RequestFundsModal
- enable JSON imports

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859c6ce2bd48333a6bb5123a2082eac