### PR TITLE
Replace OS-specific Rollup dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
             "@fullcalendar/daygrid": "^6.1.17",
             "@fullcalendar/interaction": "^6.1.17",
             "@fullcalendar/react": "^6.1.17",
-            "@rollup/rollup-linux-x64-gnu": "^4.44.0",
             "lucide-react": "^0.244.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
             "react-router-dom": "^6.14.0",
+            "rollup": "^4.44.0",
             "zustand": "^4.3.8"
          },
          "devDependencies": {
@@ -1018,6 +1018,44 @@
             "url": "https://github.com/chalk/ansi-regex?sponsor=1"
          }
       },
+      "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+         "version": "6.2.1",
+         "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+         "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+         }
+      },
+      "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+         "version": "9.2.2",
+         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+         "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@isaacs/cliui/node_modules/string-width": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+         "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+         },
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
       "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
          "version": "7.1.0",
          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -1032,6 +1070,24 @@
          },
          "funding": {
             "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+         }
+      },
+      "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+         "version": "8.1.0",
+         "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+         "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+         },
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
          }
       },
       "node_modules/@jridgewell/gen-mapping": {
@@ -1152,7 +1208,201 @@
          "dev": true,
          "license": "MIT"
       },
-
+      "node_modules/@rollup/rollup-android-arm-eabi": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz",
+         "integrity": "sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==",
+         "cpu": [
+            "arm"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "android"
+         ]
+      },
+      "node_modules/@rollup/rollup-android-arm64": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.0.tgz",
+         "integrity": "sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==",
+         "cpu": [
+            "arm64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "android"
+         ]
+      },
+      "node_modules/@rollup/rollup-darwin-arm64": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.0.tgz",
+         "integrity": "sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==",
+         "cpu": [
+            "arm64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ]
+      },
+      "node_modules/@rollup/rollup-darwin-x64": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.0.tgz",
+         "integrity": "sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==",
+         "cpu": [
+            "x64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ]
+      },
+      "node_modules/@rollup/rollup-freebsd-arm64": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.0.tgz",
+         "integrity": "sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==",
+         "cpu": [
+            "arm64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "freebsd"
+         ]
+      },
+      "node_modules/@rollup/rollup-freebsd-x64": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.0.tgz",
+         "integrity": "sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==",
+         "cpu": [
+            "x64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "freebsd"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.0.tgz",
+         "integrity": "sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==",
+         "cpu": [
+            "arm"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.0.tgz",
+         "integrity": "sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==",
+         "cpu": [
+            "arm"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-arm64-gnu": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.0.tgz",
+         "integrity": "sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==",
+         "cpu": [
+            "arm64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-arm64-musl": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.0.tgz",
+         "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
+         "cpu": [
+            "arm64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.0.tgz",
+         "integrity": "sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==",
+         "cpu": [
+            "loong64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.0.tgz",
+         "integrity": "sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==",
+         "cpu": [
+            "ppc64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.0.tgz",
+         "integrity": "sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==",
+         "cpu": [
+            "riscv64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-riscv64-musl": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.0.tgz",
+         "integrity": "sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==",
+         "cpu": [
+            "riscv64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-s390x-gnu": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.0.tgz",
+         "integrity": "sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==",
+         "cpu": [
+            "s390x"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
       "node_modules/@rollup/rollup-linux-x64-gnu": {
          "version": "4.44.0",
          "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
@@ -1161,8 +1411,48 @@
             "x64"
          ],
          "license": "MIT",
+         "optional": true,
          "os": [
             "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-x64-musl": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.0.tgz",
+         "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
+         "cpu": [
+            "x64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-win32-arm64-msvc": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.0.tgz",
+         "integrity": "sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==",
+         "cpu": [
+            "arm64"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
+         ]
+      },
+      "node_modules/@rollup/rollup-win32-ia32-msvc": {
+         "version": "4.44.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.0.tgz",
+         "integrity": "sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==",
+         "cpu": [
+            "ia32"
+         ],
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
          ]
       },
       "node_modules/@rollup/rollup-win32-x64-msvc": {
@@ -1172,7 +1462,6 @@
          "cpu": [
             "x64"
          ],
-         "dev": true,
          "license": "MIT",
          "optional": true,
          "os": [
@@ -1228,7 +1517,6 @@
          "version": "1.0.8",
          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
          "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-         "dev": true,
          "license": "MIT"
       },
       "node_modules/@types/json-schema": {
@@ -2142,6 +2430,19 @@
             "url": "https://github.com/chalk/chalk?sponsor=1"
          }
       },
+      "node_modules/chalk/node_modules/supports-color": {
+         "version": "7.2.0",
+         "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+         "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "has-flag": "^4.0.0"
+         },
+         "engines": {
+            "node": ">=8"
+         }
+      },
       "node_modules/check-more-types": {
          "version": "2.24.0",
          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -2245,28 +2546,6 @@
             "colors": "1.4.0"
          }
       },
-      "node_modules/cli-table3/node_modules/emoji-regex": {
-         "version": "8.0.0",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-         "dev": true,
-         "license": "MIT"
-      },
-      "node_modules/cli-table3/node_modules/string-width": {
-         "version": "4.2.3",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-         "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=8"
-         }
-      },
       "node_modules/cli-truncate": {
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -2282,28 +2561,6 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
-         }
-      },
-      "node_modules/cli-truncate/node_modules/emoji-regex": {
-         "version": "8.0.0",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-         "dev": true,
-         "license": "MIT"
-      },
-      "node_modules/cli-truncate/node_modules/string-width": {
-         "version": "4.2.3",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-         "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=8"
          }
       },
       "node_modules/color-convert": {
@@ -2358,9 +2615,9 @@
          }
       },
       "node_modules/commander": {
-         "version": "4.1.1",
-         "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-         "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+         "version": "6.2.1",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+         "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -2491,32 +2748,6 @@
          },
          "engines": {
             "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-         }
-      },
-      "node_modules/cypress/node_modules/commander": {
-         "version": "6.2.1",
-         "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-         "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-         "dev": true,
-         "license": "MIT",
-         "engines": {
-            "node": ">= 6"
-         }
-      },
-      "node_modules/cypress/node_modules/supports-color": {
-         "version": "8.1.1",
-         "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-         "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "has-flag": "^4.0.0"
-         },
-         "engines": {
-            "node": ">=10"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/supports-color?sponsor=1"
          }
       },
       "node_modules/dashdash": {
@@ -2655,9 +2886,9 @@
          "license": "ISC"
       },
       "node_modules/emoji-regex": {
-         "version": "9.2.2",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-         "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+         "version": "8.0.0",
+         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
          "dev": true,
          "license": "MIT"
       },
@@ -3057,13 +3288,6 @@
             "url": "https://github.com/sindresorhus/execa?sponsor=1"
          }
       },
-      "node_modules/execa/node_modules/signal-exit": {
-         "version": "3.0.7",
-         "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-         "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-         "dev": true,
-         "license": "ISC"
-      },
       "node_modules/executable": {
          "version": "4.1.1",
          "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
@@ -3294,6 +3518,19 @@
             "url": "https://github.com/sponsors/isaacs"
          }
       },
+      "node_modules/foreground-child/node_modules/signal-exit": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+         "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+         "dev": true,
+         "license": "ISC",
+         "engines": {
+            "node": ">=14"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/isaacs"
+         }
+      },
       "node_modules/forever-agent": {
          "version": "0.6.1",
          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3362,7 +3599,6 @@
          "version": "2.3.3",
          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
          "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-         "dev": true,
          "hasInstallScript": true,
          "license": "MIT",
          "optional": true,
@@ -4154,46 +4390,6 @@
             }
          }
       },
-      "node_modules/listr2/node_modules/emoji-regex": {
-         "version": "8.0.0",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-         "dev": true,
-         "license": "MIT"
-      },
-      "node_modules/listr2/node_modules/string-width": {
-         "version": "4.2.3",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-         "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=8"
-         }
-      },
-      "node_modules/listr2/node_modules/wrap-ansi": {
-         "version": "7.0.0",
-         "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-         "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-         },
-         "engines": {
-            "node": ">=10"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-         }
-      },
       "node_modules/locate-path": {
          "version": "6.0.0",
          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4267,13 +4463,6 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
-      "node_modules/log-update/node_modules/emoji-regex": {
-         "version": "8.0.0",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-         "dev": true,
-         "license": "MIT"
-      },
       "node_modules/log-update/node_modules/slice-ansi": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -4290,21 +4479,6 @@
          },
          "funding": {
             "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-         }
-      },
-      "node_modules/log-update/node_modules/string-width": {
-         "version": "4.2.3",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-         "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=8"
          }
       },
       "node_modules/log-update/node_modules/wrap-ansi": {
@@ -5232,13 +5406,6 @@
             "node": ">=8"
          }
       },
-      "node_modules/restore-cursor/node_modules/signal-exit": {
-         "version": "3.0.7",
-         "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-         "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-         "dev": true,
-         "license": "ISC"
-      },
       "node_modules/reusify": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5278,7 +5445,6 @@
          "version": "4.44.0",
          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
          "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "@types/estree": "1.0.8"
@@ -5347,13 +5513,6 @@
          "dependencies": {
             "tslib": "^2.1.0"
          }
-      },
-      "node_modules/rxjs/node_modules/tslib": {
-         "version": "2.8.1",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-         "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-         "dev": true,
-         "license": "0BSD"
       },
       "node_modules/safe-buffer": {
          "version": "5.2.1",
@@ -5505,17 +5664,11 @@
          }
       },
       "node_modules/signal-exit": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-         "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+         "version": "3.0.7",
+         "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+         "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
          "dev": true,
-         "license": "ISC",
-         "engines": {
-            "node": ">=14"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/isaacs"
-         }
+         "license": "ISC"
       },
       "node_modules/slash": {
          "version": "3.0.0",
@@ -5579,21 +5732,18 @@
          }
       },
       "node_modules/string-width": {
-         "version": "5.1.2",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-         "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+         "version": "4.2.3",
+         "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+         "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
          },
          "engines": {
-            "node": ">=12"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/sindresorhus"
+            "node": ">=8"
          }
       },
       "node_modules/string-width-cjs": {
@@ -5610,42 +5760,6 @@
          },
          "engines": {
             "node": ">=8"
-         }
-      },
-      "node_modules/string-width-cjs/node_modules/emoji-regex": {
-         "version": "8.0.0",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-         "dev": true,
-         "license": "MIT"
-      },
-      "node_modules/string-width/node_modules/ansi-regex": {
-         "version": "6.1.0",
-         "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-         "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-         "dev": true,
-         "license": "MIT",
-         "engines": {
-            "node": ">=12"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-         }
-      },
-      "node_modules/string-width/node_modules/strip-ansi": {
-         "version": "7.1.0",
-         "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-         "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "ansi-regex": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=12"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/strip-ansi?sponsor=1"
          }
       },
       "node_modules/strip-ansi": {
@@ -5731,6 +5845,16 @@
             "balanced-match": "^1.0.0"
          }
       },
+      "node_modules/sucrase/node_modules/commander": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+         "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 6"
+         }
+      },
       "node_modules/sucrase/node_modules/glob": {
          "version": "10.4.5",
          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -5769,16 +5893,19 @@
          }
       },
       "node_modules/supports-color": {
-         "version": "7.2.0",
-         "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-         "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+         "version": "8.1.1",
+         "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+         "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "has-flag": "^4.0.0"
          },
          "engines": {
-            "node": ">=8"
+            "node": ">=10"
+         },
+         "funding": {
+            "url": "https://github.com/chalk/supports-color?sponsor=1"
          }
       },
       "node_modules/supports-preserve-symlinks-flag": {
@@ -6011,9 +6138,9 @@
          "license": "Apache-2.0"
       },
       "node_modules/tslib": {
-         "version": "1.14.1",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-         "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+         "version": "2.8.1",
+         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+         "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
          "dev": true,
          "license": "0BSD"
       },
@@ -6032,6 +6159,13 @@
          "peerDependencies": {
             "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
          }
+      },
+      "node_modules/tsutils/node_modules/tslib": {
+         "version": "1.14.1",
+         "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+         "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+         "dev": true,
+         "license": "0BSD"
       },
       "node_modules/tunnel-agent": {
          "version": "0.6.0",
@@ -6586,18 +6720,18 @@
          }
       },
       "node_modules/wrap-ansi": {
-         "version": "8.1.0",
-         "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-         "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+         "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
          },
          "engines": {
-            "node": ">=12"
+            "node": ">=10"
          },
          "funding": {
             "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -6620,70 +6754,6 @@
          },
          "funding": {
             "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-         }
-      },
-      "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-         "version": "8.0.0",
-         "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-         "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-         "dev": true,
-         "license": "MIT"
-      },
-      "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-         "version": "4.2.3",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-         "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=8"
-         }
-      },
-      "node_modules/wrap-ansi/node_modules/ansi-regex": {
-         "version": "6.1.0",
-         "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-         "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-         "dev": true,
-         "license": "MIT",
-         "engines": {
-            "node": ">=12"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-         }
-      },
-      "node_modules/wrap-ansi/node_modules/ansi-styles": {
-         "version": "6.2.1",
-         "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-         "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-         "dev": true,
-         "license": "MIT",
-         "engines": {
-            "node": ">=12"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-         }
-      },
-      "node_modules/wrap-ansi/node_modules/strip-ansi": {
-         "version": "7.1.0",
-         "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-         "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-         "dev": true,
-         "license": "MIT",
-         "dependencies": {
-            "ansi-regex": "^6.0.1"
-         },
-         "engines": {
-            "node": ">=12"
-         },
-         "funding": {
-            "url": "https://github.com/chalk/strip-ansi?sponsor=1"
          }
       },
       "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "@fullcalendar/daygrid": "^6.1.17",
       "@fullcalendar/interaction": "^6.1.17",
       "@fullcalendar/react": "^6.1.17",
-      "@rollup/rollup-linux-x64-gnu": "^4.44.0",
+      "rollup": "^4.44.0",
       "lucide-react": "^0.244.0",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- use the cross‑platform `rollup` package instead of the Linux‑only binary
- regenerate `package-lock.json`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6859d70c08488333b9020ef1fee676d5