### PR TITLE
Improve DT dashboard styles

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -7,7 +7,7 @@ interface CardProps {
 }
 
 const Card = ({ children, onClick, className = '' }: CardProps) => (
-  <div onClick={onClick} className={`card card-hover ${className}`.trim()}>
+  <div onClick={onClick} className={`card-glass card-hover ${className}`.trim()}>
     {children}
   </div>
 );

--- a/src/components/common/CardSkeleton.tsx
+++ b/src/components/common/CardSkeleton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface CardSkeletonProps {
+  lines?: number;
+  className?: string;
+}
+
+const CardSkeleton = ({ lines = 3, className = '' }: CardSkeletonProps) => (
+  <div className={`card-glass p-4 animate-pulse space-y-2 ${className}`.trim()}>
+    {Array.from({ length: lines }).map((_, i) => (
+      <div key={i} className="h-4 rounded bg-white/10" />
+    ))}
+  </div>
+);
+
+export default CardSkeleton;

--- a/src/components/common/DashboardSkeleton.tsx
+++ b/src/components/common/DashboardSkeleton.tsx
@@ -1,12 +1,14 @@
+import CardSkeleton from './CardSkeleton';
+
 const DashboardSkeleton = () => (
-  <div className="container mx-auto px-4 py-8 animate-pulse space-y-6">
-    <div className="h-6 w-1/3 bg-gray-700 rounded" />
+  <div className="container mx-auto px-4 py-8 space-y-6">
+    <div className="h-6 w-1/3 animate-pulse rounded bg-white/10" />
     <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4">
       {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="h-24 bg-gray-700 rounded" />
+        <CardSkeleton key={i} className="h-24" lines={0} />
       ))}
     </div>
-    <div className="h-64 bg-gray-700 rounded" />
+    <CardSkeleton className="h-64" lines={0} />
   </div>
 );
 

--- a/src/components/common/FilterChip.tsx
+++ b/src/components/common/FilterChip.tsx
@@ -1,0 +1,20 @@
+interface FilterChipProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+const FilterChip = ({ label, active, onClick }: FilterChipProps) => (
+  <button
+    onClick={onClick}
+    className={`rounded-full px-3 py-1 text-xs ${
+      active
+        ? 'bg-accent text-black'
+        : 'bg-white/10 text-gray-300 hover:bg-white/20'
+    } focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent`}
+  >
+    {label}
+  </button>
+);
+
+export default FilterChip;

--- a/src/components/common/RankingRow.tsx
+++ b/src/components/common/RankingRow.tsx
@@ -1,0 +1,19 @@
+import { DtRanking } from '../../types';
+
+interface RankingRowProps {
+  rank: number;
+  data: DtRanking;
+}
+
+const RankingRow = ({ rank, data }: RankingRowProps) => (
+  <tr className="border-t border-white/10">
+    <td>{rank}</td>
+    <td>{data.username}</td>
+    <td className="flex items-center justify-center gap-1">
+      <img src={data.clubLogo} alt={data.clubName} className="h-4 w-4" />
+    </td>
+    <td className="text-right">{data.elo}</td>
+  </tr>
+);
+
+export default RankingRow;

--- a/src/components/common/StatsCard.tsx
+++ b/src/components/common/StatsCard.tsx
@@ -42,7 +42,7 @@ const StatsCard = ({ title, value, icon, trend, trendValue, progress }: StatsCar
   };
   
   return (
-    <div className="card p-4">
+    <div className="card-glass p-4">
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <p className="text-gray-400 text-xs sm:text-sm mb-2">{title}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -11,10 +11,26 @@
   --neon-green: #00ff8f;
   --neon-yellow: #ffe600;
   --accent: #3ff;
+  --bg-surface: #18181f;
+  --bg-overlay: rgba(255, 255, 255, 0.05);
+  --text-main: #fff;
+}
+
+html:not(.dark) {
+  --bg-surface: #f4f4f5; /* zinc-100 */
+  --bg-overlay: rgba(0, 0, 0, 0.05);
+  --text-main: #27272a; /* zinc-800 */
 }
 
 body {
-  @apply bg-[#18181f] text-white font-sans;
+  @apply bg-[var(--bg-surface)] text-[var(--text-main)] font-sans;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 2px dashed var(--accent);
+  outline-offset: 2px;
 }
 
 @layer components {
@@ -25,9 +41,13 @@ body {
   .card {
     @apply bg-gray-800 rounded-lg overflow-hidden border border-gray-700 transition-all;
   }
-  
+
   .card-hover {
     @apply hover:border-gray-600 hover:shadow-lg;
+  }
+
+  .card-glass {
+    @apply rounded-2xl border border-white/10 bg-[var(--bg-overlay)] shadow-inner backdrop-blur;
   }
   
   .input {

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -4,6 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import DtMenuTabs from '../components/DtMenuTabs';
 import EventModal, { CalendarEvent } from '../components/calendar/EventModal';
+import CardSkeleton from '../components/common/CardSkeleton';
 import fixtures from '../data/fixtures.json';
 import { VZ_CALENDAR_PREFS_KEY } from '../utils/storageKeys';
 
@@ -85,7 +86,7 @@ const Calendario = () => {
           Mercado
         </label>
       </div>
-      <Suspense fallback={<div className="text-center">Cargando…</div>}>
+      <Suspense fallback={<CardSkeleton lines={4} /> }>
         <FullCalendar
           plugins={[dayGridPlugin, interactionPlugin]}
           initialView="dayGridMonth"

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -27,7 +27,7 @@ import {
   EyeOff,
   GripVertical,
 } from "lucide-react";
-import { motion } from "framer-motion";
+import { motion, useAnimation } from "framer-motion";
 import toast, { Toaster } from "react-hot-toast";
 import ReactGA from "react-ga4";
 import {
@@ -66,6 +66,8 @@ import LatestNews from "./dt-dashboard/LatestNews";
 import QuickActions from "./dt-dashboard/QuickActions";
 import PageHeader from "../components/common/PageHeader";
 import DashboardSkeleton from "../components/common/DashboardSkeleton";
+import FilterChip from "../components/common/FilterChip";
+import RankingRow from "../components/common/RankingRow";
 import { DtRanking } from "../types";
 
 import { useAuthStore } from "../store/authStore";
@@ -271,7 +273,7 @@ const DtDashboard: React.FC = () => {
       title: "Anuncios",
       render: () => (
         <Card className="p-4" aria-label="Anuncios" aria-live="polite">
-          <h3 className="mb-3 font-semibold">Anuncios</h3>
+          <h3 className="mb-4 text-xl font-semibold leading-tight">Anuncios</h3>
           {events.length === 0 ? (
             <EmptyState label="No hay anuncios" />
           ) : (
@@ -295,7 +297,7 @@ const DtDashboard: React.FC = () => {
       title: "Mercado",
       render: () => (
         <Card className="p-4" aria-label="Mercado">
-          <h3 className="mb-3 font-semibold">Mercado</h3>
+          <h3 className="mb-4 text-xl font-semibold leading-tight">Mercado</h3>
           <div className="flex items-center gap-2">
             <span
               className={
@@ -319,7 +321,7 @@ const DtDashboard: React.FC = () => {
       title: "Logros",
       render: () => (
         <Card className="p-4" aria-label="Logros">
-          <h3 className="mb-3 font-semibold">Logros</h3>
+          <h3 className="mb-4 text-xl font-semibold leading-tight">Logros</h3>
           <ul className="space-y-2 text-sm">
             {achievements.map((a) => (
               <li
@@ -345,7 +347,7 @@ const DtDashboard: React.FC = () => {
       title: "Ranking DT",
       render: () => (
         <Card className="p-4" aria-label="Ranking DT">
-          <h3 className="mb-3 font-semibold">Ranking de Entrenadores</h3>
+          <h3 className="mb-4 text-xl font-semibold leading-tight">Ranking de Entrenadores</h3>
           {dtRankings.length === 0 ? (
             <EmptyState label="Sin datos de ranking" />
           ) : (
@@ -360,18 +362,7 @@ const DtDashboard: React.FC = () => {
               </thead>
               <tbody>
                 {dtRankings.slice(0, 10).map((d: DtRanking, idx: number) => (
-                  <tr key={d.id} className="border-t border-white/10">
-                    <td>{idx + 1}</td>
-                    <td>{d.username}</td>
-                    <td className="flex items-center justify-center gap-1">
-                      <img
-                        src={d.clubLogo}
-                        alt={d.clubName}
-                        className="h-4 w-4"
-                      />
-                    </td>
-                    <td className="text-right">{d.elo}</td>
-                  </tr>
+                  <RankingRow key={d.id} rank={idx + 1} data={d} />
                 ))}
               </tbody>
             </table>
@@ -392,20 +383,15 @@ const DtDashboard: React.FC = () => {
           {/* filtros */}
           <div className="mb-4 flex flex-wrap gap-2">
             {categories.map((c) => (
-              <button
+              <FilterChip
                 key={c}
+                label={c}
+                active={cat === c}
                 onClick={() => {
                   setCat(c);
                   setNewsCount(5);
                 }}
-                className={`rounded-full px-3 py-1 text-xs ${
-                  cat === c
-                    ? "bg-accent text-black"
-                    : "bg-white/10 text-gray-300 hover:bg-white/20"
-                } focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent`}
-              >
-                {c}
-              </button>
+              />
             ))}
           </div>
           {/* lista */}
@@ -447,7 +433,7 @@ const DtDashboard: React.FC = () => {
       title: "Recordatorios",
       render: () => (
         <Card className="p-4" aria-label="Recordatorios">
-          <h3 className="mb-3 font-semibold">Recordatorios</h3>
+          <h3 className="mb-4 text-xl font-semibold leading-tight">Recordatorios</h3>
           {tasks.length === 0 ? (
             <EmptyState label="No hay recordatorios" />
           ) : (
@@ -573,26 +559,30 @@ const DtDashboard: React.FC = () => {
 
         {/* KPI + gráfica */}
         <section className="mb-8 space-y-8 rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-lg">
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="flex gap-4 overflow-x-auto sm:grid sm:grid-cols-2 lg:grid-cols-4 sm:overflow-visible snap-x">
             <KPICard
               title="Plantilla"
               icon={<Users size={24} />}
               value={`${club.players.length} jugadores`}
+              className="min-w-[90%] sm:min-w-0 snap-start"
             />
             <KPICard
               title="Táctica"
               icon={<LayoutIcon size={24} />}
               value={club.formation}
+              className="min-w-[90%] sm:min-w-0 snap-start"
             />
             <KPICard
               title="Finanzas"
               icon={<DollarSign size={24} />}
               value={formatCurrency(club.budget)}
+              className="min-w-[90%] sm:min-w-0 snap-start"
             />
             <KPICard
               title="Mercado"
               icon={<TrendingUp size={24} />}
               value={marketOpen ? "Abierto" : "Cerrado"}
+              className="min-w-[90%] sm:min-w-0 snap-start"
             />
           </div>
 
@@ -613,7 +603,12 @@ const DtDashboard: React.FC = () => {
         {/* cuerpo principal */}
         <main className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           {/* izquierda */}
-          <div className="space-y-8 lg:col-span-2">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="space-y-8 lg:col-span-2"
+          >
             {/* Próximo partido */}
             {nextMatch && (
               <Card className="p-4" aria-label="Próximo partido">
@@ -623,7 +618,7 @@ const DtDashboard: React.FC = () => {
                   ) : (
                     <Plane size={16} className="text-accent" aria-hidden />
                   )}
-                  <h2 className="font-semibold">Próximo partido</h2>
+                  <h2 className="text-xl font-semibold leading-tight">Próximo partido</h2>
                 </div>
                 <p className="mt-2">
                   {nextMatch.homeTeam === club.name
@@ -644,7 +639,7 @@ const DtDashboard: React.FC = () => {
             {/* mini tabla + comparativa */}
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
               <Card className="p-4" aria-label="Mini tabla">
-                <h3 className="mb-3 font-semibold">Posiciones</h3>
+                <h3 className="mb-4 text-xl font-semibold leading-tight">Posiciones</h3>
                 <table className="w-full text-sm">
                   <tbody>
                     {miniTable.map((row) => (
@@ -675,7 +670,7 @@ const DtDashboard: React.FC = () => {
               </Card>
 
               <Card className="p-4" aria-label="Comparativa liga">
-                <h3 className="mb-3 font-semibold">Comparativa con la liga</h3>
+                <h3 className="mb-4 text-xl font-semibold leading-tight">Comparativa con la liga</h3>
                 <ul className="space-y-2 text-sm">
                   {bullets.map((b) => (
                     <li key={b.label} className="flex justify-between">
@@ -719,7 +714,7 @@ const DtDashboard: React.FC = () => {
 
             <SeasonObjectives />
             <LatestNews />
-          </div>
+          </motion.div>
 
           {/* derecha */}
           <RightColumn
@@ -742,14 +737,15 @@ export default DtDashboard;
 
 /* ═════════ sub-componentes ═════════ */
 
-const KPICard: React.FC<{ title: string; icon: React.ReactNode; value: string }> = ({
+const KPICard: React.FC<{ title: string; icon: React.ReactNode; value: string; className?: string }> = ({
   title,
   icon,
   value,
+  className = '',
 }) => (
   <motion.div
-    whileHover={{ scale: 1.04 }}
-    className="flex flex-col justify-between rounded-2xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-6 shadow-inner backdrop-blur-md hover:border-accent transition-colors"
+    whileHover={{ scale: 1.02, y: -2 }}
+    className={`flex flex-col justify-between rounded-2xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-6 shadow-inner backdrop-blur-md hover:border-accent transition-colors ${className}`.trim()}
   >
     <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-zinc-300">
       <span className="rounded-full bg-white/10 p-1">{icon}</span>
@@ -774,6 +770,7 @@ const ChatModule: React.FC<{
   endRef: React.RefObject<HTMLDivElement>;
 }> = ({ chat, sendChat, endRef }) => {
   const [input, setInput] = useState("");
+  const { user } = useAuthStore();
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     sendChat(input);
@@ -781,12 +778,19 @@ const ChatModule: React.FC<{
   };
   return (
     <Card className="p-4" aria-label="Chat de comunidad">
-      <h3 className="mb-3 flex items-center gap-2 font-semibold">
+      <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold leading-tight">
         <MessageCircle size={18} /> Chat
       </h3>
-      <div className="mb-3 h-48 overflow-y-auto rounded bg-white/5 p-2 text-xs">
+      <div className="mb-3 h-48 overflow-y-auto rounded bg-white/5 p-2 text-xs space-y-1">
         {chat.map((m) => (
-          <p key={m.id} className="mb-1">
+          <p
+            key={m.id}
+            className={`max-w-[90%] ${
+              m.user === user?.username
+                ? 'ml-auto text-right bg-accent/20 rounded px-1'
+                : ''
+            }`}
+          >
             <span className="font-semibold text-accent">{m.user}</span>: {m.text}
           </p>
         ))}
@@ -838,8 +842,18 @@ const RightColumn: React.FC<RightColumnProps> = ({
       useSortable({ id });
     const style = { transform: CSS.Transform.toString(transform), transition };
     const item = layout.find((l) => l.id === id)!;
+    const controls = useAnimation();
+    useEffect(() => {
+      if (!transform) {
+        controls.start({
+          opacity: [0.9, 1],
+          scale: [0.98, 1],
+          transition: { type: 'spring', stiffness: 150, damping: 12 },
+        });
+      }
+    }, [transform, controls]);
     return (
-      <div ref={setNodeRef} style={style}>
+      <motion.div ref={setNodeRef} style={style} animate={controls}>
         <div className="relative">
           {customizing && (
             <>
@@ -868,12 +882,17 @@ const RightColumn: React.FC<RightColumnProps> = ({
           )}
           {item.visible ? children : <div className="opacity-40">{children}</div>}
         </div>
-      </div>
+      </motion.div>
     );
   };
 
   return (
-    <div className="space-y-8">
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      className="space-y-8"
+    >
       {customizing ? (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={layout.map((l) => l.id)} strategy={verticalListSortingStrategy}>
@@ -889,6 +908,6 @@ const RightColumn: React.FC<RightColumnProps> = ({
           .filter((l) => l.visible)
           .map((l) => <div key={l.id}>{findModule(l.id).render()}</div>)
       )}
-    </div>
+    </motion.div>
   );
 };

--- a/src/pages/dt-dashboard/LatestNews.tsx
+++ b/src/pages/dt-dashboard/LatestNews.tsx
@@ -11,7 +11,7 @@ const LatestNews = () => {
   return (
     <Card className="p-4">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="font-semibold">Últimas noticias</h3>
+        <h3 className="text-xl font-semibold leading-tight">Últimas noticias</h3>
         <Link
           to="/liga-master/feed"
           className="text-accent text-sm hover:underline focus:outline-none focus:ring-2 focus:ring-accent"

--- a/src/pages/dt-dashboard/QuickActions.tsx
+++ b/src/pages/dt-dashboard/QuickActions.tsx
@@ -7,7 +7,7 @@ interface QuickActionsProps {
 
 const QuickActions = ({ marketOpen }: QuickActionsProps) => (
   <Card className="p-4" aria-label="Acciones rápidas">
-    <h3 className="mb-4 font-semibold">Acciones rápidas</h3>
+    <h3 className="mb-4 text-xl font-semibold leading-tight">Acciones rápidas</h3>
     <div className="grid gap-3 sm:grid-cols-2">
       <button
         className={`card-hover bg-accent px-4 py-2 font-semibold text-black flex items-center justify-center gap-2 ${!marketOpen ? 'opacity-50 cursor-not-allowed' : ''}`}

--- a/src/pages/dt-dashboard/SeasonObjectives.tsx
+++ b/src/pages/dt-dashboard/SeasonObjectives.tsx
@@ -7,7 +7,7 @@ const SeasonObjectives = () => {
 
   return (
     <Card className="p-4">
-      <h3 className="mb-4 font-semibold">Objetivos de temporada</h3>
+      <h3 className="mb-4 text-xl font-semibold leading-tight">Objetivos de temporada</h3>
       <div className="space-y-4">
         <div>
           <p className="mb-1 text-xs text-gray-400">Clasificar top 5</p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,20 +3,22 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
-      colors: {
-        primary: 'var(--primary)',
-        'primary-light': 'var(--primary-light)',
-        'primary-dark': 'var(--primary-dark)',
-        'neon-red': 'var(--neon-red)',
-        'neon-blue': 'var(--neon-blue)',
-        'neon-green': 'var(--neon-green)',
-        'neon-yellow': 'var(--neon-yellow)',
-        accent: '#3ff',
-        dark: '#1a1a24',
-        'dark-light': '#47474f',
-        'dark-lighter': '#75757b',
-        'text-secondary': '#b5b5b5'
-      },
+        colors: {
+          primary: 'var(--primary)',
+          'primary-light': 'var(--primary-light)',
+          'primary-dark': 'var(--primary-dark)',
+          'neon-red': 'var(--neon-red)',
+          'neon-blue': 'var(--neon-blue)',
+          'neon-green': 'var(--neon-green)',
+          'neon-yellow': 'var(--neon-yellow)',
+          accent: 'var(--accent)',
+          'bg-surface': 'var(--bg-surface)',
+          'bg-overlay': 'var(--bg-overlay)',
+          dark: '#1a1a24',
+          'dark-light': '#47474f',
+          'dark-lighter': '#75757b',
+          'text-secondary': '#b5b5b5'
+        },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
         display: ['Rajdhani', 'sans-serif']


### PR DESCRIPTION
## Summary
- implement glassmorphism utility `.card-glass`
- redesign DT dashboard cards and chat
- animate sortable modules and columns with framer-motion
- refine typography and responsive KPI layout
- add reusable `CardSkeleton`, `FilterChip` and `RankingRow`
- expose palette variables in tailwind config
- update calendar fallback

## Testing
- `npm run lint`
- `npm test` *(fails to run Cypress)*

------
https://chatgpt.com/codex/tasks/task_e_685b13c5f4c4833383e237742468ec16