### PR TITLE
Add salary usage progress bar

### DIFF
--- a/src/components/plantilla/ResumenClub.tsx
+++ b/src/components/plantilla/ResumenClub.tsx
@@ -1,5 +1,7 @@
 import { formatCurrency } from '../../utils/helpers';
 import { Player } from '../../types';
+import ProgressBar from '../common/ProgressBar';
+import { dtClub } from '../../data/mockData';
 
 interface Props {
   club: { name: string; logo: string };
@@ -8,6 +10,8 @@ interface Props {
 
 const ResumenClub = ({ club, players }: Props) => {
   const totalSalary = players.reduce((sum, p) => sum + p.contract.salary, 0);
+  const budget = dtClub.budget;
+  const salaryPercent = budget > 0 ? Math.round((totalSalary / budget) * 100) : null;
 
   return (
     <div className="card p-6 flex items-center">
@@ -17,6 +21,9 @@ const ResumenClub = ({ club, players }: Props) => {
         <p className="text-sm text-gray-400">
           Uso salarial: {formatCurrency(totalSalary)}
         </p>
+        <div className="mt-2">
+          <ProgressBar value={salaryPercent} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- compute salary usage percentage for club
- display salary percentage with ProgressBar component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbb64da1c8333aefef77a433acb1a