### PR TITLE
Fix slugify export

### DIFF
--- a/src/components/Home/LeagueStandings.tsx
+++ b/src/components/Home/LeagueStandings.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
-import slugify from '../../utils/slugify';
+import { slugify } from '../../utils/slugify';
 
 const LeagueStandings = () => {
   const { standings, clubs } = useDataStore();

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -10,5 +10,3 @@ export const slugify = (text: string): string => {
     .replace(/^-+/, '')
     .replace(/-+$/, '');
 };
-
-export default slugify;


### PR DESCRIPTION
## Summary
- remove default export in `src/utils/slugify.ts`
- update import in `LeagueStandings` to use named slugify

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5efd3bc0833392f7a5637e97219e