### PR TITLE
Add PWA setup with service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#ffffff" />
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
             "typescript": "^5.0.2",
             "typescript-eslint": "^8.34.1",
             "vite": "^6.3.5",
+            "vite-plugin-pwa": "^1.0.0",
             "vitest": "^3.2.4"
          }
       },
@@ -160,6 +161,19 @@
             "node": ">=6.9.0"
          }
       },
+      "node_modules/@babel/helper-annotate-as-pure": {
+         "version": "7.27.3",
+         "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+         "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/types": "^7.27.3"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
       "node_modules/@babel/helper-compilation-targets": {
          "version": "7.27.2",
          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
@@ -185,6 +199,97 @@
          "license": "ISC",
          "bin": {
             "semver": "bin/semver.js"
+         }
+      },
+      "node_modules/@babel/helper-create-class-features-plugin": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
+         "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-annotate-as-pure": "^7.27.1",
+            "@babel/helper-member-expression-to-functions": "^7.27.1",
+            "@babel/helper-optimise-call-expression": "^7.27.1",
+            "@babel/helper-replace-supers": "^7.27.1",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+            "@babel/traverse": "^7.27.1",
+            "semver": "^6.3.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+         "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+         "dev": true,
+         "license": "ISC",
+         "bin": {
+            "semver": "bin/semver.js"
+         }
+      },
+      "node_modules/@babel/helper-create-regexp-features-plugin": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
+         "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-annotate-as-pure": "^7.27.1",
+            "regexpu-core": "^6.2.0",
+            "semver": "^6.3.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+         "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+         "dev": true,
+         "license": "ISC",
+         "bin": {
+            "semver": "bin/semver.js"
+         }
+      },
+      "node_modules/@babel/helper-define-polyfill-provider": {
+         "version": "0.6.4",
+         "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
+         "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-compilation-targets": "^7.22.6",
+            "@babel/helper-plugin-utils": "^7.22.5",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+         }
+      },
+      "node_modules/@babel/helper-member-expression-to-functions": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+         "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/traverse": "^7.27.1",
+            "@babel/types": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
          }
       },
       "node_modules/@babel/helper-module-imports": {
@@ -219,12 +324,75 @@
             "@babel/core": "^7.0.0"
          }
       },
+      "node_modules/@babel/helper-optimise-call-expression": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+         "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/types": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
       "node_modules/@babel/helper-plugin-utils": {
          "version": "7.27.1",
          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
          "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
          "dev": true,
          "license": "MIT",
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
+      "node_modules/@babel/helper-remap-async-to-generator": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+         "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-annotate-as-pure": "^7.27.1",
+            "@babel/helper-wrap-function": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/helper-replace-supers": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+         "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-member-expression-to-functions": "^7.27.1",
+            "@babel/helper-optimise-call-expression": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+         "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/traverse": "^7.27.1",
+            "@babel/types": "^7.27.1"
+         },
          "engines": {
             "node": ">=6.9.0"
          }
@@ -259,6 +427,21 @@
             "node": ">=6.9.0"
          }
       },
+      "node_modules/@babel/helper-wrap-function": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
+         "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/template": "^7.27.1",
+            "@babel/traverse": "^7.27.1",
+            "@babel/types": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
       "node_modules/@babel/helpers": {
          "version": "7.27.6",
          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
@@ -287,6 +470,802 @@
          },
          "engines": {
             "node": ">=6.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
+         "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+         "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+         "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+         "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+            "@babel/plugin-transform-optional-chaining": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.13.0"
+         }
+      },
+      "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
+         "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-proposal-private-property-in-object": {
+         "version": "7.21.0-placeholder-for-preset-env.2",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+         "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-syntax-import-assertions": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
+         "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-syntax-import-attributes": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+         "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+         "version": "7.18.6",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+         "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+            "@babel/helper-plugin-utils": "^7.18.6"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-arrow-functions": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+         "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-async-generator-functions": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
+         "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-remap-async-to-generator": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-async-to-generator": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
+         "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-module-imports": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-remap-async-to-generator": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-block-scoped-functions": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+         "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-block-scoping": {
+         "version": "7.27.5",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
+         "integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-class-properties": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+         "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-class-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-class-static-block": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
+         "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-class-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.12.0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-classes": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
+         "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-annotate-as-pure": "^7.27.1",
+            "@babel/helper-compilation-targets": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-replace-supers": "^7.27.1",
+            "@babel/traverse": "^7.27.1",
+            "globals": "^11.1.0"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-classes/node_modules/globals": {
+         "version": "11.12.0",
+         "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+         "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/@babel/plugin-transform-computed-properties": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
+         "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/template": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-destructuring": {
+         "version": "7.27.3",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
+         "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-dotall-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
+         "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-duplicate-keys": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+         "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
+         "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-dynamic-import": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+         "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-exponentiation-operator": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
+         "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-export-namespace-from": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+         "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-for-of": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+         "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-function-name": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+         "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-compilation-targets": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-json-strings": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
+         "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-literals": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+         "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
+         "integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-member-expression-literals": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+         "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-modules-amd": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+         "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-module-transforms": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-modules-commonjs": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+         "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-module-transforms": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-modules-systemjs": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
+         "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-module-transforms": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-validator-identifier": "^7.27.1",
+            "@babel/traverse": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-modules-umd": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+         "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-module-transforms": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
+         "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-new-target": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+         "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+         "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-numeric-separator": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
+         "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-object-rest-spread": {
+         "version": "7.27.3",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
+         "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-compilation-targets": "^7.27.2",
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/plugin-transform-destructuring": "^7.27.3",
+            "@babel/plugin-transform-parameters": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-object-super": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+         "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-replace-supers": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-optional-catch-binding": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
+         "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-optional-chaining": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+         "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-parameters": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
+         "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-private-methods": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+         "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-class-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-private-property-in-object": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
+         "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-annotate-as-pure": "^7.27.1",
+            "@babel/helper-create-class-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-property-literals": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+         "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
          }
       },
       "node_modules/@babel/plugin-transform-react-jsx-self": {
@@ -319,6 +1298,312 @@
          },
          "peerDependencies": {
             "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-regenerator": {
+         "version": "7.27.5",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
+         "integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-regexp-modifiers": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
+         "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-reserved-words": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+         "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-shorthand-properties": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+         "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-spread": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
+         "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-sticky-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+         "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-template-literals": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+         "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-typeof-symbol": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+         "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-unicode-escapes": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+         "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-unicode-property-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
+         "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-unicode-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+         "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+         "version": "7.27.1",
+         "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
+         "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+            "@babel/helper-plugin-utils": "^7.27.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0"
+         }
+      },
+      "node_modules/@babel/preset-env": {
+         "version": "7.27.2",
+         "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
+         "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/compat-data": "^7.27.2",
+            "@babel/helper-compilation-targets": "^7.27.2",
+            "@babel/helper-plugin-utils": "^7.27.1",
+            "@babel/helper-validator-option": "^7.27.1",
+            "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+            "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+            "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+            "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+            "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+            "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+            "@babel/plugin-syntax-import-assertions": "^7.27.1",
+            "@babel/plugin-syntax-import-attributes": "^7.27.1",
+            "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+            "@babel/plugin-transform-arrow-functions": "^7.27.1",
+            "@babel/plugin-transform-async-generator-functions": "^7.27.1",
+            "@babel/plugin-transform-async-to-generator": "^7.27.1",
+            "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+            "@babel/plugin-transform-block-scoping": "^7.27.1",
+            "@babel/plugin-transform-class-properties": "^7.27.1",
+            "@babel/plugin-transform-class-static-block": "^7.27.1",
+            "@babel/plugin-transform-classes": "^7.27.1",
+            "@babel/plugin-transform-computed-properties": "^7.27.1",
+            "@babel/plugin-transform-destructuring": "^7.27.1",
+            "@babel/plugin-transform-dotall-regex": "^7.27.1",
+            "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+            "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+            "@babel/plugin-transform-dynamic-import": "^7.27.1",
+            "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+            "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+            "@babel/plugin-transform-for-of": "^7.27.1",
+            "@babel/plugin-transform-function-name": "^7.27.1",
+            "@babel/plugin-transform-json-strings": "^7.27.1",
+            "@babel/plugin-transform-literals": "^7.27.1",
+            "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+            "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+            "@babel/plugin-transform-modules-amd": "^7.27.1",
+            "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+            "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+            "@babel/plugin-transform-modules-umd": "^7.27.1",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+            "@babel/plugin-transform-new-target": "^7.27.1",
+            "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+            "@babel/plugin-transform-numeric-separator": "^7.27.1",
+            "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+            "@babel/plugin-transform-object-super": "^7.27.1",
+            "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
+            "@babel/plugin-transform-optional-chaining": "^7.27.1",
+            "@babel/plugin-transform-parameters": "^7.27.1",
+            "@babel/plugin-transform-private-methods": "^7.27.1",
+            "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+            "@babel/plugin-transform-property-literals": "^7.27.1",
+            "@babel/plugin-transform-regenerator": "^7.27.1",
+            "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+            "@babel/plugin-transform-reserved-words": "^7.27.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+            "@babel/plugin-transform-spread": "^7.27.1",
+            "@babel/plugin-transform-sticky-regex": "^7.27.1",
+            "@babel/plugin-transform-template-literals": "^7.27.1",
+            "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+            "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+            "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+            "@babel/plugin-transform-unicode-regex": "^7.27.1",
+            "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+            "@babel/preset-modules": "0.1.6-no-external-plugins",
+            "babel-plugin-polyfill-corejs2": "^0.4.10",
+            "babel-plugin-polyfill-corejs3": "^0.11.0",
+            "babel-plugin-polyfill-regenerator": "^0.6.1",
+            "core-js-compat": "^3.40.0",
+            "semver": "^6.3.1"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/preset-env/node_modules/semver": {
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+         "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+         "dev": true,
+         "license": "ISC",
+         "bin": {
+            "semver": "bin/semver.js"
+         }
+      },
+      "node_modules/@babel/preset-modules": {
+         "version": "0.1.6-no-external-plugins",
+         "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+         "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/types": "^7.4.4",
+            "esutils": "^2.0.2"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
          }
       },
       "node_modules/@babel/runtime": {
@@ -1197,6 +2482,17 @@
             "node": ">=6.0.0"
          }
       },
+      "node_modules/@jridgewell/source-map": {
+         "version": "0.3.6",
+         "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+         "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@jridgewell/gen-mapping": "^0.3.5",
+            "@jridgewell/trace-mapping": "^0.3.25"
+         }
+      },
       "node_modules/@jridgewell/sourcemap-codec": {
          "version": "1.5.0",
          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -1305,6 +2601,97 @@
          "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/@rollup/plugin-node-resolve": {
+         "version": "15.3.1",
+         "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+         "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@rollup/pluginutils": "^5.0.1",
+            "@types/resolve": "1.20.2",
+            "deepmerge": "^4.2.2",
+            "is-module": "^1.0.0",
+            "resolve": "^1.22.1"
+         },
+         "engines": {
+            "node": ">=14.0.0"
+         },
+         "peerDependencies": {
+            "rollup": "^2.78.0||^3.0.0||^4.0.0"
+         },
+         "peerDependenciesMeta": {
+            "rollup": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/@rollup/plugin-terser": {
+         "version": "0.4.4",
+         "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+         "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "serialize-javascript": "^6.0.1",
+            "smob": "^1.0.0",
+            "terser": "^5.17.4"
+         },
+         "engines": {
+            "node": ">=14.0.0"
+         },
+         "peerDependencies": {
+            "rollup": "^2.0.0||^3.0.0||^4.0.0"
+         },
+         "peerDependenciesMeta": {
+            "rollup": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/@rollup/pluginutils": {
+         "version": "5.2.0",
+         "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+         "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^4.0.2"
+         },
+         "engines": {
+            "node": ">=14.0.0"
+         },
+         "peerDependencies": {
+            "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+         },
+         "peerDependenciesMeta": {
+            "rollup": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+         "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+         "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/jonschlinkert"
+         }
       },
       "node_modules/@rollup/rollup-android-arm-eabi": {
          "version": "4.44.0",
@@ -1578,6 +2965,29 @@
          "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
          "license": "MIT"
       },
+      "node_modules/@surma/rollup-plugin-off-main-thread": {
+         "version": "2.2.3",
+         "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
+         "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "dependencies": {
+            "ejs": "^3.1.6",
+            "json5": "^2.2.0",
+            "magic-string": "^0.25.0",
+            "string.prototype.matchall": "^4.0.6"
+         }
+      },
+      "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+         "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "sourcemap-codec": "^1.4.8"
+         }
+      },
       "node_modules/@types/babel__core": {
          "version": "7.20.5",
          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1761,6 +3171,13 @@
             "@types/react": "^18.0.0"
          }
       },
+      "node_modules/@types/resolve": {
+         "version": "1.20.2",
+         "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+         "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/@types/semver": {
          "version": "7.7.0",
          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
@@ -1786,8 +3203,8 @@
          "version": "2.0.7",
          "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
          "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-         "license": "MIT",
-         "optional": true
+         "devOptional": true,
+         "license": "MIT"
       },
       "node_modules/@types/use-sync-external-store": {
          "version": "0.0.6",
@@ -2373,6 +3790,23 @@
          "dev": true,
          "license": "Python-2.0"
       },
+      "node_modules/array-buffer-byte-length": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+         "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "is-array-buffer": "^3.0.5"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/array-union": {
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2381,6 +3815,28 @@
          "license": "MIT",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/arraybuffer.prototype.slice": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+         "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "array-buffer-byte-length": "^1.0.1",
+            "call-bind": "^1.0.8",
+            "define-properties": "^1.2.1",
+            "es-abstract": "^1.23.5",
+            "es-errors": "^1.3.0",
+            "get-intrinsic": "^1.2.6",
+            "is-array-buffer": "^3.0.4"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/asn1": {
@@ -2429,6 +3885,16 @@
          "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/async-function": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+         "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         }
       },
       "node_modules/asynckit": {
          "version": "0.4.0",
@@ -2497,6 +3963,22 @@
             "postcss": "^8.1.0"
          }
       },
+      "node_modules/available-typed-arrays": {
+         "version": "1.0.7",
+         "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+         "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "possible-typed-array-names": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/aws-sign2": {
          "version": "0.7.0",
          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2513,6 +3995,58 @@
          "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/babel-plugin-polyfill-corejs2": {
+         "version": "0.4.13",
+         "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
+         "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/compat-data": "^7.22.6",
+            "@babel/helper-define-polyfill-provider": "^0.6.4",
+            "semver": "^6.3.1"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+         }
+      },
+      "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+         "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+         "dev": true,
+         "license": "ISC",
+         "bin": {
+            "semver": "bin/semver.js"
+         }
+      },
+      "node_modules/babel-plugin-polyfill-corejs3": {
+         "version": "0.11.1",
+         "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+         "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-define-polyfill-provider": "^0.6.3",
+            "core-js-compat": "^3.40.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+         }
+      },
+      "node_modules/babel-plugin-polyfill-regenerator": {
+         "version": "0.6.4",
+         "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
+         "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-define-polyfill-provider": "^0.6.4"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+         }
       },
       "node_modules/balanced-match": {
          "version": "1.0.2",
@@ -2693,6 +4227,13 @@
             "node": "*"
          }
       },
+      "node_modules/buffer-from": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+         "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/cac": {
          "version": "6.7.14",
          "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2711,6 +4252,25 @@
          "license": "MIT",
          "engines": {
             "node": ">=6"
+         }
+      },
+      "node_modules/call-bind": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+         "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind-apply-helpers": "^1.0.0",
+            "es-define-property": "^1.0.0",
+            "get-intrinsic": "^1.2.4",
+            "set-function-length": "^1.2.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/call-bind-apply-helpers": {
@@ -3095,6 +4655,20 @@
             "url": "https://opencollective.com/core-js"
          }
       },
+      "node_modules/core-js-compat": {
+         "version": "3.43.0",
+         "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
+         "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "browserslist": "^4.25.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/core-js"
+         }
+      },
       "node_modules/core-util-is": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3115,6 +4689,16 @@
          },
          "engines": {
             "node": ">= 8"
+         }
+      },
+      "node_modules/crypto-random-string": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+         "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=8"
          }
       },
       "node_modules/css-line-break": {
@@ -3340,6 +4924,60 @@
             "node": ">=0.10"
          }
       },
+      "node_modules/data-view-buffer": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+         "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "es-errors": "^1.3.0",
+            "is-data-view": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/data-view-byte-length": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+         "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "es-errors": "^1.3.0",
+            "is-data-view": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/inspect-js"
+         }
+      },
+      "node_modules/data-view-byte-offset": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+         "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "es-errors": "^1.3.0",
+            "is-data-view": "^1.0.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/dayjs": {
          "version": "1.11.13",
          "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -3387,6 +5025,52 @@
          "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/deepmerge": {
+         "version": "4.3.1",
+         "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+         "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/define-data-property": {
+         "version": "1.1.4",
+         "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+         "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "es-define-property": "^1.0.0",
+            "es-errors": "^1.3.0",
+            "gopd": "^1.0.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/define-properties": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+         "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "define-data-property": "^1.0.1",
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
       },
       "node_modules/delayed-stream": {
          "version": "1.0.0",
@@ -3481,6 +5165,22 @@
             "safer-buffer": "^2.1.0"
          }
       },
+      "node_modules/ejs": {
+         "version": "3.1.10",
+         "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+         "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "dependencies": {
+            "jake": "^10.8.5"
+         },
+         "bin": {
+            "ejs": "bin/cli.js"
+         },
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
       "node_modules/electron-to-chromium": {
          "version": "1.5.172",
          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.172.tgz",
@@ -3517,6 +5217,75 @@
          },
          "engines": {
             "node": ">=8.6"
+         }
+      },
+      "node_modules/es-abstract": {
+         "version": "1.24.0",
+         "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+         "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "array-buffer-byte-length": "^1.0.2",
+            "arraybuffer.prototype.slice": "^1.0.4",
+            "available-typed-arrays": "^1.0.7",
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.4",
+            "data-view-buffer": "^1.0.2",
+            "data-view-byte-length": "^1.0.2",
+            "data-view-byte-offset": "^1.0.1",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.1.1",
+            "es-set-tostringtag": "^2.1.0",
+            "es-to-primitive": "^1.3.0",
+            "function.prototype.name": "^1.1.8",
+            "get-intrinsic": "^1.3.0",
+            "get-proto": "^1.0.1",
+            "get-symbol-description": "^1.1.0",
+            "globalthis": "^1.0.4",
+            "gopd": "^1.2.0",
+            "has-property-descriptors": "^1.0.2",
+            "has-proto": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "internal-slot": "^1.1.0",
+            "is-array-buffer": "^3.0.5",
+            "is-callable": "^1.2.7",
+            "is-data-view": "^1.0.2",
+            "is-negative-zero": "^2.0.3",
+            "is-regex": "^1.2.1",
+            "is-set": "^2.0.3",
+            "is-shared-array-buffer": "^1.0.4",
+            "is-string": "^1.1.1",
+            "is-typed-array": "^1.1.15",
+            "is-weakref": "^1.1.1",
+            "math-intrinsics": "^1.1.0",
+            "object-inspect": "^1.13.4",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.7",
+            "own-keys": "^1.0.1",
+            "regexp.prototype.flags": "^1.5.4",
+            "safe-array-concat": "^1.1.3",
+            "safe-push-apply": "^1.0.0",
+            "safe-regex-test": "^1.1.0",
+            "set-proto": "^1.0.0",
+            "stop-iteration-iterator": "^1.1.0",
+            "string.prototype.trim": "^1.2.10",
+            "string.prototype.trimend": "^1.0.9",
+            "string.prototype.trimstart": "^1.0.8",
+            "typed-array-buffer": "^1.0.3",
+            "typed-array-byte-length": "^1.0.3",
+            "typed-array-byte-offset": "^1.0.4",
+            "typed-array-length": "^1.0.7",
+            "unbox-primitive": "^1.1.0",
+            "which-typed-array": "^1.1.19"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/es-define-property": {
@@ -3573,6 +5342,24 @@
          },
          "engines": {
             "node": ">= 0.4"
+         }
+      },
+      "node_modules/es-to-primitive": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+         "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "is-callable": "^1.2.7",
+            "is-date-object": "^1.0.5",
+            "is-symbol": "^1.0.4"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/es-toolkit": {
@@ -4036,6 +5823,23 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/fast-uri": {
+         "version": "3.0.6",
+         "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+         "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+         "dev": true,
+         "funding": [
+            {
+               "type": "github",
+               "url": "https://github.com/sponsors/fastify"
+            },
+            {
+               "type": "opencollective",
+               "url": "https://opencollective.com/fastify"
+            }
+         ],
+         "license": "BSD-3-Clause"
+      },
       "node_modules/fastq": {
          "version": "1.19.1",
          "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4101,6 +5905,39 @@
             "node": "^10.12.0 || >=12.0.0"
          }
       },
+      "node_modules/filelist": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+         "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "dependencies": {
+            "minimatch": "^5.0.1"
+         }
+      },
+      "node_modules/filelist/node_modules/brace-expansion": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+         "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "balanced-match": "^1.0.0"
+         }
+      },
+      "node_modules/filelist/node_modules/minimatch": {
+         "version": "5.1.6",
+         "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+         "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+         "dev": true,
+         "license": "ISC",
+         "dependencies": {
+            "brace-expansion": "^2.0.1"
+         },
+         "engines": {
+            "node": ">=10"
+         }
+      },
       "node_modules/fill-range": {
          "version": "7.1.1",
          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4152,6 +5989,22 @@
          "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
          "dev": true,
          "license": "ISC"
+      },
+      "node_modules/for-each": {
+         "version": "0.3.5",
+         "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+         "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "is-callable": "^1.2.7"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
       },
       "node_modules/foreground-child": {
          "version": "3.3.1",
@@ -4298,6 +6151,37 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/function.prototype.name": {
+         "version": "1.1.8",
+         "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+         "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.3",
+            "define-properties": "^1.2.1",
+            "functions-have-names": "^1.2.3",
+            "hasown": "^2.0.2",
+            "is-callable": "^1.2.7"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/functions-have-names": {
+         "version": "1.2.3",
+         "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+         "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+         "dev": true,
+         "license": "MIT",
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/gensync": {
          "version": "1.0.0-beta.2",
          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4333,6 +6217,13 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/get-own-enumerable-property-symbols": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+         "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+         "dev": true,
+         "license": "ISC"
+      },
       "node_modules/get-proto": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4361,6 +6252,24 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/get-symbol-description": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+         "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "es-errors": "^1.3.0",
+            "get-intrinsic": "^1.2.6"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/getos": {
@@ -4450,6 +6359,23 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
+      "node_modules/globalthis": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+         "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "define-properties": "^1.2.1",
+            "gopd": "^1.0.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/globby": {
          "version": "11.1.0",
          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4507,6 +6433,19 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/has-bigints": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+         "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/has-flag": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4515,6 +6454,35 @@
          "license": "MIT",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/has-property-descriptors": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+         "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "es-define-property": "^1.0.0"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/has-proto": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+         "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "dunder-proto": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/has-symbols": {
@@ -4625,6 +6593,13 @@
             "node": ">=8.12.0"
          }
       },
+      "node_modules/idb": {
+         "version": "7.1.1",
+         "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+         "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+         "dev": true,
+         "license": "ISC"
+      },
       "node_modules/ieee754": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -4732,6 +6707,21 @@
             "node": ">=10"
          }
       },
+      "node_modules/internal-slot": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+         "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "es-errors": "^1.3.0",
+            "hasown": "^2.0.2",
+            "side-channel": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
       "node_modules/internmap": {
          "version": "2.0.3",
          "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -4739,6 +6729,60 @@
          "license": "ISC",
          "engines": {
             "node": ">=12"
+         }
+      },
+      "node_modules/is-array-buffer": {
+         "version": "3.0.5",
+         "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+         "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.3",
+            "get-intrinsic": "^1.2.6"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-async-function": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+         "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "async-function": "^1.0.0",
+            "call-bound": "^1.0.3",
+            "get-proto": "^1.0.1",
+            "has-tostringtag": "^1.0.2",
+            "safe-regex-test": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-bigint": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+         "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "has-bigints": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/is-binary-path": {
@@ -4752,6 +6796,36 @@
          },
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/is-boolean-object": {
+         "version": "1.2.2",
+         "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+         "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "has-tostringtag": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-callable": {
+         "version": "1.2.7",
+         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+         "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/is-core-module": {
@@ -4770,6 +6844,41 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/is-data-view": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+         "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "get-intrinsic": "^1.2.6",
+            "is-typed-array": "^1.1.13"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-date-object": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+         "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "has-tostringtag": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/is-extglob": {
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4780,6 +6889,22 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/is-finalizationregistry": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+         "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/is-fullwidth-code-point": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4788,6 +6913,25 @@
          "license": "MIT",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/is-generator-function": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+         "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "get-proto": "^1.0.0",
+            "has-tostringtag": "^1.0.2",
+            "safe-regex-test": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/is-glob": {
@@ -4820,6 +6964,39 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
+      "node_modules/is-map": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+         "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-module": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+         "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/is-negative-zero": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+         "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/is-number": {
          "version": "7.0.0",
          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4830,6 +7007,33 @@
             "node": ">=0.12.0"
          }
       },
+      "node_modules/is-number-object": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+         "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "has-tostringtag": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-obj": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+         "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
       "node_modules/is-path-inside": {
          "version": "3.0.3",
          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -4838,6 +7042,64 @@
          "license": "MIT",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/is-regex": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+         "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "gopd": "^1.2.0",
+            "has-tostringtag": "^1.0.2",
+            "hasown": "^2.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-regexp": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+         "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/is-set": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+         "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-shared-array-buffer": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+         "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/is-stream": {
@@ -4851,6 +7113,57 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/is-string": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+         "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "has-tostringtag": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-symbol": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+         "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "has-symbols": "^1.1.0",
+            "safe-regex-test": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-typed-array": {
+         "version": "1.1.15",
+         "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+         "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "which-typed-array": "^1.1.16"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/is-typedarray": {
@@ -4872,6 +7185,59 @@
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
          }
+      },
+      "node_modules/is-weakmap": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+         "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-weakref": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+         "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/is-weakset": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+         "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "get-intrinsic": "^1.2.6"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/isarray": {
+         "version": "2.0.5",
+         "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+         "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/isexe": {
          "version": "2.0.0",
@@ -4901,6 +7267,25 @@
          },
          "optionalDependencies": {
             "@pkgjs/parseargs": "^0.11.0"
+         }
+      },
+      "node_modules/jake": {
+         "version": "10.9.2",
+         "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+         "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "dependencies": {
+            "async": "^3.2.3",
+            "chalk": "^4.0.2",
+            "filelist": "^1.0.4",
+            "minimatch": "^3.1.2"
+         },
+         "bin": {
+            "jake": "bin/cli.js"
+         },
+         "engines": {
+            "node": ">=10"
          }
       },
       "node_modules/jiti": {
@@ -5013,6 +7398,16 @@
             "graceful-fs": "^4.1.6"
          }
       },
+      "node_modules/jsonpointer": {
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+         "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
       "node_modules/jspdf": {
          "version": "3.0.1",
          "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
@@ -5074,6 +7469,16 @@
          "license": "MIT",
          "engines": {
             "node": "> 0.8"
+         }
+      },
+      "node_modules/leven": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+         "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=6"
          }
       },
       "node_modules/levn": {
@@ -5161,6 +7566,13 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/lodash.debounce": {
+         "version": "4.0.8",
+         "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+         "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/lodash.merge": {
          "version": "4.6.2",
          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5172,6 +7584,13 @@
          "version": "4.1.1",
          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
          "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/lodash.sortby": {
+         "version": "4.7.0",
+         "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+         "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
          "dev": true,
          "license": "MIT"
       },
@@ -5539,6 +7958,37 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/object-keys": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+         "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/object.assign": {
+         "version": "4.1.7",
+         "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+         "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.3",
+            "define-properties": "^1.2.1",
+            "es-object-atoms": "^1.0.0",
+            "has-symbols": "^1.1.0",
+            "object-keys": "^1.1.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/once": {
          "version": "1.4.0",
          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5589,6 +8039,24 @@
          "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/own-keys": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+         "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "get-intrinsic": "^1.2.6",
+            "object-keys": "^1.1.1",
+            "safe-push-apply": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
       },
       "node_modules/p-limit": {
          "version": "3.1.0",
@@ -5798,6 +8266,16 @@
          "license": "MIT",
          "engines": {
             "node": ">= 6"
+         }
+      },
+      "node_modules/possible-typed-array-names": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+         "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
          }
       },
       "node_modules/postcss": {
@@ -6068,6 +8546,16 @@
             "performance-now": "^2.1.0"
          }
       },
+      "node_modules/randombytes": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+         "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "safe-buffer": "^5.1.0"
+         }
+      },
       "node_modules/react": {
          "version": "18.3.1",
          "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -6253,12 +8741,127 @@
             "redux": "^5.0.0"
          }
       },
+      "node_modules/reflect.getprototypeof": {
+         "version": "1.0.10",
+         "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+         "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "define-properties": "^1.2.1",
+            "es-abstract": "^1.23.9",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0",
+            "get-intrinsic": "^1.2.7",
+            "get-proto": "^1.0.1",
+            "which-builtin-type": "^1.2.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/regenerate": {
+         "version": "1.4.2",
+         "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+         "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/regenerate-unicode-properties": {
+         "version": "10.2.0",
+         "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+         "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "regenerate": "^1.4.2"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
       "node_modules/regenerator-runtime": {
          "version": "0.13.11",
          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
          "license": "MIT",
          "optional": true
+      },
+      "node_modules/regexp.prototype.flags": {
+         "version": "1.5.4",
+         "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+         "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "define-properties": "^1.2.1",
+            "es-errors": "^1.3.0",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "set-function-name": "^2.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/regexpu-core": {
+         "version": "6.2.0",
+         "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+         "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "regenerate": "^1.4.2",
+            "regenerate-unicode-properties": "^10.2.0",
+            "regjsgen": "^0.8.0",
+            "regjsparser": "^0.12.0",
+            "unicode-match-property-ecmascript": "^2.0.0",
+            "unicode-match-property-value-ecmascript": "^2.1.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/regjsgen": {
+         "version": "0.8.0",
+         "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+         "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/regjsparser": {
+         "version": "0.12.0",
+         "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+         "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+         "dev": true,
+         "license": "BSD-2-Clause",
+         "dependencies": {
+            "jsesc": "~3.0.2"
+         },
+         "bin": {
+            "regjsparser": "bin/parser"
+         }
+      },
+      "node_modules/regjsparser/node_modules/jsesc": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+         "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+         "dev": true,
+         "license": "MIT",
+         "bin": {
+            "jsesc": "bin/jsesc"
+         },
+         "engines": {
+            "node": ">=6"
+         }
       },
       "node_modules/request-progress": {
          "version": "3.0.0",
@@ -6268,6 +8871,16 @@
          "license": "MIT",
          "dependencies": {
             "throttleit": "^1.0.0"
+         }
+      },
+      "node_modules/require-from-string": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+         "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.10.0"
          }
       },
       "node_modules/reselect": {
@@ -6439,6 +9052,26 @@
             "tslib": "^2.1.0"
          }
       },
+      "node_modules/safe-array-concat": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+         "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.2",
+            "get-intrinsic": "^1.2.6",
+            "has-symbols": "^1.1.0",
+            "isarray": "^2.0.5"
+         },
+         "engines": {
+            "node": ">=0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/safe-buffer": {
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6459,6 +9092,41 @@
             }
          ],
          "license": "MIT"
+      },
+      "node_modules/safe-push-apply": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+         "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "es-errors": "^1.3.0",
+            "isarray": "^2.0.5"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/safe-regex-test": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+         "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "es-errors": "^1.3.0",
+            "is-regex": "^1.2.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
       },
       "node_modules/safer-buffer": {
          "version": "2.1.2",
@@ -6487,6 +9155,65 @@
          },
          "engines": {
             "node": ">=10"
+         }
+      },
+      "node_modules/serialize-javascript": {
+         "version": "6.0.2",
+         "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+         "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+         "dev": true,
+         "license": "BSD-3-Clause",
+         "dependencies": {
+            "randombytes": "^2.1.0"
+         }
+      },
+      "node_modules/set-function-length": {
+         "version": "1.2.2",
+         "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+         "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "define-data-property": "^1.1.4",
+            "es-errors": "^1.3.0",
+            "function-bind": "^1.1.2",
+            "get-intrinsic": "^1.2.4",
+            "gopd": "^1.0.1",
+            "has-property-descriptors": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/set-function-name": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+         "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "define-data-property": "^1.1.4",
+            "es-errors": "^1.3.0",
+            "functions-have-names": "^1.2.3",
+            "has-property-descriptors": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/set-proto": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+         "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "dunder-proto": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
          }
       },
       "node_modules/shebang-command": {
@@ -6627,6 +9354,26 @@
             "node": ">=8"
          }
       },
+      "node_modules/smob": {
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
+         "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/source-map": {
+         "version": "0.8.0-beta.0",
+         "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+         "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+         "dev": true,
+         "license": "BSD-3-Clause",
+         "dependencies": {
+            "whatwg-url": "^7.0.0"
+         },
+         "engines": {
+            "node": ">= 8"
+         }
+      },
       "node_modules/source-map-js": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6636,6 +9383,35 @@
          "engines": {
             "node": ">=0.10.0"
          }
+      },
+      "node_modules/source-map-support": {
+         "version": "0.5.21",
+         "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+         "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+         }
+      },
+      "node_modules/source-map-support/node_modules/source-map": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+         "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+         "dev": true,
+         "license": "BSD-3-Clause",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/sourcemap-codec": {
+         "version": "1.4.8",
+         "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+         "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+         "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/sshpk": {
          "version": "1.18.0",
@@ -6687,6 +9463,20 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/stop-iteration-iterator": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+         "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "es-errors": "^1.3.0",
+            "internal-slot": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
       "node_modules/string-width": {
          "version": "4.2.3",
          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6718,6 +9508,108 @@
             "node": ">=8"
          }
       },
+      "node_modules/string.prototype.matchall": {
+         "version": "4.0.12",
+         "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+         "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.3",
+            "define-properties": "^1.2.1",
+            "es-abstract": "^1.23.6",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0",
+            "get-intrinsic": "^1.2.6",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "internal-slot": "^1.1.0",
+            "regexp.prototype.flags": "^1.5.3",
+            "set-function-name": "^2.0.2",
+            "side-channel": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/string.prototype.trim": {
+         "version": "1.2.10",
+         "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+         "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.2",
+            "define-data-property": "^1.1.4",
+            "define-properties": "^1.2.1",
+            "es-abstract": "^1.23.5",
+            "es-object-atoms": "^1.0.0",
+            "has-property-descriptors": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/string.prototype.trimend": {
+         "version": "1.0.9",
+         "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+         "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.2",
+            "define-properties": "^1.2.1",
+            "es-object-atoms": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/string.prototype.trimstart": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+         "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.7",
+            "define-properties": "^1.2.1",
+            "es-object-atoms": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/stringify-object": {
+         "version": "3.3.0",
+         "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+         "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+         "dev": true,
+         "license": "BSD-2-Clause",
+         "dependencies": {
+            "get-own-enumerable-property-symbols": "^3.0.0",
+            "is-obj": "^1.0.1",
+            "is-regexp": "^1.0.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
       "node_modules/strip-ansi": {
          "version": "6.0.1",
          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -6743,6 +9635,16 @@
          },
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/strip-comments": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+         "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=10"
          }
       },
       "node_modules/strip-final-newline": {
@@ -6944,6 +9846,74 @@
          "engines": {
             "node": ">=14.0.0"
          }
+      },
+      "node_modules/temp-dir": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+         "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=8"
+         }
+      },
+      "node_modules/tempy": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+         "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "is-stream": "^2.0.0",
+            "temp-dir": "^2.0.0",
+            "type-fest": "^0.16.0",
+            "unique-string": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=10"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/tempy/node_modules/type-fest": {
+         "version": "0.16.0",
+         "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+         "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+         "dev": true,
+         "license": "(MIT OR CC0-1.0)",
+         "engines": {
+            "node": ">=10"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/terser": {
+         "version": "5.43.1",
+         "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+         "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+         "dev": true,
+         "license": "BSD-2-Clause",
+         "dependencies": {
+            "@jridgewell/source-map": "^0.3.3",
+            "acorn": "^8.14.0",
+            "commander": "^2.20.0",
+            "source-map-support": "~0.5.20"
+         },
+         "bin": {
+            "terser": "bin/terser"
+         },
+         "engines": {
+            "node": ">=10"
+         }
+      },
+      "node_modules/terser/node_modules/commander": {
+         "version": "2.20.3",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+         "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/text-segmentation": {
          "version": "1.0.3",
@@ -7153,6 +10123,16 @@
             "node": ">=16"
          }
       },
+      "node_modules/tr46": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+         "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "punycode": "^2.1.0"
+         }
+      },
       "node_modules/tree-kill": {
          "version": "1.2.2",
          "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -7256,6 +10236,84 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/typed-array-buffer": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+         "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "es-errors": "^1.3.0",
+            "is-typed-array": "^1.1.14"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/typed-array-byte-length": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+         "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.8",
+            "for-each": "^0.3.3",
+            "gopd": "^1.2.0",
+            "has-proto": "^1.2.0",
+            "is-typed-array": "^1.1.14"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/typed-array-byte-offset": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+         "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "available-typed-arrays": "^1.0.7",
+            "call-bind": "^1.0.8",
+            "for-each": "^0.3.3",
+            "gopd": "^1.2.0",
+            "has-proto": "^1.2.0",
+            "is-typed-array": "^1.1.15",
+            "reflect.getprototypeof": "^1.0.9"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/typed-array-length": {
+         "version": "1.0.7",
+         "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+         "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bind": "^1.0.7",
+            "for-each": "^0.3.3",
+            "gopd": "^1.0.1",
+            "is-typed-array": "^1.1.13",
+            "possible-typed-array-names": "^1.0.0",
+            "reflect.getprototypeof": "^1.0.6"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/typescript": {
@@ -7526,12 +10584,88 @@
             "url": "https://github.com/sponsors/isaacs"
          }
       },
+      "node_modules/unbox-primitive": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+         "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.3",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.1.0",
+            "which-boxed-primitive": "^1.1.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/undici-types": {
          "version": "7.8.0",
          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
          "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/unicode-canonical-property-names-ecmascript": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+         "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/unicode-match-property-ecmascript": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+         "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "unicode-canonical-property-names-ecmascript": "^2.0.0",
+            "unicode-property-aliases-ecmascript": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/unicode-match-property-value-ecmascript": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+         "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/unicode-property-aliases-ecmascript": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+         "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/unique-string": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+         "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "crypto-random-string": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=8"
+         }
       },
       "node_modules/universalify": {
          "version": "2.0.1",
@@ -7551,6 +10685,17 @@
          "license": "MIT",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/upath": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+         "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=4",
+            "yarn": "*"
          }
       },
       "node_modules/update-browserslist-db": {
@@ -7765,6 +10910,50 @@
             "url": "https://opencollective.com/vitest"
          }
       },
+      "node_modules/vite-plugin-pwa": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.0.0.tgz",
+         "integrity": "sha512-X77jo0AOd5OcxmWj3WnVti8n7Kw2tBgV1c8MCXFclrSlDV23ePzv2eTDIALXI2Qo6nJ5pZJeZAuX0AawvRfoeA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "debug": "^4.3.6",
+            "pretty-bytes": "^6.1.1",
+            "tinyglobby": "^0.2.10",
+            "workbox-build": "^7.3.0",
+            "workbox-window": "^7.3.0"
+         },
+         "engines": {
+            "node": ">=16.0.0"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/antfu"
+         },
+         "peerDependencies": {
+            "@vite-pwa/assets-generator": "^1.0.0",
+            "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "workbox-build": "^7.3.0",
+            "workbox-window": "^7.3.0"
+         },
+         "peerDependenciesMeta": {
+            "@vite-pwa/assets-generator": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/vite-plugin-pwa/node_modules/pretty-bytes": {
+         "version": "6.1.1",
+         "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+         "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": "^14.13.1 || >=16.0.0"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
       "node_modules/vite/node_modules/fdir": {
          "version": "6.4.6",
          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -7879,6 +11068,25 @@
             "url": "https://github.com/sponsors/jonschlinkert"
          }
       },
+      "node_modules/webidl-conversions": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+         "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+         "dev": true,
+         "license": "BSD-2-Clause"
+      },
+      "node_modules/whatwg-url": {
+         "version": "7.1.0",
+         "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+         "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+         }
+      },
       "node_modules/which": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7893,6 +11101,95 @@
          },
          "engines": {
             "node": ">= 8"
+         }
+      },
+      "node_modules/which-boxed-primitive": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+         "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "is-bigint": "^1.1.0",
+            "is-boolean-object": "^1.2.1",
+            "is-number-object": "^1.1.1",
+            "is-string": "^1.1.1",
+            "is-symbol": "^1.1.1"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/which-builtin-type": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+         "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "call-bound": "^1.0.2",
+            "function.prototype.name": "^1.1.6",
+            "has-tostringtag": "^1.0.2",
+            "is-async-function": "^2.0.0",
+            "is-date-object": "^1.1.0",
+            "is-finalizationregistry": "^1.1.0",
+            "is-generator-function": "^1.0.10",
+            "is-regex": "^1.2.1",
+            "is-weakref": "^1.0.2",
+            "isarray": "^2.0.5",
+            "which-boxed-primitive": "^1.1.0",
+            "which-collection": "^1.0.2",
+            "which-typed-array": "^1.1.16"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/which-collection": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+         "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "is-map": "^2.0.3",
+            "is-set": "^2.0.3",
+            "is-weakmap": "^2.0.2",
+            "is-weakset": "^2.0.3"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/which-typed-array": {
+         "version": "1.1.19",
+         "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+         "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "available-typed-arrays": "^1.0.7",
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.4",
+            "for-each": "^0.3.5",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "has-tostringtag": "^1.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/why-is-node-running": {
@@ -7920,6 +11217,351 @@
          "license": "MIT",
          "engines": {
             "node": ">=0.10.0"
+         }
+      },
+      "node_modules/workbox-background-sync": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.3.0.tgz",
+         "integrity": "sha512-PCSk3eK7Mxeuyatb22pcSx9dlgWNv3+M8PqPaYDokks8Y5/FX4soaOqj3yhAZr5k6Q5JWTOMYgaJBpbw11G9Eg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "idb": "^7.0.1",
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-broadcast-update": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.3.0.tgz",
+         "integrity": "sha512-T9/F5VEdJVhwmrIAE+E/kq5at2OY6+OXXgOWQevnubal6sO92Gjo24v6dCVwQiclAF5NS3hlmsifRrpQzZCdUA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-build": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.3.0.tgz",
+         "integrity": "sha512-JGL6vZTPlxnlqZRhR/K/msqg3wKP+m0wfEUVosK7gsYzSgeIxvZLi1ViJJzVL7CEeI8r7rGFV973RiEqkP3lWQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@apideck/better-ajv-errors": "^0.3.1",
+            "@babel/core": "^7.24.4",
+            "@babel/preset-env": "^7.11.0",
+            "@babel/runtime": "^7.11.2",
+            "@rollup/plugin-babel": "^5.2.0",
+            "@rollup/plugin-node-resolve": "^15.2.3",
+            "@rollup/plugin-replace": "^2.4.1",
+            "@rollup/plugin-terser": "^0.4.3",
+            "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+            "ajv": "^8.6.0",
+            "common-tags": "^1.8.0",
+            "fast-json-stable-stringify": "^2.1.0",
+            "fs-extra": "^9.0.1",
+            "glob": "^7.1.6",
+            "lodash": "^4.17.20",
+            "pretty-bytes": "^5.3.0",
+            "rollup": "^2.43.1",
+            "source-map": "^0.8.0-beta.0",
+            "stringify-object": "^3.3.0",
+            "strip-comments": "^2.0.1",
+            "tempy": "^0.6.0",
+            "upath": "^1.2.0",
+            "workbox-background-sync": "7.3.0",
+            "workbox-broadcast-update": "7.3.0",
+            "workbox-cacheable-response": "7.3.0",
+            "workbox-core": "7.3.0",
+            "workbox-expiration": "7.3.0",
+            "workbox-google-analytics": "7.3.0",
+            "workbox-navigation-preload": "7.3.0",
+            "workbox-precaching": "7.3.0",
+            "workbox-range-requests": "7.3.0",
+            "workbox-recipes": "7.3.0",
+            "workbox-routing": "7.3.0",
+            "workbox-strategies": "7.3.0",
+            "workbox-streams": "7.3.0",
+            "workbox-sw": "7.3.0",
+            "workbox-window": "7.3.0"
+         },
+         "engines": {
+            "node": ">=16.0.0"
+         }
+      },
+      "node_modules/workbox-build/node_modules/@apideck/better-ajv-errors": {
+         "version": "0.3.6",
+         "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
+         "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "json-schema": "^0.4.0",
+            "jsonpointer": "^5.0.0",
+            "leven": "^3.1.0"
+         },
+         "engines": {
+            "node": ">=10"
+         },
+         "peerDependencies": {
+            "ajv": ">=8"
+         }
+      },
+      "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
+         "version": "5.3.1",
+         "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
+         "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@rollup/pluginutils": "^3.1.0"
+         },
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "peerDependencies": {
+            "@babel/core": "^7.0.0",
+            "@types/babel__core": "^7.1.9",
+            "rollup": "^1.20.0||^2.0.0"
+         },
+         "peerDependenciesMeta": {
+            "@types/babel__core": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
+         "version": "2.4.2",
+         "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+         "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@rollup/pluginutils": "^3.1.0",
+            "magic-string": "^0.25.7"
+         },
+         "peerDependencies": {
+            "rollup": "^1.20.0 || ^2.0.0"
+         }
+      },
+      "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+         "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+         },
+         "engines": {
+            "node": ">= 8.0.0"
+         },
+         "peerDependencies": {
+            "rollup": "^1.20.0||^2.0.0"
+         }
+      },
+      "node_modules/workbox-build/node_modules/@types/estree": {
+         "version": "0.0.39",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+         "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/workbox-build/node_modules/ajv": {
+         "version": "8.17.1",
+         "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+         "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+         },
+         "funding": {
+            "type": "github",
+            "url": "https://github.com/sponsors/epoberezkin"
+         }
+      },
+      "node_modules/workbox-build/node_modules/estree-walker": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+         "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/workbox-build/node_modules/json-schema-traverse": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+         "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/workbox-build/node_modules/magic-string": {
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+         "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "sourcemap-codec": "^1.4.8"
+         }
+      },
+      "node_modules/workbox-build/node_modules/rollup": {
+         "version": "2.79.2",
+         "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+         "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+         "dev": true,
+         "license": "MIT",
+         "bin": {
+            "rollup": "dist/bin/rollup"
+         },
+         "engines": {
+            "node": ">=10.0.0"
+         },
+         "optionalDependencies": {
+            "fsevents": "~2.3.2"
+         }
+      },
+      "node_modules/workbox-cacheable-response": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.3.0.tgz",
+         "integrity": "sha512-eAFERIg6J2LuyELhLlmeRcJFa5e16Mj8kL2yCDbhWE+HUun9skRQrGIFVUagqWj4DMaaPSMWfAolM7XZZxNmxA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-core": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.3.0.tgz",
+         "integrity": "sha512-Z+mYrErfh4t3zi7NVTvOuACB0A/jA3bgxUN3PwtAVHvfEsZxV9Iju580VEETug3zYJRc0Dmii/aixI/Uxj8fmw==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/workbox-expiration": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.3.0.tgz",
+         "integrity": "sha512-lpnSSLp2BM+K6bgFCWc5bS1LR5pAwDWbcKt1iL87/eTSJRdLdAwGQznZE+1czLgn/X05YChsrEegTNxjM067vQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "idb": "^7.0.1",
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-google-analytics": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.3.0.tgz",
+         "integrity": "sha512-ii/tSfFdhjLHZ2BrYgFNTrb/yk04pw2hasgbM70jpZfLk0vdJAXgaiMAWsoE+wfJDNWoZmBYY0hMVI0v5wWDbg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-background-sync": "7.3.0",
+            "workbox-core": "7.3.0",
+            "workbox-routing": "7.3.0",
+            "workbox-strategies": "7.3.0"
+         }
+      },
+      "node_modules/workbox-navigation-preload": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.3.0.tgz",
+         "integrity": "sha512-fTJzogmFaTv4bShZ6aA7Bfj4Cewaq5rp30qcxl2iYM45YD79rKIhvzNHiFj1P+u5ZZldroqhASXwwoyusnr2cg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-precaching": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.3.0.tgz",
+         "integrity": "sha512-ckp/3t0msgXclVAYaNndAGeAoWQUv7Rwc4fdhWL69CCAb2UHo3Cef0KIUctqfQj1p8h6aGyz3w8Cy3Ihq9OmIw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0",
+            "workbox-routing": "7.3.0",
+            "workbox-strategies": "7.3.0"
+         }
+      },
+      "node_modules/workbox-range-requests": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.3.0.tgz",
+         "integrity": "sha512-EyFmM1KpDzzAouNF3+EWa15yDEenwxoeXu9bgxOEYnFfCxns7eAxA9WSSaVd8kujFFt3eIbShNqa4hLQNFvmVQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-recipes": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.3.0.tgz",
+         "integrity": "sha512-BJro/MpuW35I/zjZQBcoxsctgeB+kyb2JAP5EB3EYzePg8wDGoQuUdyYQS+CheTb+GhqJeWmVs3QxLI8EBP1sg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-cacheable-response": "7.3.0",
+            "workbox-core": "7.3.0",
+            "workbox-expiration": "7.3.0",
+            "workbox-precaching": "7.3.0",
+            "workbox-routing": "7.3.0",
+            "workbox-strategies": "7.3.0"
+         }
+      },
+      "node_modules/workbox-routing": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.3.0.tgz",
+         "integrity": "sha512-ZUlysUVn5ZUzMOmQN3bqu+gK98vNfgX/gSTZ127izJg/pMMy4LryAthnYtjuqcjkN4HEAx1mdgxNiKJMZQM76A==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-strategies": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.3.0.tgz",
+         "integrity": "sha512-tmZydug+qzDFATwX7QiEL5Hdf7FrkhjaF9db1CbB39sDmEZJg3l9ayDvPxy8Y18C3Y66Nrr9kkN1f/RlkDgllg==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0"
+         }
+      },
+      "node_modules/workbox-streams": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.3.0.tgz",
+         "integrity": "sha512-SZnXucyg8x2Y61VGtDjKPO5EgPUG5NDn/v86WYHX+9ZqvAsGOytP0Jxp1bl663YUuMoXSAtsGLL+byHzEuMRpw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "workbox-core": "7.3.0",
+            "workbox-routing": "7.3.0"
+         }
+      },
+      "node_modules/workbox-sw": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.3.0.tgz",
+         "integrity": "sha512-aCUyoAZU9IZtH05mn0ACUpyHzPs0lMeJimAYkQkBsOWiqaJLgusfDCR+yllkPkFRxWpZKF8vSvgHYeG7LwhlmA==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/workbox-window": {
+         "version": "7.3.0",
+         "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.3.0.tgz",
+         "integrity": "sha512-qW8PDy16OV1UBaUNGlTVcepzrlzyzNW/ZJvFQQs2j2TzGsg6IKjcpZC1RSquqQnTOafl5pCj5bGfAHlCjOOjdA==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@types/trusted-types": "^2.0.2",
+            "workbox-core": "7.3.0"
          }
       },
       "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       "typescript": "^5.0.2",
       "typescript-eslint": "^8.34.1",
       "vite": "^6.3.5",
+      "vite-plugin-pwa": "^1.0.0",
       "vitest": "^3.2.4"
    }
 }

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "La Virtual Zone",
+  "short_name": "VirtualZone",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/src/assets/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { registerSW } from 'virtual:pwa-register';
 import App from './App';
 import './index.css';
+
+registerSW();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,46 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) =>
+              request.destination === 'script' ||
+              request.destination === 'style' ||
+              request.destination === 'image',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'static-assets',
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 60 * 60 * 24 * 7,
+              },
+            },
+          },
+          {
+            urlPattern: /\/api\/.*$/,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-cache',
+              networkTimeoutSeconds: 10,
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60 * 24,
+              },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
+      },
+    }),
+  ],
   optimizeDeps: {
     include: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- add `vite-plugin-pwa` dependency
- register the service worker
- generate manifest file for icons
- configure `VitePWA` with runtime caching for assets and API calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b257fec1083338862ecffa6ab9014