### PR TITLE
Fix lint and build errors

### DIFF
--- a/src/pages/TacticasPage.tsx
+++ b/src/pages/TacticasPage.tsx
@@ -1,7 +1,7 @@
 import FormationSelector from '../components/tacticas/FormationSelector';
 import PitchCanvas, { TacticsState } from '../components/tacticas/PitchCanvas';
-import TeamInstructions, { Instructions } from '../components/tacticas/TeamInstructions';
-import SetPiecesManager, { SetPieces } from '../components/tacticas/SetPiecesManager';
+import TeamInstructions from '../components/tacticas/TeamInstructions';
+import SetPiecesManager from '../components/tacticas/SetPiecesManager';
 import usePersistentState from '../utils/usePersistentState';
 import { useDataStore } from '../store/dataStore';
 

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -2,3 +2,6 @@ export const VZ_USERS_KEY = 'vz_users';
 export const VZ_CURRENT_USER_KEY = 'vz_current_user';
 export const VZ_COMMENTS_KEY = 'vz_comments';
 export const VZ_CALENDAR_PREFS_KEY = 'vz_calendar_prefs';
+export const VZ_PLAYERS_KEY = 'vz_players';
+export const VZ_FIXTURES_KEY = 'vz_fixtures';
+export const VZ_FINANCE_HISTORY_KEY = 'vz_finance_history';


### PR DESCRIPTION
## Summary
- remove unused imports in `TacticasPage`
- export missing storage keys for finances, fixtures and players

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d5261bbc83338587038aae49f09c