### PR TITLE
Fix unstable React keys

### DIFF
--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -129,8 +129,8 @@ const ClubProfile = () => {
               </p>
               
               <div className="flex justify-center space-x-4 mb-6">
-                {club.titles.map((title, index) => (
-                  <div key={index} className="flex flex-col items-center">
+                {club.titles.map((title) => (
+                  <div key={title.id} className="flex flex-col items-center">
                     <Trophy size={24} className="text-yellow-400 mb-1" />
                     <span className="text-sm">{title.name}</span>
                     <span className="text-xs text-gray-400">{title.year}</span>
@@ -318,8 +318,8 @@ const ClubProfile = () => {
                       <h3 className="text-lg font-bold mb-4">Títulos y Logros</h3>
                       {club.titles.length > 0 ? (
                         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                          {club.titles.map((title, index) => (
-                            <div key={index} className="p-4 bg-gray-800 rounded-lg flex items-center">
+                          {club.titles.map((title) => (
+                            <div key={title.id} className="p-4 bg-gray-800 rounded-lg flex items-center">
                               <Trophy size={24} className="text-yellow-400 mr-3" />
                               <div>
                                 <p className="font-medium">{title.name}</p>

--- a/src/pages/HallOfFame.tsx
+++ b/src/pages/HallOfFame.tsx
@@ -246,8 +246,8 @@ const HallOfFame = () => {
                       <div className="mb-4">
                         <h4 className="font-bold mb-2">Títulos</h4>
                         <ul className="space-y-1">
-                          {club.titles.map((title, index) => (
-                            <li key={index} className="flex items-center">
+                          {club.titles.map((title) => (
+                            <li key={title.id} className="flex items-center">
                               <Trophy size={16} className="text-yellow-400 mr-2" />
                               <span>{title.name} {title.year}</span>
                             </li>

--- a/src/pages/Rankings.tsx
+++ b/src/pages/Rankings.tsx
@@ -26,11 +26,14 @@ const Rankings = () => {
     .map(standing => {
       const club = clubs.find(c => c.id === standing.clubId);
       return {
+        id: standing.clubId,
         name: club?.manager || 'Unknown',
         club: club?.name || 'Unknown',
         clubLogo: club?.logo || '',
         points: standing.points,
-        winRate: standing.played > 0 ? Math.round((standing.won / standing.played) * 100) : 0
+        winRate: standing.played > 0
+          ? Math.round((standing.won / standing.played) * 100)
+          : 0
       };
     });
   
@@ -339,7 +342,7 @@ const Rankings = () => {
                 </thead>
                 <tbody className="divide-y divide-gray-800">
                   {topManagers.map((manager, index) => (
-                    <tr key={index} className="hover:bg-gray-800/50">
+                    <tr key={manager.id} className="hover:bg-gray-800/50">
                       <td className="p-4 text-center">
                         <span className={`
                           inline-block w-6 h-6 rounded-full font-medium text-sm flex items-center justify-center


### PR DESCRIPTION
## Summary
- avoid using array index as key in ClubProfile, Rankings and HallOfFame pages
- assign `id` when creating `topManagers` list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5efd9e948333bfe3088a20ef0a54