### PR TITLE
Add missing routes and lazy imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,20 @@ const Tacticas = lazy(() => import("./pages/Tacticas"));
 const Finanzas = lazy(() => import("./pages/Finanzas"));
 const Calendario = lazy(() => import("./pages/Calendario"));
 
+const Login = lazy(() => import("./pages/Login"));
+const Register = lazy(() => import("./pages/Register"));
+const UserPanel = lazy(() => import("./pages/UserPanel"));
+
+const Tournaments = lazy(() => import("./pages/Tournaments"));
+const TournamentDetail = lazy(() => import("./pages/TournamentDetail"));
+
+const Blog = lazy(() => import("./pages/Blog"));
+const BlogPost = lazy(() => import("./pages/BlogPost"));
+
+const Gallery = lazy(() => import("./pages/Gallery"));
+const Store = lazy(() => import("./pages/Store"));
+const Help = lazy(() => import("./pages/Help"));
+
 function App() {
   return (
     <div className="min-h-screen bg-[#18181f] text-white">
@@ -21,11 +35,31 @@ function App() {
         <Routes>
           <Route element={<Layout />}>
             <Route index element={<Home />} />
+
+            <Route path="login" element={<Login />} />
+            <Route path="registro" element={<Register />} />
+            <Route path="usuario" element={<UserPanel />} />
+
+            <Route path="torneos">
+              <Route index element={<Tournaments />} />
+              <Route path=":tournamentName" element={<TournamentDetail />} />
+            </Route>
+
+            <Route path="blog">
+              <Route index element={<Blog />} />
+              <Route path=":slug" element={<BlogPost />} />
+            </Route>
+
+            <Route path="galeria" element={<Gallery />} />
+            <Route path="tienda" element={<Store />} />
+            <Route path="ayuda" element={<Help />} />
+
             <Route path="liga-master" element={<LigaMaster />} />
             <Route path="liga-master/plantilla" element={<Plantilla />} />
             <Route path="liga-master/tacticas" element={<Tacticas />} />
             <Route path="liga-master/finanzas" element={<Finanzas />} />
             <Route path="liga-master/calendario" element={<Calendario />} />
+
             <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>


### PR DESCRIPTION
## Summary
- lazily import the rest of the page components
- register Login, Register, UserPanel routes
- add routes for tournaments, blog, gallery, store and help
- keep Liga Master routes and NotFound fallback

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:unit`
- `npm run test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e263670833387ba2071c7c42633