### PR TITLE
Fix import spacing and run project build

### DIFF
--- a/src/components/Home/FeaturedTournaments.tsx
+++ b/src/components/Home/FeaturedTournaments.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Trophy, Calendar, Award, Users } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate } from '../../utils/helpers';

--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Users, TrendingUp, Trophy } from 'lucide-react';
 
 const HeroSection = () => {

--- a/src/components/Home/LatestNews.tsx
+++ b/src/components/Home/LatestNews.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate, formatNewsType, getNewsTypeColor } from '../../utils/helpers';

--- a/src/components/Home/LeagueStandings.tsx
+++ b/src/components/Home/LeagueStandings.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 

--- a/src/components/Home/UpcomingMatches.tsx
+++ b/src/components/Home/UpcomingMatches.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate, formatTime } from '../../utils/helpers';

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { 
   Trophy, 
   Mail, 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import  { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import  { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Menu, X, User, LogOut, ChevronDown, Settings, Trophy, Shield, ShoppingCart } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { LogIn, User, Lock } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { User, Mail, Lock, CheckCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';

--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -1,4 +1,4 @@
-import  { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { X, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,4 +1,4 @@
-import  {
+import {
   Club,
   Player,
   Tournament,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import  { StrictMode } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Calendar, Search, ChevronRight, FileText } from 'lucide-react';

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Calendar, ChevronLeft, MessageSquare, Share, ThumbsUp, ArrowRight } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
 import Comments from '../components/comments/Comments';

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { 
   ChevronLeft, 

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Image, Search, Calendar, User, Tag, Plus } from 'lucide-react';
 

--- a/src/pages/HallOfFame.tsx
+++ b/src/pages/HallOfFame.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Award, ChevronLeft, Star, Shield, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Mail, ChevronDown, ChevronUp, AlertCircle, Calendar, ShoppingBag, Trophy, FileText, Info } from 'lucide-react';
 

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import DtDashboard from './DtDashboard';
 import { useAuthStore } from '../store/authStore';
 import { 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { LogIn, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Home } from 'lucide-react';
 
 const NotFound = () => {

--- a/src/pages/Rankings.tsx
+++ b/src/pages/Rankings.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronLeft } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { User, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import { Search, AlertCircle } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/TestMarket.tsx
+++ b/src/pages/TestMarket.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { User, CheckCircle, X, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 

--- a/src/pages/TournamentDetail.tsx
+++ b/src/pages/TournamentDetail.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, ChevronLeft, Image, ArrowRight, Star } from 'lucide-react';

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -1,4 +1,4 @@
-import  { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, Calendar, Users, ChevronRight, Filter } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,4 +1,4 @@
-import  { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';


### PR DESCRIPTION
## Summary
- cleanup extra space in import statements across the app
- ensure the React project builds and unit tests run

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af58fae848333b381cb4b47bd681b