### PR TITLE
Fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run the Cypress test suite:
 npm run test
 ```
 
-This command lints the code, builds the project and then runs Cypress in
+This command lints the code, builds the project, and then runs Cypress in
 headless mode. To open the interactive Cypress UI instead, execute:
 
 ```bash


### PR DESCRIPTION
## Summary
- fix grammar in README about tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ca25f789c8333b2c0a5716397154d