### PR TITLE
Add admin store persistence

### DIFF
--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -1,0 +1,51 @@
+export interface AdminData {
+  users: import('../types').User[];
+  clubs: import('../types').Club[];
+  players: import('../types').Player[];
+  tournaments: import('../types').Tournament[];
+  newsItems: import('../types').NewsItem[];
+  transfers: import('../types').Transfer[];
+  standings: import('../types').Standing[];
+  activities: import('../types').ActivityLog[];
+  comments: import('../types').Comment[];
+}
+
+const PREFIX = 'vz_';
+
+const keys = {
+  users: `${PREFIX}users_admin`,
+  clubs: `${PREFIX}clubs_admin`,
+  players: `${PREFIX}players_admin`,
+  tournaments: `${PREFIX}tournaments_admin`,
+  newsItems: `${PREFIX}news_admin`,
+  transfers: `${PREFIX}transfers_admin`,
+  standings: `${PREFIX}standings_admin`,
+  activities: `${PREFIX}activities_admin`,
+  comments: `${PREFIX}comments_admin`
+};
+
+export const loadAdminData = (defaults: AdminData): AdminData => {
+  const data: AdminData = { ...defaults };
+  Object.entries(keys).forEach(([prop, key]) => {
+    const json = localStorage.getItem(key);
+    if (json) {
+      try {
+        (data as any)[prop] = JSON.parse(json);
+      } catch {
+        // ignore parse errors and keep defaults
+      }
+    }
+  });
+  return data;
+};
+
+export const saveAdminData = (data: AdminData): void => {
+  Object.entries(keys).forEach(([prop, key]) => {
+    const value = (data as any)[prop];
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore write errors
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- add `adminStorage` helper for persisting admin panel data
- load and save global admin store using localStorage
- persist every mutator action

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: vite not found)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: missing eslint deps)*

------
https://chatgpt.com/codex/tasks/task_e_685f5f0720548333895d9f707f031e26