### PR TITLE
Update Atletico Pixelado manager

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -61,7 +61,7 @@ export const clubs: Club[] = [
     foundedYear: 2023,
     stadium: 'Pixel Arena',
     budget: 22000000,
-    manager: 'DT Pixel',
+    manager: 'jackso',
     playStyle: 'Contraataque',
     primaryColor: '#3b82f6',
     secondaryColor: '#ffffff',
@@ -1084,7 +1084,7 @@ export const dtRankings: DtRanking[] = [
   },
   {
     id: 'r3',
-    username: 'DT Pixel',
+    username: 'jackso',
     clubName: clubs[1].name,
     clubLogo: clubs[1].logo,
     elo: 1450

--- a/src/data/seed.json
+++ b/src/data/seed.json
@@ -29,7 +29,7 @@
       "foundedYear": 2023,
       "stadium": "Pixel Arena",
       "budget": 22000000,
-      "manager": "DT Pixel",
+      "manager": "jackso",
       "playStyle": "Contraataque",
       "primaryColor": "#3b82f6",
       "secondaryColor": "#ffffff",


### PR DESCRIPTION
## Summary
- update Atletico Pixelado's manager to "jackso" in mock data and seed files
- align DT rankings with new manager name

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f6ecce87c8333b4e4ce301ea905e7