### PR TITLE
Fix scroll jumping on DT dashboard load

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -231,8 +231,13 @@ const DtDashboard: React.FC = () => {
     }
   });
   const chatEndRef = useRef<HTMLDivElement>(null);
+  const firstRender = useRef(true);
   useEffect(() => {
     localStorage.setItem("vz_chat_history", JSON.stringify(chat));
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [chat]);
   const sendChat = (text: string) => {


### PR DESCRIPTION
## Summary
- prevent chat module from scrolling into view on initial render

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c34c365208333963ad1e51327f6ef