### PR TITLE
Add player search filter

### DIFF
--- a/src/components/plantilla/PlayerTable.tsx
+++ b/src/components/plantilla/PlayerTable.tsx
@@ -18,13 +18,21 @@ interface Props {
   players: Player[];
   setPlayers: React.Dispatch<React.SetStateAction<Player[]>>;
   onSelectPlayer: (p: Player) => void;
+  search: string;
 }
 
-const PlayerTable = ({ players, setPlayers, onSelectPlayer }: Props) => {
+const PlayerTable = ({ players, setPlayers, onSelectPlayer, search }: Props) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [selected, setSelected] = useState<Player | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
+
+  const searchLower = search.toLowerCase();
+  const filteredPlayers = players.filter(
+    (p) =>
+      p.name.toLowerCase().includes(searchLower) ||
+      p.position.toLowerCase().includes(searchLower)
+  );
 
   const handleRenew = (player: Player) => {
     setSelected(player);
@@ -87,7 +95,7 @@ const PlayerTable = ({ players, setPlayers, onSelectPlayer }: Props) => {
           </tr>
         </thead>
         <tbody>
-          {players.map(p => (
+          {filteredPlayers.map(p => (
             <tr
               key={p.id}
               className="border-b border-zinc-800 hover:bg-zinc-800"

--- a/src/pages/Plantilla.tsx
+++ b/src/pages/Plantilla.tsx
@@ -15,6 +15,7 @@ const Plantilla = () => {
     playersData as Player[]
   );
   const [active, setActive] = useState<Player | null>(null);
+  const [search, setSearch] = useState('');
 
   return (
     <div>
@@ -22,7 +23,20 @@ const Plantilla = () => {
       <div className="container mx-auto px-4 py-8">
         <ResumenClub club={{ name: dtClub.name, logo: dtClub.logo }} players={players} />
         <div className="mt-6">
-          <PlayerTable players={players} setPlayers={setPlayers} onSelectPlayer={setActive} />
+          <input
+            data-cy="player-search"
+            type="text"
+            placeholder="Buscar jugador..."
+            className="mb-4 w-full max-w-xs rounded bg-zinc-800 p-2"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <PlayerTable
+            players={players}
+            search={search}
+            setPlayers={setPlayers}
+            onSelectPlayer={setActive}
+          />
         </div>
         {active && <PlayerDrawer player={active} onClose={() => setActive(null)} />}
       </div>

--- a/tests/e2e/plantilla_edit.cy.ts
+++ b/tests/e2e/plantilla_edit.cy.ts
@@ -13,4 +13,12 @@ describe('Plantilla editing', () => {
       expect(players).to.contain('Updated Name');
     });
   });
+
+  it('filters players by search', () => {
+    cy.visit('/liga-master/plantilla');
+
+    cy.get('[data-cy="player-search"]').type('Juan');
+    cy.get('tbody tr').should('have.length', 1);
+    cy.contains('td', 'Juan Pérez');
+  });
 });


### PR DESCRIPTION
## Summary
- include a search box in the squad page
- filter players by name or position in `PlayerTable`
- test the new search functionality in e2e

## Testing
- `npm run lint` *(fails: Cannot find package globals)*
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cbb63fde08333a7f344efae93929f