### PR TITLE
Update README with npm install reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Before running the project, make sure you have **Node.js** installed. Install th
 npm install
 ```
 
+> **Important**: run `npm install` before executing `npm run lint` or
+> `npm run test` to ensure all dependencies are installed. In CI
+> environments, provide network access or use an offline npm cache so
+> that this installation step succeeds.
+
 After the packages are installed you can start the development server.
 
 ## Development


### PR DESCRIPTION
## Summary
- remind developers to run `npm install` before running any lint or test commands
- add note about network access/offline cache in CI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5efc279883338887dfbc61bf5446