### PR TITLE
Fix Plantilla type mismatch

### DIFF
--- a/src/pages/Plantilla.tsx
+++ b/src/pages/Plantilla.tsx
@@ -4,8 +4,18 @@ import ResumenClub from '../components/plantilla/ResumenClub';
 import PlayerTable from '../components/plantilla/PlayerTable';
 import playersData from '../data/players.json';
 import { dtClub } from '../data/mockData';
-import type { Player } from '../types';
 import usePersistentState from '../hooks/usePersistentState';
+
+interface Player {
+  id: string | number;
+  number: number;
+  name: string;
+  position: string;
+  ovr: number;
+  age: number;
+  contractYears: number;
+  salary: number;
+}
 
 const PlayerDrawer = lazy(() => import('../components/plantilla/PlayerDrawer'));
 


### PR DESCRIPTION
## Summary
- define a local `Player` interface in `Plantilla.tsx`
- use squad data from `players.json` with the local interface

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cbcaf1b7483338af9028bcb7ea293