### PR TITLE
Improve club listing with shared component

### DIFF
--- a/src/components/common/ClubListItem.tsx
+++ b/src/components/common/ClubListItem.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import { Club } from '../../types';
+
+interface ClubListItemProps {
+  club: Club;
+  to?: string;
+  className?: string;
+}
+
+const ClubListItem = ({ club, to, className = '' }: ClubListItemProps) => {
+  const content = (
+    <div
+      className={`flex items-center p-3 rounded-lg hover:bg-gray-800 transition-colors ${className}`.trim()}
+    >
+      <img
+        src={club.logo}
+        alt={club.name}
+        className="w-12 h-12 object-contain mr-4"
+      />
+      <div>
+        <h3 className="font-bold" aria-live="polite">
+          {club.name}
+        </h3>
+        <p className="text-sm text-gray-400">DT: {club.manager}</p>
+      </div>
+    </div>
+  );
+
+  return to ? <Link to={to}>{content}</Link> : content;
+};
+
+export default ClubListItem;

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import StatsCard from '../components/common/StatsCard';
+import ClubListItem from '../components/common/ClubListItem';
 import DashboardSkeleton from '../components/common/DashboardSkeleton';
 import { useDataStore } from '../store/dataStore';
 import { formatDate, formatCurrency } from '../utils/helpers';
@@ -288,23 +289,11 @@ const topScorers = [...players]
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
                 {clubs.map(club => (
-                  <Link 
-                    key={club.id} 
+                  <ClubListItem
+                    key={club.id}
+                    club={club}
                     to={`/liga-master/club/${club.slug}`}
-                    className="flex items-center p-3 rounded-lg hover:bg-gray-800 transition-colors"
-                  >
-                    <img 
-                      src={club.logo} 
-                      alt={club.name}
-                      className="w-12 h-12 object-contain mr-4"
-                    />
-                    <div>
-                      <h3 className="font-bold">{club.name}</h3>
-                      <p className="text-sm text-gray-400">
-                        DT: {club.manager}
-                      </p>
-                    </div>
-                  </Link>
+                  />
                 ))}
               </div>
             </div>

--- a/src/pages/TournamentDetail.tsx
+++ b/src/pages/TournamentDetail.tsx
@@ -5,6 +5,7 @@ import { Trophy, ChevronLeft, Image, ArrowRight, Star } from 'lucide-react';
 import { useDataStore } from '../store/dataStore';
 import { Match } from '../types';
 import { formatDate, slugify } from '../utils/helpers';
+import ClubListItem from '../components/common/ClubListItem';
 
 const TournamentDetail = () => {
   const { tournamentName } = useParams<{ tournamentName: string }>();
@@ -207,19 +208,12 @@ const TournamentDetail = () => {
                     
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                       {tournamentClubs.map(club => (
-                        <Link
+                        <ClubListItem
                           key={club.id}
+                          club={club}
                           to={`/liga-master/club/${club.slug}`}
-                          className="bg-dark-lighter rounded-lg p-4 flex items-center hover:bg-dark transition-colors"
-                        >
-                          <div className="w-12 h-12 rounded-full overflow-hidden mr-3">
-                            <img src={club.logo} alt={club.name} className="w-full h-full object-cover" />
-                          </div>
-                          <div>
-                            <p className="font-medium">{club.name}</p>
-                            <p className="text-xs text-gray-400">DT: {club.manager}</p>
-                          </div>
-                        </Link>
+                          className="bg-dark-lighter hover:bg-dark"
+                        />
                       ))}
                       
                       {tournament.status === 'open' && tournament.participants.length < 8 && (


### PR DESCRIPTION
## Summary
- add **ClubListItem** reusable component
- refactor Liga Master and tournament pages to use ClubListItem for club lists

## Testing
- `npm run test` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c7d5f9e488333a64ed82f0425a6fc