### PR TITLE
Improve modal accessibility

### DIFF
--- a/src/components/finanzas/RequestFundsModal.tsx
+++ b/src/components/finanzas/RequestFundsModal.tsx
@@ -1,11 +1,14 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { X } from 'lucide-react';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface Props {
   onClose: () => void;
 }
 
 const RequestFundsModal = ({ onClose }: Props) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
   const [sent, setSent] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -17,7 +20,13 @@ const RequestFundsModal = ({ onClose }: Props) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
-      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-6">
+      <div
+        className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="request-funds-title"
+        ref={dialogRef}
+      >
         <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
           <X size={24} />
         </button>
@@ -28,7 +37,7 @@ const RequestFundsModal = ({ onClose }: Props) => {
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
-            <h3 className="text-xl font-bold">Solicitar Fondos</h3>
+            <h3 id="request-funds-title" className="text-xl font-bold">Solicitar Fondos</h3>
             <div>
               <label className="block text-sm text-gray-400 mb-1">Cantidad</label>
               <input type="number" className="input w-full" required />

--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -1,10 +1,11 @@
-import  { useState, useEffect } from 'react';
+import  { useState, useEffect, useRef } from 'react';
 import { X, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';
 import { Player } from '../../types';
 import { makeOffer, getMinOfferAmount, getMaxOfferAmount } from '../../utils/transferService';
 import { formatCurrency } from '../../utils/helpers';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface OfferModalProps {
   player: Player;
@@ -12,6 +13,8 @@ interface OfferModalProps {
 }
 
 const OfferModal = ({ player, onClose }: OfferModalProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
   const [offerAmount, setOfferAmount] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean>(false);
@@ -98,8 +101,14 @@ const OfferModal = ({ player, onClose }: OfferModalProps) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
-      
-      <div className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6">
+
+      <div
+        className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="offer-modal-title"
+        ref={dialogRef}
+      >
         <button 
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-400 hover:text-white"
@@ -107,7 +116,7 @@ const OfferModal = ({ player, onClose }: OfferModalProps) => {
           <X size={24} />
         </button>
         
-        <h3 className="text-xl font-bold mb-4">Hacer Oferta</h3>
+        <h3 id="offer-modal-title" className="text-xl font-bold mb-4">Hacer Oferta</h3>
         
         {success ? (
           <div className="mb-4 p-3 bg-green-500/20 text-green-400 rounded-lg">

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+
+export default function useFocusTrap(ref: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const previousActive = document.activeElement as HTMLElement | null;
+    const focusableSelectors =
+      'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"]), [contenteditable]';
+    const focusable = Array.from(node.querySelectorAll<HTMLElement>(focusableSelectors));
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    (first || node).focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    node.addEventListener('keydown', handleKeyDown);
+    return () => {
+      node.removeEventListener('keydown', handleKeyDown);
+      if (previousActive && previousActive.focus) previousActive.focus();
+    };
+  }, [ref]);
+}


### PR DESCRIPTION
## Summary
- add focus trapping hook
- use role and aria attributes on offer and funds modals

## Testing
- `npm test` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6859ddba6e7c8333868761072862f10c