### PR TITLE
Add basic API server and query hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
             "@fullcalendar/daygrid": "^6.1.17",
             "@fullcalendar/interaction": "^6.1.17",
             "@fullcalendar/react": "^6.1.17",
+            "@tanstack/react-query": "^5.81.2",
+            "cors": "^2.8.5",
+            "express": "^5.1.0",
             "framer-motion": "^12.19.1",
             "jspdf": "^3.0.1",
             "jspdf-autotable": "^5.0.2",
@@ -44,6 +47,7 @@
             "globals": "^13.20.0",
             "postcss": "^8.4.24",
             "tailwindcss": "^3.3.2",
+            "ts-node": "^10.9.2",
             "typescript": "^5.0.2",
             "typescript-eslint": "^8.34.1",
             "vite": "^6.3.5",
@@ -386,6 +390,30 @@
          },
          "engines": {
             "node": ">=6.9.0"
+         }
+      },
+      "node_modules/@cspotcode/source-map-support": {
+         "version": "0.8.1",
+         "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+         "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@jridgewell/trace-mapping": "0.3.9"
+         },
+         "engines": {
+            "node": ">=12"
+         }
+      },
+      "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+         "version": "0.3.9",
+         "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+         "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
          }
       },
       "node_modules/@cypress/request": {
@@ -1578,6 +1606,60 @@
          "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
          "license": "MIT"
       },
+      "node_modules/@tanstack/query-core": {
+         "version": "5.81.2",
+         "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.2.tgz",
+         "integrity": "sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==",
+         "license": "MIT",
+         "funding": {
+            "type": "github",
+            "url": "https://github.com/sponsors/tannerlinsley"
+         }
+      },
+      "node_modules/@tanstack/react-query": {
+         "version": "5.81.2",
+         "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.2.tgz",
+         "integrity": "sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==",
+         "license": "MIT",
+         "dependencies": {
+            "@tanstack/query-core": "5.81.2"
+         },
+         "funding": {
+            "type": "github",
+            "url": "https://github.com/sponsors/tannerlinsley"
+         },
+         "peerDependencies": {
+            "react": "^18 || ^19"
+         }
+      },
+      "node_modules/@tsconfig/node10": {
+         "version": "1.0.11",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+         "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@tsconfig/node12": {
+         "version": "1.0.11",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+         "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@tsconfig/node14": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+         "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@tsconfig/node16": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+         "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/@types/babel__core": {
          "version": "7.20.5",
          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2198,6 +2280,40 @@
             "url": "https://opencollective.com/vitest"
          }
       },
+      "node_modules/accepts": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+         "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+         "license": "MIT",
+         "dependencies": {
+            "mime-types": "^3.0.0",
+            "negotiator": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/accepts/node_modules/mime-db": {
+         "version": "1.54.0",
+         "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+         "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/accepts/node_modules/mime-types": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+         "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+         "license": "MIT",
+         "dependencies": {
+            "mime-db": "^1.54.0"
+         },
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
       "node_modules/acorn": {
          "version": "8.15.0",
          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2219,6 +2335,19 @@
          "license": "MIT",
          "peerDependencies": {
             "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+         }
+      },
+      "node_modules/acorn-walk": {
+         "version": "8.3.4",
+         "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+         "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "acorn": "^8.11.0"
+         },
+         "engines": {
+            "node": ">=0.4.0"
          }
       },
       "node_modules/aggregate-error": {
@@ -2589,6 +2718,26 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/body-parser": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+         "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+         "license": "MIT",
+         "dependencies": {
+            "bytes": "^3.1.2",
+            "content-type": "^1.0.5",
+            "debug": "^4.4.0",
+            "http-errors": "^2.0.0",
+            "iconv-lite": "^0.6.3",
+            "on-finished": "^2.4.1",
+            "qs": "^6.14.0",
+            "raw-body": "^3.0.0",
+            "type-is": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
       "node_modules/brace-expansion": {
          "version": "1.1.12",
          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2693,6 +2842,15 @@
             "node": "*"
          }
       },
+      "node_modules/bytes": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+         "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/cac": {
          "version": "6.7.14",
          "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2717,7 +2875,6 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
          "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "es-errors": "^1.3.0",
@@ -2731,7 +2888,6 @@
          "version": "1.0.4",
          "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
          "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "call-bind-apply-helpers": "^1.0.2",
@@ -3076,12 +3232,51 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/content-disposition": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+         "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+         "license": "MIT",
+         "dependencies": {
+            "safe-buffer": "5.2.1"
+         },
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/content-type": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+         "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
       "node_modules/convert-source-map": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/cookie": {
+         "version": "0.7.2",
+         "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+         "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/cookie-signature": {
+         "version": "1.2.2",
+         "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+         "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.6.0"
+         }
       },
       "node_modules/core-js": {
          "version": "3.43.0",
@@ -3099,6 +3294,26 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/cors": {
+         "version": "2.8.5",
+         "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+         "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+         "license": "MIT",
+         "dependencies": {
+            "object-assign": "^4",
+            "vary": "^1"
+         },
+         "engines": {
+            "node": ">= 0.10"
+         }
+      },
+      "node_modules/create-require": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+         "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
          "dev": true,
          "license": "MIT"
       },
@@ -3351,7 +3566,6 @@
          "version": "4.4.1",
          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "ms": "^2.1.3"
@@ -3398,12 +3612,31 @@
             "node": ">=0.4.0"
          }
       },
+      "node_modules/depd": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+         "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/didyoumean": {
          "version": "1.2.2",
          "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
          "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
          "dev": true,
          "license": "Apache-2.0"
+      },
+      "node_modules/diff": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+         "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+         "dev": true,
+         "license": "BSD-3-Clause",
+         "engines": {
+            "node": ">=0.3.1"
+         }
       },
       "node_modules/dir-glob": {
          "version": "3.0.1",
@@ -3452,7 +3685,6 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
          "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "call-bind-apply-helpers": "^1.0.1",
@@ -3481,6 +3713,12 @@
             "safer-buffer": "^2.1.0"
          }
       },
+      "node_modules/ee-first": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+         "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+         "license": "MIT"
+      },
       "node_modules/electron-to-chromium": {
          "version": "1.5.172",
          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.172.tgz",
@@ -3494,6 +3732,15 @@
          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/encodeurl": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+         "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
+         }
       },
       "node_modules/end-of-stream": {
          "version": "1.4.5",
@@ -3523,7 +3770,6 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">= 0.4"
@@ -3533,7 +3779,6 @@
          "version": "1.3.0",
          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">= 0.4"
@@ -3550,7 +3795,6 @@
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "es-errors": "^1.3.0"
@@ -3635,6 +3879,12 @@
          "engines": {
             "node": ">=6"
          }
+      },
+      "node_modules/escape-html": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+         "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+         "license": "MIT"
       },
       "node_modules/escape-string-regexp": {
          "version": "4.0.0",
@@ -3887,6 +4137,15 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/etag": {
+         "version": "1.8.1",
+         "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+         "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
       "node_modules/eventemitter2": {
          "version": "6.4.7",
          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
@@ -3945,6 +4204,69 @@
          "license": "Apache-2.0",
          "engines": {
             "node": ">=12.0.0"
+         }
+      },
+      "node_modules/express": {
+         "version": "5.1.0",
+         "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+         "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+         "license": "MIT",
+         "dependencies": {
+            "accepts": "^2.0.0",
+            "body-parser": "^2.2.0",
+            "content-disposition": "^1.0.0",
+            "content-type": "^1.0.5",
+            "cookie": "^0.7.1",
+            "cookie-signature": "^1.2.1",
+            "debug": "^4.4.0",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "etag": "^1.8.1",
+            "finalhandler": "^2.1.0",
+            "fresh": "^2.0.0",
+            "http-errors": "^2.0.0",
+            "merge-descriptors": "^2.0.0",
+            "mime-types": "^3.0.0",
+            "on-finished": "^2.4.1",
+            "once": "^1.4.0",
+            "parseurl": "^1.3.3",
+            "proxy-addr": "^2.0.7",
+            "qs": "^6.14.0",
+            "range-parser": "^1.2.1",
+            "router": "^2.2.0",
+            "send": "^1.1.0",
+            "serve-static": "^2.2.0",
+            "statuses": "^2.0.1",
+            "type-is": "^2.0.1",
+            "vary": "^1.1.2"
+         },
+         "engines": {
+            "node": ">= 18"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/express"
+         }
+      },
+      "node_modules/express/node_modules/mime-db": {
+         "version": "1.54.0",
+         "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+         "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/express/node_modules/mime-types": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+         "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+         "license": "MIT",
+         "dependencies": {
+            "mime-db": "^1.54.0"
+         },
+         "engines": {
+            "node": ">= 0.6"
          }
       },
       "node_modules/extend": {
@@ -4114,6 +4436,23 @@
             "node": ">=8"
          }
       },
+      "node_modules/finalhandler": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+         "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+         "license": "MIT",
+         "dependencies": {
+            "debug": "^4.4.0",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "on-finished": "^2.4.1",
+            "parseurl": "^1.3.3",
+            "statuses": "^2.0.1"
+         },
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/find-up": {
          "version": "5.0.0",
          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4210,6 +4549,15 @@
             "node": ">= 6"
          }
       },
+      "node_modules/forwarded": {
+         "version": "0.2.0",
+         "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+         "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
       "node_modules/fraction.js": {
          "version": "4.3.7",
          "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -4249,6 +4597,15 @@
             "react-dom": {
                "optional": true
             }
+         }
+      },
+      "node_modules/fresh": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+         "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
          }
       },
       "node_modules/fs-extra": {
@@ -4292,7 +4649,6 @@
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-         "dev": true,
          "license": "MIT",
          "funding": {
             "url": "https://github.com/sponsors/ljharb"
@@ -4312,7 +4668,6 @@
          "version": "1.3.0",
          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "call-bind-apply-helpers": "^1.0.2",
@@ -4337,7 +4692,6 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
          "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "dunder-proto": "^1.0.1",
@@ -4484,7 +4838,6 @@
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">= 0.4"
@@ -4521,7 +4874,6 @@
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">= 0.4"
@@ -4577,7 +4929,6 @@
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "function-bind": "^1.1.2"
@@ -4598,6 +4949,31 @@
          },
          "engines": {
             "node": ">=8.0.0"
+         }
+      },
+      "node_modules/http-errors": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+         "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+         "license": "MIT",
+         "dependencies": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+         },
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
+      "node_modules/http-errors/node_modules/statuses": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+         "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
          }
       },
       "node_modules/http-signature": {
@@ -4623,6 +4999,18 @@
          "license": "Apache-2.0",
          "engines": {
             "node": ">=8.12.0"
+         }
+      },
+      "node_modules/iconv-lite": {
+         "version": "0.6.3",
+         "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+         "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+         "license": "MIT",
+         "dependencies": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+         },
+         "engines": {
+            "node": ">=0.10.0"
          }
       },
       "node_modules/ieee754": {
@@ -4719,7 +5107,6 @@
          "version": "2.0.4",
          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-         "dev": true,
          "license": "ISC"
       },
       "node_modules/ini": {
@@ -4739,6 +5126,15 @@
          "license": "ISC",
          "engines": {
             "node": ">=12"
+         }
+      },
+      "node_modules/ipaddr.js": {
+         "version": "1.9.1",
+         "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+         "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.10"
          }
       },
       "node_modules/is-binary-path": {
@@ -4839,6 +5235,12 @@
          "engines": {
             "node": ">=8"
          }
+      },
+      "node_modules/is-promise": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+         "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+         "license": "MIT"
       },
       "node_modules/is-stream": {
          "version": "2.0.1",
@@ -5292,14 +5694,41 @@
             "@jridgewell/sourcemap-codec": "^1.5.0"
          }
       },
+      "node_modules/make-error": {
+         "version": "1.3.6",
+         "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+         "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+         "dev": true,
+         "license": "ISC"
+      },
       "node_modules/math-intrinsics": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">= 0.4"
+         }
+      },
+      "node_modules/media-typer": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+         "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
+      "node_modules/merge-descriptors": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+         "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=18"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
          }
       },
       "node_modules/merge-stream": {
@@ -5418,7 +5847,6 @@
          "version": "2.1.3",
          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-         "dev": true,
          "license": "MIT"
       },
       "node_modules/mz": {
@@ -5466,6 +5894,15 @@
          "dev": true,
          "license": "MIT"
       },
+      "node_modules/negotiator": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+         "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
       "node_modules/node-releases": {
          "version": "2.0.19",
          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -5510,7 +5947,6 @@
          "version": "4.1.1",
          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
          "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">=0.10.0"
@@ -5530,7 +5966,6 @@
          "version": "1.13.4",
          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
          "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-         "dev": true,
          "license": "MIT",
          "engines": {
             "node": ">= 0.4"
@@ -5539,11 +5974,22 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/on-finished": {
+         "version": "2.4.1",
+         "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+         "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+         "license": "MIT",
+         "dependencies": {
+            "ee-first": "1.1.1"
+         },
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/once": {
          "version": "1.4.0",
          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-         "dev": true,
          "license": "ISC",
          "dependencies": {
             "wrappy": "1"
@@ -5658,6 +6104,15 @@
             "node": ">=6"
          }
       },
+      "node_modules/parseurl": {
+         "version": "1.3.3",
+         "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+         "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/path-exists": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5718,6 +6173,15 @@
          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
          "dev": true,
          "license": "ISC"
+      },
+      "node_modules/path-to-regexp": {
+         "version": "8.2.0",
+         "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+         "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=16"
+         }
       },
       "node_modules/path-type": {
          "version": "4.0.0",
@@ -5993,6 +6457,19 @@
             "node": ">= 0.6.0"
          }
       },
+      "node_modules/proxy-addr": {
+         "version": "2.0.7",
+         "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+         "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+         "license": "MIT",
+         "dependencies": {
+            "forwarded": "0.2.0",
+            "ipaddr.js": "1.9.1"
+         },
+         "engines": {
+            "node": ">= 0.10"
+         }
+      },
       "node_modules/proxy-from-env": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -6025,7 +6502,6 @@
          "version": "6.14.0",
          "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
          "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-         "dev": true,
          "license": "BSD-3-Clause",
          "dependencies": {
             "side-channel": "^1.1.0"
@@ -6066,6 +6542,30 @@
          "optional": true,
          "dependencies": {
             "performance-now": "^2.1.0"
+         }
+      },
+      "node_modules/range-parser": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+         "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/raw-body": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+         "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+         "license": "MIT",
+         "dependencies": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.6.3",
+            "unpipe": "1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.8"
          }
       },
       "node_modules/react": {
@@ -6405,6 +6905,22 @@
             "fsevents": "~2.3.2"
          }
       },
+      "node_modules/router": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+         "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+         "license": "MIT",
+         "dependencies": {
+            "debug": "^4.4.0",
+            "depd": "^2.0.0",
+            "is-promise": "^4.0.0",
+            "parseurl": "^1.3.3",
+            "path-to-regexp": "^8.0.0"
+         },
+         "engines": {
+            "node": ">= 18"
+         }
+      },
       "node_modules/run-parallel": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6443,7 +6959,6 @@
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-         "dev": true,
          "funding": [
             {
                "type": "github",
@@ -6464,7 +6979,6 @@
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-         "dev": true,
          "license": "MIT"
       },
       "node_modules/scheduler": {
@@ -6488,6 +7002,70 @@
          "engines": {
             "node": ">=10"
          }
+      },
+      "node_modules/send": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+         "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+         "license": "MIT",
+         "dependencies": {
+            "debug": "^4.3.5",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "etag": "^1.8.1",
+            "fresh": "^2.0.0",
+            "http-errors": "^2.0.0",
+            "mime-types": "^3.0.1",
+            "ms": "^2.1.3",
+            "on-finished": "^2.4.1",
+            "range-parser": "^1.2.1",
+            "statuses": "^2.0.1"
+         },
+         "engines": {
+            "node": ">= 18"
+         }
+      },
+      "node_modules/send/node_modules/mime-db": {
+         "version": "1.54.0",
+         "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+         "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/send/node_modules/mime-types": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+         "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+         "license": "MIT",
+         "dependencies": {
+            "mime-db": "^1.54.0"
+         },
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/serve-static": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+         "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+         "license": "MIT",
+         "dependencies": {
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "parseurl": "^1.3.3",
+            "send": "^1.2.0"
+         },
+         "engines": {
+            "node": ">= 18"
+         }
+      },
+      "node_modules/setprototypeof": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+         "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+         "license": "ISC"
       },
       "node_modules/shebang-command": {
          "version": "2.0.0",
@@ -6516,7 +7094,6 @@
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
          "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "es-errors": "^1.3.0",
@@ -6536,7 +7113,6 @@
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
          "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "es-errors": "^1.3.0",
@@ -6553,7 +7129,6 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
          "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "call-bound": "^1.0.2",
@@ -6572,7 +7147,6 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
          "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-         "dev": true,
          "license": "MIT",
          "dependencies": {
             "call-bound": "^1.0.2",
@@ -6678,6 +7252,15 @@
          "optional": true,
          "engines": {
             "node": ">=0.1.14"
+         }
+      },
+      "node_modules/statuses": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+         "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
          }
       },
       "node_modules/std-env": {
@@ -7140,6 +7723,15 @@
             "node": ">=8.0"
          }
       },
+      "node_modules/toidentifier": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+         "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.6"
+         }
+      },
       "node_modules/tough-cookie": {
          "version": "5.1.2",
          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -7182,6 +7774,57 @@
          "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
          "dev": true,
          "license": "Apache-2.0"
+      },
+      "node_modules/ts-node": {
+         "version": "10.9.2",
+         "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+         "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@cspotcode/source-map-support": "^0.8.0",
+            "@tsconfig/node10": "^1.0.7",
+            "@tsconfig/node12": "^1.0.7",
+            "@tsconfig/node14": "^1.0.0",
+            "@tsconfig/node16": "^1.0.2",
+            "acorn": "^8.4.1",
+            "acorn-walk": "^8.1.1",
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "v8-compile-cache-lib": "^3.0.1",
+            "yn": "3.1.1"
+         },
+         "bin": {
+            "ts-node": "dist/bin.js",
+            "ts-node-cwd": "dist/bin-cwd.js",
+            "ts-node-esm": "dist/bin-esm.js",
+            "ts-node-script": "dist/bin-script.js",
+            "ts-node-transpile-only": "dist/bin-transpile.js",
+            "ts-script": "dist/bin-script-deprecated.js"
+         },
+         "peerDependencies": {
+            "@swc/core": ">=1.2.50",
+            "@swc/wasm": ">=1.2.50",
+            "@types/node": "*",
+            "typescript": ">=2.7"
+         },
+         "peerDependenciesMeta": {
+            "@swc/core": {
+               "optional": true
+            },
+            "@swc/wasm": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/ts-node/node_modules/arg": {
+         "version": "4.1.3",
+         "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+         "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/tslib": {
          "version": "2.8.1",
@@ -7256,6 +7899,41 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/type-is": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+         "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+         "license": "MIT",
+         "dependencies": {
+            "content-type": "^1.0.5",
+            "media-typer": "^1.1.0",
+            "mime-types": "^3.0.0"
+         },
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/type-is/node_modules/mime-db": {
+         "version": "1.54.0",
+         "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+         "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.6"
+         }
+      },
+      "node_modules/type-is/node_modules/mime-types": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+         "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+         "license": "MIT",
+         "dependencies": {
+            "mime-db": "^1.54.0"
+         },
+         "engines": {
+            "node": ">= 0.6"
          }
       },
       "node_modules/typescript": {
@@ -7543,6 +8221,15 @@
             "node": ">= 10.0.0"
          }
       },
+      "node_modules/unpipe": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+         "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/untildify": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -7628,6 +8315,22 @@
          "license": "MIT",
          "bin": {
             "uuid": "dist/bin/uuid"
+         }
+      },
+      "node_modules/v8-compile-cache-lib": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+         "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/vary": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+         "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 0.8"
          }
       },
       "node_modules/verror": {
@@ -7963,7 +8666,6 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-         "dev": true,
          "license": "ISC"
       },
       "node_modules/yallist": {
@@ -7995,6 +8697,16 @@
          "dependencies": {
             "buffer-crc32": "~0.2.3",
             "fd-slicer": "~1.1.0"
+         }
+      },
+      "node_modules/yn": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+         "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=6"
          }
       },
       "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,16 @@
    "private": true,
    "version": "0.1.0",
    "type": "module",
-   "scripts": {
-      "dev": "vite",
-      "build": "tsc && vite build",
-      "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
-      "preview": "vite preview",
-      "cypress:open": "cypress open",
-      "test:unit": "vitest run",
-      "test": "npm run lint && npm run build && npm run test:unit && (npx cypress run || echo \"Skipping e2e tests: Cypress not installed\")"
-   },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview",
+    "cypress:open": "cypress open",
+    "test:unit": "vitest run",
+    "test": "npm run lint && npm run build && npm run test:unit && (npx cypress run || echo \"Skipping e2e tests: Cypress not installed\")",
+    "server": "node server/server.js"
+  },
    "dependencies": {
       "@dnd-kit/core": "^6.3.1",
       "@dnd-kit/sortable": "^10.0.0",
@@ -20,6 +21,9 @@
       "@fullcalendar/daygrid": "^6.1.17",
       "@fullcalendar/interaction": "^6.1.17",
       "@fullcalendar/react": "^6.1.17",
+      "@tanstack/react-query": "^5.81.2",
+      "cors": "^2.8.5",
+      "express": "^5.1.0",
       "framer-motion": "^12.19.1",
       "jspdf": "^3.0.1",
       "jspdf-autotable": "^5.0.2",
@@ -49,6 +53,7 @@
       "globals": "^13.20.0",
       "postcss": "^8.4.24",
       "tailwindcss": "^3.3.2",
+      "ts-node": "^10.9.2",
       "typescript": "^5.0.2",
       "typescript-eslint": "^8.34.1",
       "vite": "^6.3.5",

--- a/server/data/clubs.json
+++ b/server/data/clubs.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "club1",
+    "slug": "rayo-digital-fc",
+    "name": "Rayo Digital FC",
+    "logo": "https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true",
+    "foundedYear": 2023,
+    "stadium": "Estadio Cyber Arena",
+    "budget": 25000000,
+    "manager": "coach",
+    "playStyle": "Posesión",
+    "primaryColor": "#ef4444",
+    "secondaryColor": "#000000",
+    "description": "Club fundador de la Liga Master, conocido por su juego de posesión y formación de talento joven.",
+    "reputation": 85,
+    "fanBase": 10000,
+    "morale": 75
+  },
+  {
+    "id": "club2",
+    "slug": "atletico-pixelado",
+    "name": "Atlético Pixelado",
+    "logo": "https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true",
+    "foundedYear": 2023,
+    "stadium": "Pixel Arena",
+    "budget": 22000000,
+    "manager": "DT Pixel",
+    "playStyle": "Contraataque",
+    "primaryColor": "#3b82f6",
+    "secondaryColor": "#ffffff",
+    "description": "Club histórico con un estilo de juego agresivo y rápido, especializado en contraataques letales.",
+    "reputation": 80,
+    "fanBase": 8500,
+    "morale": 70
+  },
+  {
+    "id": "club4",
+    "slug": "neon-fc",
+    "name": "Neón FC",
+    "logo": "https://ui-avatars.com/api/?name=NFC&background=ec4899&color=fff&size=128&bold=true",
+    "foundedYear": 2023,
+    "stadium": "Estadio Luminoso",
+    "budget": 23000000,
+    "manager": "DT Neon",
+    "playStyle": "Ofensivo",
+    "primaryColor": "#ec4899",
+    "secondaryColor": "#00b3ff",
+    "description": "Club con estilo de juego espectacular y ofensivo. Conocido por sus fichajes estrella.",
+    "reputation": 83,
+    "fanBase": 9500,
+    "morale": 80
+  }
+]

--- a/server/data/fixtures.json
+++ b/server/data/fixtures.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "match1",
+    "category": "partido",
+    "title": "Rayo Digital FC vs Atlético Pixelado",
+    "start": "2025-02-02T18:00:00",
+    "homeTeam": "Rayo Digital FC",
+    "homeLogo": "https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true",
+    "awayTeam": "Atlético Pixelado",
+    "awayLogo": "https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true",
+    "venue": "Estadio Cyber Arena",
+    "weather": "Soleado",
+    "moral": "Alta"
+  },
+  {
+    "id": "training1",
+    "category": "entrenamiento",
+    "title": "Entrenamiento matutino",
+    "start": "2025-02-04T10:00:00",
+    "venue": "Campo de entrenamiento",
+    "weather": "Parcialmente nublado",
+    "moral": "Media"
+  },
+  {
+    "id": "finance1",
+    "category": "finanzas",
+    "title": "Revisión financiera",
+    "start": "2025-02-10T12:00:00"
+  },
+  {
+    "id": "match2",
+    "category": "partido",
+    "title": "Neón FC vs Rayo Digital FC",
+    "start": "2025-02-12T20:00:00",
+    "homeTeam": "Neón FC",
+    "homeLogo": "https://ui-avatars.com/api/?name=NFC&background=ec4899&color=fff&size=128&bold=true",
+    "awayTeam": "Rayo Digital FC",
+    "awayLogo": "https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true",
+    "venue": "Estadio Luminoso",
+    "weather": "Lluvia",
+    "moral": "Alta"
+  },
+  {
+    "id": "marketEnd",
+    "category": "mercado",
+    "title": "Fin de mercado",
+    "start": "2025-02-15"
+  }
+]

--- a/server/data/players.json
+++ b/server/data/players.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 1,
+    "number": 1,
+    "name": "Juan Pérez",
+    "position": "GK",
+    "ovr": 82,
+    "age": 28,
+    "contractYears": 2,
+    "salary": 5000
+  },
+  {
+    "id": 2,
+    "number": 9,
+    "name": "Carlos Sánchez",
+    "position": "ST",
+    "ovr": 85,
+    "age": 25,
+    "contractYears": 3,
+    "salary": 7000
+  }
+]

--- a/server/data/rankings.json
+++ b/server/data/rankings.json
@@ -1,0 +1,5 @@
+[
+  { "id": "r1", "username": "coach", "clubName": "Rayo Digital FC", "clubLogo": "https://ui-avatars.com/api/?name=RD&background=ef4444&color=fff&size=128&bold=true", "elo": 1500 },
+  { "id": "r2", "username": "DT Neon", "clubName": "Neón FC", "clubLogo": "https://ui-avatars.com/api/?name=NFC&background=ec4899&color=fff&size=128&bold=true", "elo": 1480 },
+  { "id": "r3", "username": "DT Pixel", "clubName": "Atlético Pixelado", "clubLogo": "https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true", "elo": 1450 }
+]

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,44 @@
+import express from 'express';
+import cors from 'cors';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const read = (name) => JSON.parse(fs.readFileSync(path.join(__dirname, 'data', name), 'utf-8'));
+
+app.get('/clubs', (req, res) => {
+  res.json(read('clubs.json'));
+});
+
+app.get('/players', (req, res) => {
+  res.json(read('players.json'));
+});
+
+app.get('/fixtures', (req, res) => {
+  res.json(read('fixtures.json'));
+});
+
+app.get('/rankings', (req, res) => {
+  res.json(read('rankings.json'));
+});
+
+let chat = [];
+app.get('/chat', (req, res) => {
+  res.json(chat);
+});
+app.post('/chat', (req, res) => {
+  const msg = { id: Date.now().toString(), ...req.body };
+  chat.push(msg);
+  res.status(201).json(msg);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`API listening on http://localhost:${PORT}`);
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,18 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>
 );
- 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -304,3 +304,10 @@ export interface DtRanking {
   clubLogo: string;
   elo: number;
 }
+
+export interface ChatMsg {
+  id: string;
+  user: string;
+  text: string;
+  ts: number;
+}


### PR DESCRIPTION
## Summary
- add lightweight Express API under `server/`
- create data endpoints for clubs, players, fixtures and rankings
- fetch server data with React Query and cache in localStorage
- wrap the React app with `QueryClientProvider`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685b258046848333b06247161373ed66