### PR TITLE
Add Liga Master routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,16 @@ const Store = lazy(() => import("./pages/Store"));
 const Help = lazy(() => import("./pages/Help"));
 const DtDashboard = lazy(() => import("./pages/DtDashboard"));
 
+const Market = lazy(() => import("./pages/Market"));
+const Fixtures = lazy(() => import("./pages/Fixtures"));
+const Rankings = lazy(() => import("./pages/Rankings"));
+const HallOfFame = lazy(() => import("./pages/HallOfFame"));
+const Feed = lazy(() => import("./pages/Feed"));
+const Analisis = lazy(() => import("./pages/Analisis"));
+const ClubProfile = lazy(() => import("./pages/ClubProfile"));
+const ClubFinances = lazy(() => import("./pages/ClubFinances"));
+const ClubSquad = lazy(() => import("./pages/ClubSquad"));
+
 function App() {
   return (
     <div className="min-h-screen bg-[#18181f] text-white">
@@ -61,6 +71,15 @@ function App() {
             <Route path="liga-master/tacticas" element={<Tacticas />} />
             <Route path="liga-master/finanzas" element={<Finanzas />} />
             <Route path="liga-master/calendario" element={<Calendario />} />
+            <Route path="liga-master/mercado" element={<Market />} />
+            <Route path="liga-master/fixture" element={<Fixtures />} />
+            <Route path="liga-master/rankings" element={<Rankings />} />
+            <Route path="liga-master/hall-of-fame" element={<HallOfFame />} />
+            <Route path="liga-master/feed" element={<Feed />} />
+            <Route path="liga-master/analisis" element={<Analisis />} />
+            <Route path="liga-master/club/:clubName" element={<ClubProfile />} />
+            <Route path="liga-master/club/:clubName/finanzas" element={<ClubFinances />} />
+            <Route path="liga-master/club/:clubName/plantilla" element={<ClubSquad />} />
 
             <Route path="*" element={<NotFound />} />
           </Route>


### PR DESCRIPTION
## Summary
- lazily import Liga Master pages
- register Liga Master routes for market, fixtures, rankings, hall of fame, feed, analisis, and club sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685caa3fc1808333b9b394e96d125405