### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,21 @@ npm run preview
 ```
 ## Tests
 
-Testing has not been configured yet. Once Cypress or another test framework is
-added, instructions for running tests will be documented here.
+Run the Cypress test suite:
 
+```bash
+npm run test
+```
+
+This command lints the code, builds the project and then runs Cypress in
+headless mode. To open the interactive Cypress UI instead, execute:
+
+```bash
+npx cypress open
+```
+
+Ensure the development server is running on `http://localhost:5173` before
+starting the E2E tests.
 
 ## Admin Panel
 


### PR DESCRIPTION
## Summary
- document how to run Cypress tests via `npm run test`
- add interactive launch option with `npx cypress open`
- state that the dev server must be running on localhost:5173

## Testing
- `npm run test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e2bc0088333ad20b0521d0f5ca9