### PR TITLE
Add FullCalendar page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
          "name": "la-virtual-zone",
          "version": "0.1.0",
          "dependencies": {
+            "@fullcalendar/core": "^6.1.17",
+            "@fullcalendar/daygrid": "^6.1.17",
+            "@fullcalendar/interaction": "^6.1.17",
+            "@fullcalendar/react": "^6.1.17",
+            "@rollup/rollup-linux-x64-gnu": "^4.44.0",
             "lucide-react": "^0.244.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
@@ -446,6 +451,44 @@
             "url": "https://eslint.org/donate"
          }
       },
+      "node_modules/@fullcalendar/core": {
+         "version": "6.1.17",
+         "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz",
+         "integrity": "sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==",
+         "license": "MIT",
+         "dependencies": {
+            "preact": "~10.12.1"
+         }
+      },
+      "node_modules/@fullcalendar/daygrid": {
+         "version": "6.1.17",
+         "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.17.tgz",
+         "integrity": "sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==",
+         "license": "MIT",
+         "peerDependencies": {
+            "@fullcalendar/core": "~6.1.17"
+         }
+      },
+      "node_modules/@fullcalendar/interaction": {
+         "version": "6.1.17",
+         "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.17.tgz",
+         "integrity": "sha512-AudvQvgmJP2FU89wpSulUUjeWv24SuyCx8FzH2WIPVaYg+vDGGYarI7K6PcM3TH7B/CyaBjm5Rqw9lXgnwt5YA==",
+         "license": "MIT",
+         "peerDependencies": {
+            "@fullcalendar/core": "~6.1.17"
+         }
+      },
+      "node_modules/@fullcalendar/react": {
+         "version": "6.1.17",
+         "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.17.tgz",
+         "integrity": "sha512-AA8soHhlfRH5dUeqHnfAtzDiXa2vrgWocJSK/F5qzw/pOxc9MqpuoS/nQBROWtHHg6yQUg3DoGqOOhi7dmylXQ==",
+         "license": "MIT",
+         "peerDependencies": {
+            "@fullcalendar/core": "~6.1.17",
+            "react": "^16.7.0 || ^17 || ^18 || ^19",
+            "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+         }
+      },
       "node_modules/@humanwhocodes/config-array": {
          "version": "0.13.0",
          "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -648,6 +691,18 @@
          "integrity": "sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/@rollup/rollup-linux-x64-gnu": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
+         "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+         "cpu": [
+            "x64"
+         ],
+         "license": "MIT",
+         "os": [
+            "linux"
+         ]
       },
       "node_modules/@rollup/rollup-win32-x64-msvc": {
          "version": "4.44.0",
@@ -2930,6 +2985,16 @@
          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/preact": {
+         "version": "10.12.1",
+         "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+         "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+         "license": "MIT",
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/preact"
+         }
       },
       "node_modules/prelude-ls": {
          "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
       "preview": "vite preview"
    },
    "dependencies": {
+      "@fullcalendar/core": "^6.1.17",
+      "@fullcalendar/daygrid": "^6.1.17",
+      "@fullcalendar/interaction": "^6.1.17",
+      "@fullcalendar/react": "^6.1.17",
+      "@rollup/rollup-linux-x64-gnu": "^4.44.0",
       "lucide-react": "^0.244.0",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const Tacticas = lazy(() => import('./pages/Tacticas'));
 const Analisis = lazy(() => import('./pages/Analisis'));
 const Plantilla = lazy(() => import('./pages/Plantilla'));
 const Finanzas = lazy(() => import('./pages/Finanzas'));
-const Calendario = lazy(() => import('./pages/Calendario'));
+const Calendario = lazy(() => import('./pages/CalendarioPage'));
 
 function App() {
   return (

--- a/src/components/calendar/EventModal.tsx
+++ b/src/components/calendar/EventModal.tsx
@@ -1,0 +1,59 @@
+import { X } from 'lucide-react';
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  start: string;
+  category: 'partido' | 'entrenamiento' | 'finanzas' | 'mercado';
+  homeTeam?: string;
+  awayTeam?: string;
+  homeLogo?: string;
+  awayLogo?: string;
+  venue?: string;
+  weather?: string;
+  moral?: string;
+}
+
+interface Props {
+  event: CalendarEvent;
+  onClose: () => void;
+}
+
+const EventModal = ({ event, onClose }: Props) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+    <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 text-gray-400 hover:text-white"
+      >
+        <X size={24} />
+      </button>
+      <h3 className="text-xl font-bold mb-4">{event.title}</h3>
+      {event.category === 'partido' && event.homeTeam && event.awayTeam && (
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {event.homeLogo && (
+              <img src={event.homeLogo} alt={event.homeTeam} className="h-8 w-8 rounded-full" />
+            )}
+            <span>{event.homeTeam}</span>
+          </div>
+          <span className="text-sm text-gray-400">vs</span>
+          <div className="flex items-center gap-2">
+            {event.awayLogo && (
+              <img src={event.awayLogo} alt={event.awayTeam} className="h-8 w-8 rounded-full" />
+            )}
+            <span>{event.awayTeam}</span>
+          </div>
+        </div>
+      )}
+      <ul className="space-y-1 text-sm text-gray-300">
+        {event.venue && <li>Sede: {event.venue}</li>}
+        {event.weather && <li>Clima: {event.weather}</li>}
+        {event.moral && <li>Ánimo: {event.moral}</li>}
+      </ul>
+    </div>
+  </div>
+);
+
+export default EventModal;

--- a/src/data/fixtures.json
+++ b/src/data/fixtures.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "match1",
+    "category": "partido",
+    "title": "Rayo Digital FC vs Atlético Pixelado",
+    "start": "2025-02-02T18:00:00",
+    "homeTeam": "Rayo Digital FC",
+    "homeLogo": "https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true",
+    "awayTeam": "Atlético Pixelado",
+    "awayLogo": "https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true",
+    "venue": "Estadio Cyber Arena",
+    "weather": "Soleado",
+    "moral": "Alta"
+  },
+  {
+    "id": "training1",
+    "category": "entrenamiento",
+    "title": "Entrenamiento matutino",
+    "start": "2025-02-04T10:00:00",
+    "venue": "Campo de entrenamiento",
+    "weather": "Parcialmente nublado",
+    "moral": "Media"
+  },
+  {
+    "id": "finance1",
+    "category": "finanzas",
+    "title": "Revisión financiera",
+    "start": "2025-02-10T12:00:00"
+  },
+  {
+    "id": "match2",
+    "category": "partido",
+    "title": "Neón FC vs Rayo Digital FC",
+    "start": "2025-02-12T20:00:00",
+    "homeTeam": "Neón FC",
+    "homeLogo": "https://ui-avatars.com/api/?name=NFC&background=ec4899&color=fff&size=128&bold=true",
+    "awayTeam": "Rayo Digital FC",
+    "awayLogo": "https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true",
+    "venue": "Estadio Luminoso",
+    "weather": "Lluvia",
+    "moral": "Alta"
+  },
+  {
+    "id": "marketEnd",
+    "category": "mercado",
+    "title": "Fin de mercado",
+    "start": "2025-02-15"
+  }
+]

--- a/src/index.css
+++ b/src/index.css
@@ -107,3 +107,23 @@ body {
   }
 }
 
+
+/* FullCalendar dark overrides */
+.fc-theme-standard,
+.fc-theme-standard td,
+.fc-theme-standard th {
+  @apply border-zinc-700;
+}
+.fc .fc-button {
+  @apply bg-dark-light text-white border-none hover:bg-dark-lighter rounded;
+}
+.fc .fc-button.fc-button-active {
+  @apply bg-primary;
+}
+.fc .fc-daygrid-day-number {
+  @apply text-gray-300;
+}
+.fc .fc-daygrid-event {
+  background-color: rgb(127 57 251 / 0.2);
+  @apply border border-primary text-primary text-xs rounded px-1;
+}

--- a/src/pages/CalendarioPage.tsx
+++ b/src/pages/CalendarioPage.tsx
@@ -1,0 +1,101 @@
+import { lazy, Suspense, useEffect, useState } from 'react';
+import type { EventClickArg } from '@fullcalendar/core';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import fixtures from '../data/fixtures.json';
+import DtMenuTabs from '../components/DtMenuTabs';
+import EventModal, { CalendarEvent } from '../components/calendar/EventModal';
+import { VZ_CALENDAR_PREFS_KEY } from '../utils/storageKeys';
+
+const FullCalendar = lazy(() => import('@fullcalendar/react'));
+
+interface Filters {
+  partidos: boolean;
+  entrenos: boolean;
+  finanzas: boolean;
+  mercado: boolean;
+}
+
+const defaultFilters: Filters = {
+  partidos: true,
+  entrenos: true,
+  finanzas: true,
+  mercado: true
+};
+
+const CalendarioPage = () => {
+  const [filters, setFilters] = useState<Filters>(() => {
+    const saved = localStorage.getItem(VZ_CALENDAR_PREFS_KEY);
+    return saved ? JSON.parse(saved) : defaultFilters;
+  });
+  const [selected, setSelected] = useState<CalendarEvent | null>(null);
+
+  useEffect(() => {
+    localStorage.setItem(VZ_CALENDAR_PREFS_KEY, JSON.stringify(filters));
+  }, [filters]);
+
+  const handleEventClick = (arg: EventClickArg) => {
+    const event = fixtures.find(f => f.id === arg.event.id);
+    if (event) setSelected(event);
+  };
+
+  const filteredEvents = fixtures.filter(ev => {
+    if (ev.category === 'partido' && !filters.partidos) return false;
+    if (ev.category === 'entrenamiento' && !filters.entrenos) return false;
+    if (ev.category === 'finanzas' && !filters.finanzas) return false;
+    if (ev.category === 'mercado' && !filters.mercado) return false;
+    return true;
+  });
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <DtMenuTabs />
+      <h1 className="text-2xl font-bold mb-4">Calendario</h1>
+      <div className="mb-4 flex gap-4 text-sm">
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={filters.partidos}
+            onChange={() => setFilters(f => ({ ...f, partidos: !f.partidos }))}
+          />
+          Partidos
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={filters.entrenos}
+            onChange={() => setFilters(f => ({ ...f, entrenos: !f.entrenos }))}
+          />
+          Entrenamientos
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={filters.finanzas}
+            onChange={() => setFilters(f => ({ ...f, finanzas: !f.finanzas }))}
+          />
+          Finanzas
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={filters.mercado}
+            onChange={() => setFilters(f => ({ ...f, mercado: !f.mercado }))}
+          />
+          Mercado
+        </label>
+      </div>
+      <Suspense fallback={<div className="text-center">Cargando…</div>}>
+        <FullCalendar
+          plugins={[dayGridPlugin, interactionPlugin]}
+          initialView="dayGridMonth"
+          events={filteredEvents}
+          eventClick={handleEventClick}
+        />
+      </Suspense>
+      {selected && <EventModal event={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+};
+
+export default CalendarioPage;

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,3 +1,4 @@
 export const VZ_USERS_KEY = 'vz_users';
 export const VZ_CURRENT_USER_KEY = 'vz_current_user';
 export const VZ_COMMENTS_KEY = 'vz_comments';
+export const VZ_CALENDAR_PREFS_KEY = 'vz_calendar_prefs';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,6 +8,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- add calendar dependencies
- create fixtures.json with sample events
- allow JSON imports in tsconfig
- add EventModal and full calendar page
- adjust CSS for dark theme
- route Liga Master calendar to new page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859c6ce3ac88333b70302c4408d1acc