### PR TITLE
Fix RightModuleId mismatch

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -86,7 +86,7 @@ ReactGA.initialize("G-XXXXXXX");
 
 /* ---------- Tipos ---------- */
 interface LayoutItem {
-  id: string;
+  id: RightModuleId;
   visible: boolean;
 }
 interface ChatMsg {
@@ -824,7 +824,7 @@ const RightColumn: React.FC<RightColumnProps> = ({
   handleDragEnd,
   findModule,
 }) => {
-  const SortableItem: React.FC<{ id: string; children: React.ReactNode }> = ({
+  const SortableItem: React.FC<{ id: RightModuleId; children: React.ReactNode }> = ({
     id,
     children,
   }) => {


### PR DESCRIPTION
## Summary
- type layout IDs with the `RightModuleId` union
- ensure sortable items use `RightModuleId`

## Testing
- `npm run test:unit`
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685b0bb930bc833389f77b87e425ff9c