### PR TITLE
Improve accessibility of navigation tabs

### DIFF
--- a/src/components/DtMenuTabs.tsx
+++ b/src/components/DtMenuTabs.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useMatch } from 'react-router-dom';
 
 const tabs = [
   { to: '/liga-master/plantilla', label: 'Plantilla' },
@@ -7,18 +7,32 @@ const tabs = [
   { to: '/liga-master/calendario', label: 'Calendario' }
 ];
 
+const TabLink = ({ to, label }: { to: string; label: string }) => {
+  const match = useMatch(to);
+
+  return (
+    <NavLink
+      to={to}
+      role="tab"
+      aria-selected={match ? 'true' : 'false'}
+      className={({ isActive }) =>
+        `pb-2 border-b-2 ${
+          isActive ? 'border-accent' : 'border-transparent'
+        } focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`
+      }
+    >
+      {label}
+    </NavLink>
+  );
+};
+
 const DtMenuTabs = () => (
-  <nav className="flex gap-4 text-sm md:text-base font-semibold border-b border-zinc-700 mb-4">
+  <nav
+    className="flex gap-4 text-sm md:text-base font-semibold border-b border-zinc-700 mb-4"
+    role="tablist"
+  >
     {tabs.map(tab => (
-      <NavLink
-        key={tab.to}
-        to={tab.to}
-        className={({ isActive }) =>
-          `pb-2 border-b-2 ${isActive ? 'border-accent' : 'border-transparent'}`
-        }
-      >
-        {tab.label}
-      </NavLink>
+      <TabLink key={tab.to} to={tab.to} label={tab.label} />
     ))}
   </nav>
 );


### PR DESCRIPTION
## Summary
- add `role="tablist"` to the navigation wrapper
- implement `TabLink` wrapper component to provide `role="tab"` and `aria-selected`
- add visible keyboard focus styles

## Testing
- `npm test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ddba74c48333bd3ba8d9fb720bb3