### PR TITLE
Fix DT dashboard types

### DIFF
--- a/src/components/common/PageHeader.tsx
+++ b/src/components/common/PageHeader.tsx
@@ -3,9 +3,10 @@ interface PageHeaderProps {
   subtitle?: string;
   image?: string;
   breadcrumb?: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-const PageHeader = ({ title, subtitle, image, breadcrumb }: PageHeaderProps) => {
+const PageHeader = ({ title, subtitle, image, breadcrumb, children }: PageHeaderProps) => {
   return (
     <div className="relative bg-gray-900 py-16 md:py-24 overflow-hidden">
       {image && (
@@ -24,12 +25,13 @@ const PageHeader = ({ title, subtitle, image, breadcrumb }: PageHeaderProps) => 
         <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold font-display neon-text-blue">
           {title}
         </h1>
-        
+
         {subtitle && (
           <p className="text-gray-300 mt-4 max-w-3xl">
             {subtitle}
           </p>
         )}
+        {children}
       </div>
     </div>
   );

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -687,8 +687,10 @@ export const newsItems: NewsItem[] = [
     title: 'Comienza la Liga Master 2025',
     content: 'La temporada 2025 de La Virtual Zone ha arrancado oficialmente. 10 clubes compiten por el título en una liga que promete emociones hasta la última jornada.',
     type: 'announcement',
+    category: 'Anuncios',
     imageUrl: 'https://images.unsplash.com/photo-1511447333015-45b65e60f6d5?w=1600&auto=format&fit=crop&fm=webp&ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw2fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
     publishDate: '2025-01-15',
+    date: '2025-01-15',
     author: 'Admin',
     featured: true
   },
@@ -697,8 +699,10 @@ export const newsItems: NewsItem[] = [
     title: 'El mercado de fichajes está abierto',
     content: 'Desde hoy los clubes pueden realizar ofertas por jugadores de otros equipos. El mercado permanecerá abierto hasta el 15 de febrero.',
     type: 'announcement',
+    category: 'Anuncios',
     imageUrl: 'https://images.unsplash.com/photo-1494178270175-e96de2971df9?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHw0fHxlc3BvcnRzJTIwZ2FtaW5nJTIwdG91cm5hbWVudCUyMGRhcmslMjBuZW9ufGVufDB8fHx8MTc0NzE3MzUxNHww&ixlib=rb-4.1.0',
     publishDate: '2025-01-16',
+    date: '2025-01-16',
     author: 'Admin',
     featured: false
   },
@@ -707,7 +711,9 @@ export const newsItems: NewsItem[] = [
     title: 'Diego López ficha por Rayo Digital FC',
     content: 'El delantero ha firmado un contrato de 3 temporadas tras el pago de 8.5 millones. "Estoy emocionado por este nuevo reto", declaró el jugador.',
     type: 'transfer',
+    category: 'Fichajes',
     publishDate: '2025-01-05',
+    date: '2025-01-05',
     author: 'Admin',
     clubId: 'club1',
     playerId: 'player21',
@@ -718,7 +724,9 @@ export const newsItems: NewsItem[] = [
     title: 'Rayo Digital vence en el derbi',
     content: 'Los rojiblancos se impusieron 3-1 a Atlético Pixelado en un partido vibrante. Diego López, nuevo fichaje, marcó dos goles.',
     type: 'result',
+    category: 'Resultados',
     publishDate: '2025-01-20',
+    date: '2025-01-20',
     author: 'Admin',
     clubId: 'club1',
     tournamentId: 'tournament1',
@@ -729,7 +737,9 @@ export const newsItems: NewsItem[] = [
     title: 'Rumor: Neón FC tras una estrella de Binary Strikers',
     content: 'Según fuentes cercanas al club, los neonistas estarían dispuestos a pagar hasta 15 millones por un centrocampista de los Strikers.',
     type: 'rumor',
+    category: 'Rumores',
     publishDate: '2025-01-22',
+    date: '2025-01-22',
     author: 'Admin',
     clubId: 'club4',
     featured: false
@@ -739,7 +749,9 @@ export const newsItems: NewsItem[] = [
     title: 'DT de Glitchers 404: "Vamos a por el título"',
     content: '"Este año tenemos un equipo para luchar arriba. No renunciamos a nada y vamos partido a partido", declaró el técnico tras la victoria 2-0 ante Connection FC.',
     type: 'statement',
+    category: 'Declaraciones',
     publishDate: '2025-01-23',
+    date: '2025-01-23',
     author: 'Admin',
     clubId: 'club6',
     featured: false
@@ -1043,8 +1055,8 @@ export const dtMarket: DtMarket = { open: true };
 export const dtObjectives: DtObjectives = { position: 50, fairplay: 70 };
 
 export const dtTasks: DtTask[] = [
-  { id: 'task1', text: 'Actualizar tácticas' },
-  { id: 'task2', text: 'Revisar informe médico' }
+  { id: 'task1', text: 'Actualizar tácticas', done: false },
+  { id: 'task2', text: 'Revisar informe médico', done: false }
 ];
 
 export const dtEvents: DtEvent[] = [
@@ -1054,4 +1066,28 @@ export const dtEvents: DtEvent[] = [
 
 export const dtNews: NewsItem[] = newsItems.slice(0, 5);
 export const dtPositions: Standing[] = leagueStandings;
+
+export const dtRankings: DtRanking[] = [
+  {
+    id: 'r1',
+    username: 'coach',
+    clubName: clubs[0].name,
+    clubLogo: clubs[0].logo,
+    elo: 1500
+  },
+  {
+    id: 'r2',
+    username: 'DT Neon',
+    clubName: clubs[3].name,
+    clubLogo: clubs[3].logo,
+    elo: 1480
+  },
+  {
+    id: 'r3',
+    username: 'DT Pixel',
+    clubName: clubs[1].name,
+    clubLogo: clubs[1].logo,
+    elo: 1450
+  }
+];
  

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -66,6 +66,7 @@ import LatestNews from "./dt-dashboard/LatestNews";
 import QuickActions from "./dt-dashboard/QuickActions";
 import PageHeader from "../components/common/PageHeader";
 import DashboardSkeleton from "../components/common/DashboardSkeleton";
+import { DtRanking } from "../types";
 
 import { useAuthStore } from "../store/authStore";
 import { useDataStore } from "../store/dataStore";
@@ -94,6 +95,16 @@ interface ChatMsg {
   text: string;
   ts: number;
 }
+
+type RightModuleId =
+  | "chat"
+  | "anuncios"
+  | "mercado"
+  | "logros"
+  | "ranking"
+  | "noticias"
+  | "recordatorios"
+  | "acciones";
 
 /* ---------- componente principal ---------- */
 const DtDashboard: React.FC = () => {
@@ -155,8 +166,8 @@ const DtDashboard: React.FC = () => {
     .slice(-5)
     .map((m) => ({
       name: `J${m.round}`,
-      GF: m.homeTeam === club.name ? m.homeGoals : m.awayGoals,
-      GC: m.homeTeam === club.name ? m.awayGoals : m.homeGoals,
+      GF: m.homeTeam === club.name ? m.homeScore ?? 0 : m.awayScore ?? 0,
+      GC: m.homeTeam === club.name ? m.awayScore ?? 0 : m.homeScore ?? 0,
     }));
 
   /* ===== logros ===== */
@@ -188,9 +199,10 @@ const DtDashboard: React.FC = () => {
 
   const filteredNews = useMemo(
     () =>
-      (news ?? []).filter(
-        (n) => cat === "Todas" || n.category.toLowerCase() === cat.toLowerCase()
-      ),
+      (news ?? []).filter((n) => {
+        const category = n.category ?? n.type;
+        return cat === "Todas" || category.toLowerCase() === cat.toLowerCase();
+      }),
     [news, cat]
   );
   const visibleNews = filteredNews.slice(0, newsCount);
@@ -216,7 +228,7 @@ const DtDashboard: React.FC = () => {
     if (!text.trim()) return;
     const msg: ChatMsg = {
       id: crypto.randomUUID(),
-      user: user.username,
+      user: user?.username ?? 'Anon',
       text: text.trim(),
       ts: Date.now(),
     };
@@ -347,7 +359,7 @@ const DtDashboard: React.FC = () => {
                 </tr>
               </thead>
               <tbody>
-                {dtRankings.slice(0, 10).map((d, idx) => (
+                {dtRankings.slice(0, 10).map((d: DtRanking, idx: number) => (
                   <tr key={d.id} className="border-t border-white/10">
                     <td>{idx + 1}</td>
                     <td>{d.username}</td>
@@ -405,7 +417,7 @@ const DtDashboard: React.FC = () => {
                 <li key={n.id} className="rounded bg-white/5 p-2">
                   <p className="font-medium">{n.title}</p>
                   <p className="text-xs text-gray-400">
-                    {formatDate(n.date)} • {n.category}
+                    {formatDate(n.date ?? n.publishDate)} • {n.category ?? n.type}
                   </p>
                 </li>
               ))}
@@ -466,8 +478,6 @@ const DtDashboard: React.FC = () => {
       render: () => <QuickActions marketOpen={marketOpen} />,
     },
   ] as const;
-
-  type RightModuleId = (typeof RIGHT_MODULES)[number]["id"];
 
   /* layout */
   const DEFAULT_LAYOUT: LayoutItem[] = RIGHT_MODULES.map((m) => ({
@@ -803,7 +813,7 @@ interface RightColumnProps {
   setLayout: (l: LayoutItem[]) => void;
   sensors: ReturnType<typeof useSensors>;
   handleDragEnd: (e: DragEndEvent) => void;
-  findModule: (id: string) => { id: string; title: string; render: () => JSX.Element };
+  findModule: (id: RightModuleId) => { id: string; title: string; render: () => JSX.Element };
 }
 
 const RightColumn: React.FC<RightColumnProps> = ({

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -26,7 +26,8 @@ import {
   dtTasks,
   dtEvents,
   dtNews,
-  dtPositions
+  dtPositions,
+  dtRankings
 } from '../data/mockData';
 import {
   Club,
@@ -46,7 +47,8 @@ import {
   DtMarket,
   DtObjectives,
   DtTask,
-  DtEvent
+  DtEvent,
+  DtRanking
 } from '../types';
 
 interface DataState {
@@ -72,6 +74,7 @@ interface DataState {
   events: DtEvent[];
   news: NewsItem[];
   positions: Standing[];
+  dtRankings: DtRanking[];
   
   updateClubs: (newClubs: Club[]) => void;
   updatePlayers: (newPlayers: Player[]) => void;
@@ -96,6 +99,7 @@ interface DataState {
   addNewsItem: (item: NewsItem) => void;
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
+  toggleTask: (id: string) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -119,6 +123,7 @@ export const useDataStore = create<DataState>((set) => ({
   events: dtEvents,
   news: dtNews,
   positions: dtPositions,
+  dtRankings,
   users: getUsers(),
   
   updateClubs: (newClubs) => set({ clubs: newClubs }),
@@ -244,6 +249,13 @@ export const useDataStore = create<DataState>((set) => ({
     newsItems: state.newsItems.filter(n => n.id !== id)
   })),
 
-  updateStandings: (newStandings) => set({ standings: newStandings })
+  updateStandings: (newStandings) => set({ standings: newStandings }),
+
+  toggleTask: (id) =>
+    set((state) => ({
+      tasks: state.tasks.map(t =>
+        t.id === id ? { ...t, done: !t.done } : t
+      )
+    }))
 }));
  

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,8 +161,12 @@ export interface NewsItem {
   title: string;
   content: string;
   type: 'transfer' | 'rumor' | 'result' | 'announcement' | 'statement';
+  /** Optional category label used in some views */
+  category?: string;
   imageUrl?: string;
+  /** Publication date (alias 'date' used in some components) */
   publishDate: string;
+  date?: string;
   author: string;
   clubId?: string;
   playerId?: string;
@@ -284,10 +288,19 @@ export interface DtObjectives {
 export interface DtTask {
   id: string;
   text: string;
+  done?: boolean;
 }
 
 export interface DtEvent {
   id: string;
   message: string;
   date: string;
+}
+
+export interface DtRanking {
+  id: string;
+  username: string;
+  clubName: string;
+  clubLogo: string;
+  elo: number;
 }


### PR DESCRIPTION
## Summary
- extend `PageHeader` to accept children
- add rankings and task toggling support to data store
- update mock data with news categories, dt rankings and tasks with done flags
- adjust `DtDashboard` to use new types
- update shared type definitions

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b08b986008333b172aa6354f899b4