### PR TITLE
Fix typed onChange handler

### DIFF
--- a/src/components/finanzas/IncomeVsExpensesChart.tsx
+++ b/src/components/finanzas/IncomeVsExpensesChart.tsx
@@ -28,7 +28,9 @@ const IncomeVsExpensesChart: React.FC = () => {
         <h3 className="text-sm font-semibold">Ingresos vs Gastos</h3>
         <select
           value={range}
-          onChange={(e) => setRange(e.target.value as any)}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            setRange(e.target.value as "3m" | "6m" | "12m")
+          }
           className="rounded bg-zinc-700 p-1 text-xs"
         >
           <option value="3m">3 meses</option>


### PR DESCRIPTION
## Summary
- improve typing for `IncomeVsExpensesChart` onChange event

## Testing
- `npm test` *(fails: Parsing error in ESLint)*
- `npm run build` *(fails: react-hot-toast dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ef3dfdec833398f30f58723958e9