### PR TITLE
Add tactic management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ const Rankings = lazy(() => import('./pages/Rankings'));
 const Fixtures = lazy(() => import('./pages/Fixtures'));
 const DtDashboard = lazy(() => import('./pages/DtDashboard'));
 const Feed = lazy(() => import('./pages/Feed'));
-const Tacticas = lazy(() => import('./pages/Tacticas'));
+const Tacticas = lazy(() => import('./pages/TacticasPage'));
 const Analisis = lazy(() => import('./pages/Analisis'));
 const Plantilla = lazy(() => import('./pages/Plantilla'));
 const Finanzas = lazy(() => import('./pages/Finanzas'));

--- a/src/components/tacticas/FormationSelector.tsx
+++ b/src/components/tacticas/FormationSelector.tsx
@@ -1,0 +1,22 @@
+interface FormationSelectorProps {
+  value: string;
+  onChange: (f: string) => void;
+}
+
+const formations = ['4-4-2', '4-3-3', '3-5-2', '4-2-3-1', '5-3-2', '3-4-3'];
+
+const FormationSelector = ({ value, onChange }: FormationSelectorProps) => (
+  <select
+    className="p-2 rounded bg-gray-800"
+    value={value}
+    onChange={e => onChange(e.target.value)}
+  >
+    {formations.map(f => (
+      <option key={f} value={f}>
+        {f}
+      </option>
+    ))}
+  </select>
+);
+
+export default FormationSelector;

--- a/src/components/tacticas/PitchCanvas.tsx
+++ b/src/components/tacticas/PitchCanvas.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Player } from '../../types';
+import usePersistentState from '../../utils/usePersistentState';
+import PlayerCard from './PlayerCard';
+import SynergyIndicator from './SynergyIndicator';
+import { Instructions } from './TeamInstructions';
+import { SetPieces } from './SetPiecesManager';
+
+interface LayoutItem {
+  row: number;
+  col: number;
+  playerId: string;
+}
+
+interface TacticsState {
+  formation: string;
+  layout: LayoutItem[];
+  instructions: Instructions;
+  setPieces: SetPieces;
+}
+
+interface PitchCanvasProps {
+  players: Player[];
+  state: TacticsState;
+  onChange: (s: TacticsState) => void;
+}
+
+const rows = 6;
+const cols = 4;
+
+const PitchCanvas = ({ players, state, onChange }: PitchCanvasProps) => {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [, save] = usePersistentState('vz_tactics', state); // ensure key exists
+
+  const layout = state.layout;
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, row: number, col: number) => {
+    const id = e.dataTransfer.getData('text/plain');
+    const without = layout.filter(l => l.playerId !== id);
+    const updated = [...without, { playerId: id, row, col }];
+    const newState = { ...state, layout: updated };
+    onChange(newState);
+    save(newState);
+  };
+
+  const handleContextMenu = (e: React.MouseEvent, id: string) => {
+    e.preventDefault();
+    setSelected(id === selected ? null : id);
+  };
+
+  const synergy = Math.round((layout.length / players.length) * 100);
+
+  return (
+    <div>
+      <SynergyIndicator value={synergy} />
+      <div className="grid grid-rows-6 grid-cols-4 gap-2 bg-green-700 p-4 rounded">
+        {Array.from({ length: rows }).map((_, r) =>
+          Array.from({ length: cols }).map((_, c) => {
+            const item = layout.find(l => l.row === r && l.col === c);
+            const player = item ? players.find(p => p.id === item.playerId) : undefined;
+            return (
+              <div
+                key={`${r}-${c}`}
+                className="relative border border-white/20 h-16 flex items-center justify-center"
+                onDragOver={e => e.preventDefault()}
+                onDrop={e => handleDrop(e, r, c)}
+              >
+                {player && (
+                  <div onContextMenu={e => handleContextMenu(e, player.id)} className="w-full">
+                    <PlayerCard player={player} />
+                    {selected === player.id && (
+                      <div className="absolute top-full left-0 mt-1 bg-gray-800 text-xs p-2 rounded z-10">
+                        Instrucciones del jugador
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+export type { TacticsState };
+export default PitchCanvas;

--- a/src/components/tacticas/PlayerCard.tsx
+++ b/src/components/tacticas/PlayerCard.tsx
@@ -1,0 +1,18 @@
+import { Player } from '../../types';
+
+interface PlayerCardProps {
+  player: Player;
+}
+
+const PlayerCard = ({ player }: PlayerCardProps) => (
+  <div
+    draggable
+    onDragStart={e => e.dataTransfer.setData('text/plain', player.id)}
+    className="bg-gray-900 text-xs text-center rounded p-1 cursor-move"
+  >
+    <img src={player.image} alt={player.name} className="w-8 h-8 mx-auto rounded-full mb-1" />
+    <div>{player.dorsal}</div>
+  </div>
+);
+
+export default PlayerCard;

--- a/src/components/tacticas/SetPiecesManager.tsx
+++ b/src/components/tacticas/SetPiecesManager.tsx
@@ -1,0 +1,38 @@
+import { Player } from '../../types';
+
+interface SetPieces {
+  penalties?: string;
+  freeKicks?: string;
+  corners?: string;
+}
+
+interface SetPiecesManagerProps {
+  players: Player[];
+  value: SetPieces;
+  onChange: (v: SetPieces) => void;
+}
+
+const Select = ({ label, value, onChange, players }: { label: string; value?: string; onChange: (id: string) => void; players: Player[] }) => (
+  <div className="mb-2">
+    <label className="block text-sm mb-1">{label}</label>
+    <select className="p-2 rounded bg-gray-800 w-full" value={value || ''} onChange={e => onChange(e.target.value)}>
+      <option value="">-</option>
+      {players.map(p => (
+        <option key={p.id} value={p.id}>
+          {p.name}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+const SetPiecesManager = ({ players, value, onChange }: SetPiecesManagerProps) => (
+  <div className="p-4 bg-gray-800 rounded">
+    <Select label="Penales" value={value.penalties} onChange={v => onChange({ ...value, penalties: v })} players={players} />
+    <Select label="Tiros Libres" value={value.freeKicks} onChange={v => onChange({ ...value, freeKicks: v })} players={players} />
+    <Select label="Córners" value={value.corners} onChange={v => onChange({ ...value, corners: v })} players={players} />
+  </div>
+);
+
+export type { SetPieces };
+export default SetPiecesManager;

--- a/src/components/tacticas/SynergyIndicator.tsx
+++ b/src/components/tacticas/SynergyIndicator.tsx
@@ -1,0 +1,10 @@
+interface SynergyIndicatorProps {
+  value: number;
+}
+
+const SynergyIndicator = ({ value }: SynergyIndicatorProps) => {
+  const color = value > 70 ? 'text-green-400' : value > 40 ? 'text-yellow-400' : 'text-red-400';
+  return <div className={color}>Sinergia: {value}%</div>;
+};
+
+export default SynergyIndicator;

--- a/src/components/tacticas/TeamInstructions.tsx
+++ b/src/components/tacticas/TeamInstructions.tsx
@@ -1,0 +1,38 @@
+interface TeamInstructionsProps {
+  values: Instructions;
+  onChange: (v: Instructions) => void;
+}
+
+export interface Instructions {
+  possession: number;
+  pressure: number;
+  width: number;
+  line: number;
+}
+
+const Slider = ({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) => (
+  <div className="mb-4">
+    <label className="block text-sm mb-1">
+      {label}: {value}
+    </label>
+    <input
+      type="range"
+      min={0}
+      max={100}
+      value={value}
+      onChange={e => onChange(Number(e.target.value))}
+      className="w-full"
+    />
+  </div>
+);
+
+const TeamInstructions = ({ values, onChange }: TeamInstructionsProps) => (
+  <div className="p-4 bg-gray-800 rounded">
+    <Slider label="Posesión" value={values.possession} onChange={v => onChange({ ...values, possession: v })} />
+    <Slider label="Presión" value={values.pressure} onChange={v => onChange({ ...values, pressure: v })} />
+    <Slider label="Anchura" value={values.width} onChange={v => onChange({ ...values, width: v })} />
+    <Slider label="Línea" value={values.line} onChange={v => onChange({ ...values, line: v })} />
+  </div>
+);
+
+export default TeamInstructions;

--- a/src/pages/TacticasPage.tsx
+++ b/src/pages/TacticasPage.tsx
@@ -1,0 +1,40 @@
+import FormationSelector from '../components/tacticas/FormationSelector';
+import PitchCanvas, { TacticsState } from '../components/tacticas/PitchCanvas';
+import TeamInstructions, { Instructions } from '../components/tacticas/TeamInstructions';
+import SetPiecesManager, { SetPieces } from '../components/tacticas/SetPiecesManager';
+import usePersistentState from '../utils/usePersistentState';
+import { useDataStore } from '../store/dataStore';
+
+const TacticasPage = () => {
+  const { club } = useDataStore();
+  const players = club.players.slice(0, 11);
+
+  const initialState: TacticsState = {
+    formation: club.formation,
+    layout: [],
+    instructions: { possession: 50, pressure: 50, width: 50, line: 50 },
+    setPieces: {}
+  };
+
+  const [state, setState] = usePersistentState<TacticsState>('vz_tactics', initialState);
+
+  const updateState = (s: Partial<TacticsState>) => setState({ ...state, ...s });
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Tácticas</h1>
+
+      <div>
+        <FormationSelector value={state.formation} onChange={f => updateState({ formation: f })} />
+      </div>
+
+      <PitchCanvas players={players} state={state} onChange={setState} />
+
+      <TeamInstructions values={state.instructions} onChange={v => updateState({ instructions: v })} />
+
+      <SetPiecesManager players={players} value={state.setPieces} onChange={v => updateState({ setPieces: v })} />
+    </div>
+  );
+};
+
+export default TacticasPage;

--- a/src/utils/usePersistentState.ts
+++ b/src/utils/usePersistentState.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+function usePersistentState<T>(key: string, initialValue: T): [T, (v: T) => void] {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored ? (JSON.parse(stored) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const updateState = (value: T) => {
+    setState(value);
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (err) {
+      console.error('Failed to store state', err);
+    }
+  };
+
+  return [state, updateState];
+}
+
+export default usePersistentState;


### PR DESCRIPTION
## Summary
- add `usePersistentState` hook for localStorage-backed state
- create tactics components (`FormationSelector`, `PitchCanvas`, `TeamInstructions`, `SetPiecesManager`, `SynergyIndicator`, `PlayerCard`)
- build `TacticasPage` using these components
- route `liga-master/tacticas` to new page

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6859c6cec7b48333b6c42028da55ead6