### PR TITLE
Improve DT dashboard design

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -562,6 +562,12 @@ const DtDashboard: React.FC = () => {
         </button>
       </PageHeader>
 
+      {customizing && (
+        <div className="bg-accent py-2 text-center text-sm font-semibold text-black">
+          Modo personalización activo
+        </div>
+      )}
+
       <div className="container mx-auto px-4 py-8">
         <DtMenuTabs />
 
@@ -570,22 +576,22 @@ const DtDashboard: React.FC = () => {
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
             <KPICard
               title="Plantilla"
-              icon={<Users size={20} />}
+              icon={<Users size={24} />}
               value={`${club.players.length} jugadores`}
             />
             <KPICard
               title="Táctica"
-              icon={<LayoutIcon size={20} />}
+              icon={<LayoutIcon size={24} />}
               value={club.formation}
             />
             <KPICard
               title="Finanzas"
-              icon={<DollarSign size={20} />}
+              icon={<DollarSign size={24} />}
               value={formatCurrency(club.budget)}
             />
             <KPICard
               title="Mercado"
-              icon={<TrendingUp size={20} />}
+              icon={<TrendingUp size={24} />}
               value={marketOpen ? "Abierto" : "Cerrado"}
             />
           </div>
@@ -743,10 +749,10 @@ const KPICard: React.FC<{ title: string; icon: React.ReactNode; value: string }>
 }) => (
   <motion.div
     whileHover={{ scale: 1.04 }}
-    className="flex flex-col justify-between rounded-2xl bg-white/5 p-6 shadow-inner backdrop-blur-md"
+    className="flex flex-col justify-between rounded-2xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-6 shadow-inner backdrop-blur-md"
   >
     <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-zinc-300">
-      {icon}
+      <span className="rounded-full bg-white/10 p-1">{icon}</span>
       {title}
     </div>
     <p className="text-xl font-bold text-white" aria-live="polite">

--- a/src/pages/dt-dashboard/QuickActions.tsx
+++ b/src/pages/dt-dashboard/QuickActions.tsx
@@ -1,3 +1,4 @@
+import Card from '../../components/common/Card';
 import { Banknote, Stethoscope, UserPlus, Megaphone } from 'lucide-react';
 
 interface QuickActionsProps {
@@ -5,36 +6,39 @@ interface QuickActionsProps {
 }
 
 const QuickActions = ({ marketOpen }: QuickActionsProps) => (
-  <div className="grid gap-3 sm:grid-cols-2">
-    <button
-      className={`card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
-      disabled={!marketOpen}
-    >
-      <Banknote size={16} />
-      <span>Enviar oferta</span>
-    </button>
-    <button
-      aria-label="Informe médico"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
-    >
-      <Stethoscope size={16} />
-      <span>Informe médico</span>
-    </button>
-    <button
-      aria-label="Firmar juvenil"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
-    >
-      <UserPlus size={16} />
-      <span>Firmar juvenil</span>
-    </button>
-    <button
-      aria-label="Publicar declaración"
-      className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
-    >
-      <Megaphone size={16} />
-      <span>Publicar declaración</span>
-    </button>
-  </div>
+  <Card className="p-4" aria-label="Acciones rápidas">
+    <h3 className="mb-4 font-semibold">Acciones rápidas</h3>
+    <div className="grid gap-3 sm:grid-cols-2">
+      <button
+        className={`card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
+        disabled={!marketOpen}
+      >
+        <Banknote size={16} />
+        <span>Enviar oferta</span>
+      </button>
+      <button
+        aria-label="Informe médico"
+        className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      >
+        <Stethoscope size={16} />
+        <span>Informe médico</span>
+      </button>
+      <button
+        aria-label="Firmar juvenil"
+        className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      >
+        <UserPlus size={16} />
+        <span>Firmar juvenil</span>
+      </button>
+      <button
+        aria-label="Publicar declaración"
+        className="card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2"
+      >
+        <Megaphone size={16} />
+        <span>Publicar declaración</span>
+      </button>
+    </div>
+  </Card>
 );
 
 export default QuickActions;


### PR DESCRIPTION
## Summary
- restyle KPI cards with a subtle gradient and icon badge
- wrap QuickActions inside a card and add heading
- show a banner when customization is active
- use larger icons for KPIs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ceae8e08333a8ed93b3532dc3ac