### PR TITLE
Fix Liga Master auto-scroll

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -236,9 +236,14 @@ const DtDashboard: React.FC = () => {
     }
   });
   const chatEndRef = useRef<HTMLDivElement>(null);
+  const initialChatRender = useRef(true);
 
   useEffect(() => {
     localStorage.setItem("vz_chat_history", JSON.stringify(chat));
+    if (initialChatRender.current) {
+      initialChatRender.current = false;
+      return;
+    }
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [chat]);
 


### PR DESCRIPTION
## Summary
- prevent chat module from scrolling to bottom on first render

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c7796b6288333bd55b8a8be6ffe6d