### PR TITLE
Fix DT dashboard visibility

### DIFF
--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -22,7 +22,7 @@ const LigaMaster = () => {
   const { user } = useAuthStore();
   const { clubs, tournaments, players, standings, marketStatus } = useDataStore();
 
-  if (user?.role === 'dt' && (user.club || user.clubId)) {
+  if (user?.role === 'dt') {
     return <DtDashboard />;
   }
   


### PR DESCRIPTION
## Summary
- ensure DT users always see the dashboard when visiting Liga Master

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ca7e310548333bc529059ddea35d3