### PR TITLE
Fix build dependencies and linter warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
             "@fullcalendar/daygrid": "^6.1.17",
             "@fullcalendar/interaction": "^6.1.17",
             "@fullcalendar/react": "^6.1.17",
+            "framer-motion": "^12.19.1",
             "lucide-react": "^0.244.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
+            "react-ga4": "^2.1.0",
             "react-hot-toast": "^2.5.2",
             "react-router-dom": "^6.14.0",
             "recharts": "^3.0.0",
@@ -4049,6 +4051,33 @@
             "url": "https://github.com/sponsors/rawify"
          }
       },
+      "node_modules/framer-motion": {
+         "version": "12.19.1",
+         "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.1.tgz",
+         "integrity": "sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==",
+         "license": "MIT",
+         "dependencies": {
+            "motion-dom": "^12.19.0",
+            "motion-utils": "^12.19.0",
+            "tslib": "^2.4.0"
+         },
+         "peerDependencies": {
+            "@emotion/is-prop-valid": "*",
+            "react": "^18.0.0 || ^19.0.0",
+            "react-dom": "^18.0.0 || ^19.0.0"
+         },
+         "peerDependenciesMeta": {
+            "@emotion/is-prop-valid": {
+               "optional": true
+            },
+            "react": {
+               "optional": true
+            },
+            "react-dom": {
+               "optional": true
+            }
+         }
+      },
       "node_modules/fs-extra": {
          "version": "9.1.0",
          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -5156,6 +5185,21 @@
             "node": ">=16 || 14 >=14.17"
          }
       },
+      "node_modules/motion-dom": {
+         "version": "12.19.0",
+         "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+         "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+         "license": "MIT",
+         "dependencies": {
+            "motion-utils": "^12.19.0"
+         }
+      },
+      "node_modules/motion-utils": {
+         "version": "12.19.0",
+         "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+         "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+         "license": "MIT"
+      },
       "node_modules/ms": {
          "version": "2.1.3",
          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5824,6 +5868,12 @@
          "peerDependencies": {
             "react": "^18.3.1"
          }
+      },
+      "node_modules/react-ga4": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+         "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
+         "license": "MIT"
       },
       "node_modules/react-hot-toast": {
          "version": "2.5.2",
@@ -6866,7 +6916,6 @@
          "version": "2.8.1",
          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-         "dev": true,
          "license": "0BSD"
       },
       "node_modules/tsutils": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
       "react-router-dom": "^6.14.0",
       "recharts": "^3.0.0",
       "rollup": "^4.44.0",
-      "zustand": "^4.3.8"
+     "zustand": "^4.3.8",
+     "framer-motion": "^12.19.1",
+     "react-ga4": "^2.1.0"
    },
    "devDependencies": {
       "@eslint/js": "^9.27.0",

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -11,7 +11,6 @@ import {
   Trophy,
   Calendar,
   Inbox,
-  ChevronRight,
   Sun,
   Moon,
 } from "lucide-react";
@@ -19,7 +18,6 @@ import { motion } from "framer-motion";
 import toast from "react-hot-toast";
 import ReactGA from "react-ga4";
 
-import StatsCard from "../components/common/StatsCard";
 import Card from "../components/common/Card";
 import DtMenuTabs from "../components/DtMenuTabs";
 import CountdownBar from "../components/common/CountdownBar";


### PR DESCRIPTION
## Summary
- remove unused imports in `DtDashboard`
- add `framer-motion` and `react-ga4` dependencies

## Testing
- `npx eslint "src/**/*.{ts,tsx}" --report-unused-disable-directives --max-warnings 0`
- `npm run build`
- `npm run test:unit`
- `npm run test` *(fails: Cypress binary missing)*


------
https://chatgpt.com/codex/tasks/task_e_685aa7fe20e48333aabb6e42c41c4990