### PR TITLE
Add helper for overall color and use in PlayerTable

### DIFF
--- a/src/components/plantilla/PlayerTable.tsx
+++ b/src/components/plantilla/PlayerTable.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 import RenewContractModal from './RenewContractModal';
+import { getPositionColor, getOverallColor } from '../../utils/helpers';
 
 interface Player {
   id: string;
@@ -106,8 +107,16 @@ const PlayerTable = ({ players, setPlayers, onSelectPlayer }: Props) => {
                   p.name
                 )}
               </td>
-              <td className="px-4 py-2 text-center">{p.position}</td>
-              <td className="px-4 py-2 text-center">{p.ovr}</td>
+              <td className="px-4 py-2 text-center">
+                <span className={`px-2 py-0.5 rounded ${getPositionColor(p.position)}`}>
+                  {p.position}
+                </span>
+              </td>
+              <td className="px-4 py-2 text-center">
+                <span className={`px-2 py-0.5 rounded ${getOverallColor(p.ovr)}`}>
+                  {p.ovr}
+                </span>
+              </td>
               <td className="px-4 py-2 text-center">{p.age}</td>
               <td className="px-4 py-2 text-center">{p.contractYears}y</td>
               <td className="px-4 py-2 text-center space-x-2">

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -2,7 +2,7 @@ import { useParams, Link } from 'react-router-dom';
 import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
-import { formatCurrency } from '../utils/helpers';
+import { formatCurrency, getOverallColor } from '../utils/helpers';
 import { useState } from 'react';
 
 const ClubSquad = () => {
@@ -396,12 +396,6 @@ const getPositionColor = (position: string) => {
   }
 };
 
-const getOverallColor = (overall: number) => {
-  if (overall >= 85) return 'bg-green-500/20 text-green-500';
-  if (overall >= 80) return 'bg-blue-500/20 text-blue-400';
-  if (overall >= 75) return 'bg-yellow-500/20 text-yellow-500';
-  return 'bg-gray-500/20 text-gray-400';
-};
 
 export default ClubSquad;
  

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -50,6 +50,13 @@ export const getPositionColor = (position: string): string => {
   }
 };
 
+export const getOverallColor = (overall: number): string => {
+  if (overall >= 85) return 'bg-green-500/20 text-green-500';
+  if (overall >= 80) return 'bg-blue-500/20 text-blue-400';
+  if (overall >= 75) return 'bg-yellow-500/20 text-yellow-500';
+  return 'bg-gray-500/20 text-gray-400';
+};
+
 // Get transfer status badge
 export const getStatusBadge = (status: string): string => {
   switch(status) {


### PR DESCRIPTION
## Summary
- provide `getOverallColor` in utility helpers
- wrap position and overall data in `PlayerTable` with colored spans
- reuse new helper in `ClubSquad` instead of local function

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cbb6527788333b76b6875b0f6b731