### PR TITLE
Add Vitest unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
             "tailwindcss": "^3.3.2",
             "typescript": "^5.0.2",
             "typescript-eslint": "^8.34.1",
-            "vite": "^6.3.5"
+            "vite": "^6.3.5",
+            "vitest": "^3.2.4"
          }
       },
       "node_modules/@alloc/quick-lru": {
@@ -1553,6 +1554,16 @@
             "@babel/types": "^7.20.7"
          }
       },
+      "node_modules/@types/chai": {
+         "version": "5.2.2",
+         "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+         "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/deep-eql": "*"
+         }
+      },
       "node_modules/@types/d3-array": {
          "version": "3.2.1",
          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -1614,6 +1625,13 @@
          "version": "3.0.2",
          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
          "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+         "license": "MIT"
+      },
+      "node_modules/@types/deep-eql": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+         "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+         "dev": true,
          "license": "MIT"
       },
       "node_modules/@types/estree": {
@@ -1982,6 +2000,121 @@
             "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
          }
       },
+      "node_modules/@vitest/expect": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+         "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/chai": "^5.2.2",
+            "@vitest/spy": "3.2.4",
+            "@vitest/utils": "3.2.4",
+            "chai": "^5.2.0",
+            "tinyrainbow": "^2.0.0"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
+      "node_modules/@vitest/mocker": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+         "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@vitest/spy": "3.2.4",
+            "estree-walker": "^3.0.3",
+            "magic-string": "^0.30.17"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         },
+         "peerDependencies": {
+            "msw": "^2.4.9",
+            "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+         },
+         "peerDependenciesMeta": {
+            "msw": {
+               "optional": true
+            },
+            "vite": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/@vitest/pretty-format": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+         "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "tinyrainbow": "^2.0.0"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
+      "node_modules/@vitest/runner": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+         "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@vitest/utils": "3.2.4",
+            "pathe": "^2.0.3",
+            "strip-literal": "^3.0.0"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
+      "node_modules/@vitest/snapshot": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+         "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@vitest/pretty-format": "3.2.4",
+            "magic-string": "^0.30.17",
+            "pathe": "^2.0.3"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
+      "node_modules/@vitest/spy": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+         "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "tinyspy": "^4.0.3"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
+      "node_modules/@vitest/utils": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+         "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@vitest/pretty-format": "3.2.4",
+            "loupe": "^3.1.4",
+            "tinyrainbow": "^2.0.0"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
       "node_modules/acorn": {
          "version": "8.15.0",
          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2185,6 +2318,16 @@
          "license": "MIT",
          "engines": {
             "node": ">=0.8"
+         }
+      },
+      "node_modules/assertion-error": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+         "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12"
          }
       },
       "node_modules/astral-regex": {
@@ -2433,6 +2576,16 @@
             "node": "*"
          }
       },
+      "node_modules/cac": {
+         "version": "6.7.14",
+         "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+         "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=8"
+         }
+      },
       "node_modules/cachedir": {
          "version": "2.4.0",
          "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
@@ -2522,6 +2675,23 @@
          "dev": true,
          "license": "Apache-2.0"
       },
+      "node_modules/chai": {
+         "version": "5.2.0",
+         "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+         "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "assertion-error": "^2.0.1",
+            "check-error": "^2.1.1",
+            "deep-eql": "^5.0.1",
+            "loupe": "^3.1.0",
+            "pathval": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=12"
+         }
+      },
       "node_modules/chalk": {
          "version": "4.1.2",
          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2550,6 +2720,16 @@
          },
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/check-error": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+         "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 16"
          }
       },
       "node_modules/check-more-types": {
@@ -3032,6 +3212,16 @@
          "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
          "license": "MIT"
       },
+      "node_modules/deep-eql": {
+         "version": "5.0.2",
+         "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+         "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=6"
+         }
+      },
       "node_modules/deep-is": {
          "version": "0.1.4",
          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3179,6 +3369,13 @@
          "engines": {
             "node": ">= 0.4"
          }
+      },
+      "node_modules/es-module-lexer": {
+         "version": "1.7.0",
+         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+         "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/es-object-atoms": {
          "version": "1.1.1",
@@ -3501,6 +3698,16 @@
             "node": ">=4.0"
          }
       },
+      "node_modules/estree-walker": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+         "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/estree": "^1.0.0"
+         }
+      },
       "node_modules/esutils": {
          "version": "2.0.3",
          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3559,6 +3766,16 @@
          },
          "engines": {
             "node": ">=4"
+         }
+      },
+      "node_modules/expect-type": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+         "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "engines": {
+            "node": ">=12.0.0"
          }
       },
       "node_modules/extend": {
@@ -4796,6 +5013,13 @@
             "loose-envify": "cli.js"
          }
       },
+      "node_modules/loupe": {
+         "version": "3.1.4",
+         "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+         "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/lru-cache": {
          "version": "5.1.1",
          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4813,6 +5037,16 @@
          "license": "ISC",
          "peerDependencies": {
             "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+         }
+      },
+      "node_modules/magic-string": {
+         "version": "0.30.17",
+         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+         "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@jridgewell/sourcemap-codec": "^1.5.0"
          }
       },
       "node_modules/math-intrinsics": {
@@ -5235,6 +5469,23 @@
          "license": "MIT",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/pathe": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+         "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/pathval": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+         "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 14.16"
          }
       },
       "node_modules/pend": {
@@ -6046,6 +6297,13 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/siginfo": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+         "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+         "dev": true,
+         "license": "ISC"
+      },
       "node_modules/signal-exit": {
          "version": "3.0.7",
          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6113,6 +6371,20 @@
          "engines": {
             "node": ">=0.10.0"
          }
+      },
+      "node_modules/stackback": {
+         "version": "0.0.2",
+         "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+         "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/std-env": {
+         "version": "3.9.0",
+         "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+         "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/string-width": {
          "version": "4.2.3",
@@ -6194,6 +6466,26 @@
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
          }
+      },
+      "node_modules/strip-literal": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+         "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "js-tokens": "^9.0.1"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/antfu"
+         }
+      },
+      "node_modules/strip-literal/node_modules/js-tokens": {
+         "version": "9.0.1",
+         "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+         "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/sucrase": {
          "version": "3.35.0",
@@ -6395,6 +6687,20 @@
          "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
          "license": "MIT"
       },
+      "node_modules/tinybench": {
+         "version": "2.9.0",
+         "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+         "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/tinyexec": {
+         "version": "0.3.2",
+         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+         "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/tinyglobby": {
          "version": "0.2.14",
          "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -6438,6 +6744,36 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/jonschlinkert"
+         }
+      },
+      "node_modules/tinypool": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+         "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": "^18.0.0 || >=20.0.0"
+         }
+      },
+      "node_modules/tinyrainbow": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+         "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=14.0.0"
+         }
+      },
+      "node_modules/tinyspy": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+         "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=14.0.0"
          }
       },
       "node_modules/tldts": {
@@ -7076,6 +7412,29 @@
             }
          }
       },
+      "node_modules/vite-node": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+         "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "cac": "^6.7.14",
+            "debug": "^4.4.1",
+            "es-module-lexer": "^1.7.0",
+            "pathe": "^2.0.3",
+            "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+         },
+         "bin": {
+            "vite-node": "vite-node.mjs"
+         },
+         "engines": {
+            "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         }
+      },
       "node_modules/vite/node_modules/fdir": {
          "version": "6.4.6",
          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -7104,6 +7463,92 @@
             "url": "https://github.com/sponsors/jonschlinkert"
          }
       },
+      "node_modules/vitest": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+         "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/chai": "^5.2.2",
+            "@vitest/expect": "3.2.4",
+            "@vitest/mocker": "3.2.4",
+            "@vitest/pretty-format": "^3.2.4",
+            "@vitest/runner": "3.2.4",
+            "@vitest/snapshot": "3.2.4",
+            "@vitest/spy": "3.2.4",
+            "@vitest/utils": "3.2.4",
+            "chai": "^5.2.0",
+            "debug": "^4.4.1",
+            "expect-type": "^1.2.1",
+            "magic-string": "^0.30.17",
+            "pathe": "^2.0.3",
+            "picomatch": "^4.0.2",
+            "std-env": "^3.9.0",
+            "tinybench": "^2.9.0",
+            "tinyexec": "^0.3.2",
+            "tinyglobby": "^0.2.14",
+            "tinypool": "^1.1.1",
+            "tinyrainbow": "^2.0.0",
+            "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+            "vite-node": "3.2.4",
+            "why-is-node-running": "^2.3.0"
+         },
+         "bin": {
+            "vitest": "vitest.mjs"
+         },
+         "engines": {
+            "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+         },
+         "funding": {
+            "url": "https://opencollective.com/vitest"
+         },
+         "peerDependencies": {
+            "@edge-runtime/vm": "*",
+            "@types/debug": "^4.1.12",
+            "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+            "@vitest/browser": "3.2.4",
+            "@vitest/ui": "3.2.4",
+            "happy-dom": "*",
+            "jsdom": "*"
+         },
+         "peerDependenciesMeta": {
+            "@edge-runtime/vm": {
+               "optional": true
+            },
+            "@types/debug": {
+               "optional": true
+            },
+            "@types/node": {
+               "optional": true
+            },
+            "@vitest/browser": {
+               "optional": true
+            },
+            "@vitest/ui": {
+               "optional": true
+            },
+            "happy-dom": {
+               "optional": true
+            },
+            "jsdom": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/vitest/node_modules/picomatch": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+         "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/jonschlinkert"
+         }
+      },
       "node_modules/which": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7118,6 +7563,23 @@
          },
          "engines": {
             "node": ">= 8"
+         }
+      },
+      "node_modules/why-is-node-running": {
+         "version": "2.3.0",
+         "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+         "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "siginfo": "^2.0.0",
+            "stackback": "0.0.2"
+         },
+         "bin": {
+            "why-is-node-running": "cli.js"
+         },
+         "engines": {
+            "node": ">=8"
          }
       },
       "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
       "build": "tsc && vite build",
       "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
       "preview": "vite preview",
-      "cypress:open": "cypress open",
-      "test": "npm run lint && npm run build && cypress run"
+     "cypress:open": "cypress open",
+     "test:unit": "vitest run",
+     "test": "npm run lint && npm run build && npm run test:unit && cypress run"
    },
    "dependencies": {
       "@fullcalendar/core": "^6.1.17",
@@ -43,6 +44,7 @@
       "tailwindcss": "^3.3.2",
       "typescript": "^5.0.2",
       "typescript-eslint": "^8.34.1",
-      "vite": "^6.3.5"
+      "vite": "^6.3.5",
+      "vitest": "^3.2.4"
    }
 }

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,13 +1,32 @@
+import { test, expect } from 'vitest';
 import { getMiniTable, calcStreak, getTopPerformer, goalsDiff, possessionDiff, yellowDiff } from '../src/utils/helpers.ts';
 import { leagueStandings, tournaments } from '../src/data/mockData.ts';
 
-const mini = getMiniTable('club1', leagueStandings);
-console.log('mini', mini.length === 5);
-
 const fixtures = tournaments.find(t => t.id === 'tournament1')?.matches ?? [];
-console.log('streak', calcStreak('club1', fixtures).length <= 5);
 
-console.log('performer', getTopPerformer('club1') !== null);
-console.log('goals', typeof goalsDiff('club1').diff === 'number');
-console.log('possession', typeof possessionDiff('club1').diff === 'number');
-console.log('cards', typeof yellowDiff('club1').diff === 'number');
+test('getMiniTable returns 5 rows', () => {
+  const mini = getMiniTable('club1', leagueStandings);
+  expect(mini).toHaveLength(5);
+});
+
+test('calcStreak returns at most 5 entries', () => {
+  const streak = calcStreak('club1', fixtures);
+  expect(streak.length).toBeLessThanOrEqual(5);
+});
+
+test('getTopPerformer returns a performer', () => {
+  const performer = getTopPerformer('club1');
+  expect(performer).not.toBeNull();
+});
+
+test('goalsDiff returns numeric diff', () => {
+  expect(typeof goalsDiff('club1').diff).toBe('number');
+});
+
+test('possessionDiff returns numeric diff', () => {
+  expect(typeof possessionDiff('club1').diff).toBe('number');
+});
+
+test('yellowDiff returns numeric diff', () => {
+  expect(typeof yellowDiff('club1').diff).toBe('number');
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- introduce Vitest for unit tests
- rewrite `helpers.test.ts` to use `test`/`expect`
- run unit tests with `npm test`

## Testing
- `npm run test:unit`
- `npm test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e2cc3688333a3ebc97a56ace2d5