### PR TITLE
Fix lint warnings and update DtDashboard dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,16 @@
          "name": "la-virtual-zone",
          "version": "0.1.0",
          "dependencies": {
+            "@dnd-kit/core": "^6.3.1",
+            "@dnd-kit/sortable": "^10.0.0",
+            "@dnd-kit/utilities": "^3.2.2",
             "@fullcalendar/core": "^6.1.17",
             "@fullcalendar/daygrid": "^6.1.17",
             "@fullcalendar/interaction": "^6.1.17",
             "@fullcalendar/react": "^6.1.17",
             "framer-motion": "^12.19.1",
+            "jspdf": "^3.0.1",
+            "jspdf-autotable": "^5.0.2",
             "lucide-react": "^0.244.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
@@ -316,6 +321,15 @@
             "@babel/core": "^7.0.0-0"
          }
       },
+      "node_modules/@babel/runtime": {
+         "version": "7.27.6",
+         "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+         "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
       "node_modules/@babel/template": {
          "version": "7.27.2",
          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -423,6 +437,59 @@
          "license": "MIT",
          "dependencies": {
             "ms": "^2.1.1"
+         }
+      },
+      "node_modules/@dnd-kit/accessibility": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+         "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+         "license": "MIT",
+         "dependencies": {
+            "tslib": "^2.0.0"
+         },
+         "peerDependencies": {
+            "react": ">=16.8.0"
+         }
+      },
+      "node_modules/@dnd-kit/core": {
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+         "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+         "license": "MIT",
+         "dependencies": {
+            "@dnd-kit/accessibility": "^3.1.1",
+            "@dnd-kit/utilities": "^3.2.2",
+            "tslib": "^2.0.0"
+         },
+         "peerDependencies": {
+            "react": ">=16.8.0",
+            "react-dom": ">=16.8.0"
+         }
+      },
+      "node_modules/@dnd-kit/sortable": {
+         "version": "10.0.0",
+         "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+         "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+         "license": "MIT",
+         "dependencies": {
+            "@dnd-kit/utilities": "^3.2.2",
+            "tslib": "^2.0.0"
+         },
+         "peerDependencies": {
+            "@dnd-kit/core": "^6.3.0",
+            "react": ">=16.8.0"
+         }
+      },
+      "node_modules/@dnd-kit/utilities": {
+         "version": "3.2.2",
+         "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+         "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+         "license": "MIT",
+         "dependencies": {
+            "tslib": "^2.0.0"
+         },
+         "peerDependencies": {
+            "react": ">=16.8.0"
          }
       },
       "node_modules/@esbuild/aix-ppc64": {
@@ -1666,6 +1733,13 @@
          "devOptional": true,
          "license": "MIT"
       },
+      "node_modules/@types/raf": {
+         "version": "3.4.3",
+         "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+         "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+         "license": "MIT",
+         "optional": true
+      },
       "node_modules/@types/react": {
          "version": "18.3.23",
          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
@@ -1707,6 +1781,13 @@
          "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/@types/trusted-types": {
+         "version": "2.0.7",
+         "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+         "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+         "license": "MIT",
+         "optional": true
       },
       "node_modules/@types/use-sync-external-store": {
          "version": "0.0.6",
@@ -2366,6 +2447,18 @@
             "node": ">= 4.0.0"
          }
       },
+      "node_modules/atob": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+         "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+         "license": "(MIT OR Apache-2.0)",
+         "bin": {
+            "atob": "bin/atob.js"
+         },
+         "engines": {
+            "node": ">= 4.5.0"
+         }
+      },
       "node_modules/autoprefixer": {
          "version": "10.4.21",
          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2427,6 +2520,16 @@
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/base64-arraybuffer": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+         "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+         "license": "MIT",
+         "optional": true,
+         "engines": {
+            "node": ">= 0.6.0"
+         }
       },
       "node_modules/base64-js": {
          "version": "1.5.1",
@@ -2541,6 +2644,18 @@
          },
          "engines": {
             "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+         }
+      },
+      "node_modules/btoa": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+         "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+         "license": "(MIT OR Apache-2.0)",
+         "bin": {
+            "btoa": "bin/btoa.js"
+         },
+         "engines": {
+            "node": ">= 0.4.0"
          }
       },
       "node_modules/buffer": {
@@ -2669,6 +2784,26 @@
             }
          ],
          "license": "CC-BY-4.0"
+      },
+      "node_modules/canvg": {
+         "version": "3.0.11",
+         "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+         "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "@babel/runtime": "^7.12.5",
+            "@types/raf": "^3.4.0",
+            "core-js": "^3.8.3",
+            "raf": "^3.4.1",
+            "regenerator-runtime": "^0.13.7",
+            "rgbcolor": "^1.0.1",
+            "stackblur-canvas": "^2.0.0",
+            "svg-pathdata": "^6.0.3"
+         },
+         "engines": {
+            "node": ">=10.0.0"
+         }
       },
       "node_modules/caseless": {
          "version": "0.12.0",
@@ -2948,6 +3083,18 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/core-js": {
+         "version": "3.43.0",
+         "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+         "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+         "hasInstallScript": true,
+         "license": "MIT",
+         "optional": true,
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/core-js"
+         }
+      },
       "node_modules/core-util-is": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2968,6 +3115,16 @@
          },
          "engines": {
             "node": ">= 8"
+         }
+      },
+      "node_modules/css-line-break": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+         "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "utrie": "^1.0.2"
          }
       },
       "node_modules/cssesc": {
@@ -3279,6 +3436,16 @@
          },
          "engines": {
             "node": ">=6.0.0"
+         }
+      },
+      "node_modules/dompurify": {
+         "version": "3.2.6",
+         "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+         "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+         "license": "(MPL-2.0 OR Apache-2.0)",
+         "optional": true,
+         "optionalDependencies": {
+            "@types/trusted-types": "^2.0.7"
          }
       },
       "node_modules/dunder-proto": {
@@ -3889,6 +4056,12 @@
             "pend": "~1.2.0"
          }
       },
+      "node_modules/fflate": {
+         "version": "0.8.2",
+         "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+         "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+         "license": "MIT"
+      },
       "node_modules/figures": {
          "version": "3.2.0",
          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -4413,6 +4586,20 @@
             "node": ">= 0.4"
          }
       },
+      "node_modules/html2canvas": {
+         "version": "1.4.1",
+         "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+         "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "css-line-break": "^2.1.0",
+            "text-segmentation": "^1.0.3"
+         },
+         "engines": {
+            "node": ">=8.0.0"
+         }
+      },
       "node_modules/http-signature": {
          "version": "1.4.0",
          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
@@ -4824,6 +5011,33 @@
          },
          "optionalDependencies": {
             "graceful-fs": "^4.1.6"
+         }
+      },
+      "node_modules/jspdf": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+         "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+         "license": "MIT",
+         "dependencies": {
+            "@babel/runtime": "^7.26.7",
+            "atob": "^2.1.2",
+            "btoa": "^1.2.1",
+            "fflate": "^0.8.1"
+         },
+         "optionalDependencies": {
+            "canvg": "^3.0.11",
+            "core-js": "^3.6.0",
+            "dompurify": "^3.2.4",
+            "html2canvas": "^1.0.0-rc.5"
+         }
+      },
+      "node_modules/jspdf-autotable": {
+         "version": "5.0.2",
+         "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+         "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+         "license": "MIT",
+         "peerDependencies": {
+            "jspdf": "^2 || ^3"
          }
       },
       "node_modules/jsprim": {
@@ -5543,7 +5757,7 @@
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
          "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-         "dev": true,
+         "devOptional": true,
          "license": "MIT"
       },
       "node_modules/picocolors": {
@@ -5844,6 +6058,16 @@
          ],
          "license": "MIT"
       },
+      "node_modules/raf": {
+         "version": "3.4.1",
+         "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+         "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "performance-now": "^2.1.0"
+         }
+      },
       "node_modules/react": {
          "version": "18.3.1",
          "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -6029,6 +6253,13 @@
             "redux": "^5.0.0"
          }
       },
+      "node_modules/regenerator-runtime": {
+         "version": "0.13.11",
+         "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+         "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+         "license": "MIT",
+         "optional": true
+      },
       "node_modules/request-progress": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -6107,6 +6338,16 @@
          "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/rgbcolor": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+         "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+         "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+         "optional": true,
+         "engines": {
+            "node": ">= 0.8.15"
+         }
       },
       "node_modules/rimraf": {
          "version": "3.0.2",
@@ -6429,6 +6670,16 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/stackblur-canvas": {
+         "version": "2.7.0",
+         "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+         "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+         "license": "MIT",
+         "optional": true,
+         "engines": {
+            "node": ">=0.1.14"
+         }
+      },
       "node_modules/std-env": {
          "version": "3.9.0",
          "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -6646,6 +6897,16 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/svg-pathdata": {
+         "version": "6.0.3",
+         "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+         "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+         "license": "MIT",
+         "optional": true,
+         "engines": {
+            "node": ">=12.0.0"
+         }
+      },
       "node_modules/tailwindcss": {
          "version": "3.4.17",
          "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -6682,6 +6943,16 @@
          },
          "engines": {
             "node": ">=14.0.0"
+         }
+      },
+      "node_modules/text-segmentation": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+         "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "utrie": "^1.0.2"
          }
       },
       "node_modules/text-table": {
@@ -7338,6 +7609,16 @@
          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/utrie": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+         "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "base64-arraybuffer": "^1.0.2"
+         }
       },
       "node_modules/uuid": {
          "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,16 @@
       "test": "npm run lint && npm run build && npm run test:unit && cypress run"
    },
    "dependencies": {
+      "@dnd-kit/core": "^6.3.1",
+      "@dnd-kit/sortable": "^10.0.0",
+      "@dnd-kit/utilities": "^3.2.2",
       "@fullcalendar/core": "^6.1.17",
       "@fullcalendar/daygrid": "^6.1.17",
       "@fullcalendar/interaction": "^6.1.17",
       "@fullcalendar/react": "^6.1.17",
       "framer-motion": "^12.19.1",
+      "jspdf": "^3.0.1",
+      "jspdf-autotable": "^5.0.2",
       "lucide-react": "^0.244.0",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- clean up unused imports in `DtDashboard`
- avoid calling hooks conditionally
- add `loading` fallback and default values
- switch to `@ts-expect-error`
- install missing packages for pdf generation and drag-and-drop

## Testing
- `npm run lint`
- `npm test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af35dd9548333b87621daea2c0447