### PR TITLE
Compute club from auth store

### DIFF
--- a/src/components/plantilla/ResumenClub.tsx
+++ b/src/components/plantilla/ResumenClub.tsx
@@ -1,23 +1,22 @@
 import { formatCurrency } from '../../utils/helpers';
-import { Player } from '../../types';
+import { Player, Club } from '../../types';
 import ProgressBar from '../common/ProgressBar';
-import { dtClub } from '../../data/mockData';
 
 interface Props {
-  club: { name: string; logo: string };
+  club?: Club;
   players: Player[];
 }
 
 const ResumenClub = ({ club, players }: Props) => {
-   const totalSalary = players.reduce((sum, p) => sum + (p.contract?.salary || 0), 0); 
-  const budget = dtClub.budget;
+  const totalSalary = players.reduce((sum, p) => sum + (p.contract?.salary || 0), 0);
+  const budget = club?.budget ?? 0;
   const salaryPercent = budget > 0 ? Math.round((totalSalary / budget) * 100) : null;
 
   return (
     <div className="card p-6 flex items-center">
-      <img src={club.logo} alt={club.name} className="w-16 h-16 mr-4" />
+      <img src={club?.logo || ''} alt={club?.name || ''} className="w-16 h-16 mr-4" />
       <div>
-        <h2 className="text-xl font-bold mb-1">{club.name}</h2>
+        <h2 className="text-xl font-bold mb-1">{club?.name}</h2>
         <p className="text-sm text-gray-400">
           Uso salarial: {formatCurrency(totalSalary)}
         </p>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1035,18 +1035,8 @@ export const storeItems: StoreItem[] = [
 ];
 
 // --- Datos para el tablero del DT ---
-export const dtClub: DtClub = {
-  id: 'club1',
-  name: 'Rayo Digital FC',
-  slug: 'rayo-digital-fc',
-  logo: clubs[0].logo,
-  formation: '4-3-3',
-  budget: clubs[0].budget,
-  players: players.filter(p => p.clubId === 'club1')
-};
-
 export const dtFixtures: DtFixture[] = tournaments[0].matches
-  .filter(m => m.homeTeam === dtClub.name || m.awayTeam === dtClub.name)
+  .filter(m => m.homeTeam === clubs[0].name || m.awayTeam === clubs[0].name)
   .slice(0, 6)
   .map(m => ({ ...m, played: m.status === 'finished' }));
 

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -27,12 +27,28 @@ const    tabs = [
 
 export default function DtDashboard() {
   const { user } = useAuthStore();
-  const { club, fixtures } = useDataStore();
+  const { clubs, tournaments } = useDataStore();
+  const club = useMemo(
+    () => clubs.find(c => c.id === user?.clubId),
+    [clubs, user?.clubId]
+  );
+  const fixtures = useMemo(() => {
+    const matches = tournaments[0]?.matches || [];
+    return matches
+      .filter(m =>
+        club ? m.homeTeam === club.name || m.awayTeam === club.name : false
+      )
+      .slice(0, 6)
+      .map(m => ({ ...m, played: m.status === 'finished' }));
+  }, [tournaments, club]);
   const [activeTab, setActiveTab] = useState<Tab>('plantilla');
   const tabsRef = useRef<HTMLDivElement>(null);
 
-  const nextMatch = useMemo(() => 
-    fixtures.find(m => !m.played && (m.homeTeam === club?.name || m.awayTeam === club?.name)),
+  const nextMatch = useMemo(
+    () =>
+      fixtures.find(
+        m => !m.played && (m.homeTeam === club?.name || m.awayTeam === club?.name)
+      ),
     [fixtures, club?.name]
   );
 

--- a/src/pages/Plantilla.tsx
+++ b/src/pages/Plantilla.tsx
@@ -3,7 +3,8 @@ import PageHeader from '../components/common/PageHeader';
 import ResumenClub from '../components/plantilla/ResumenClub';
 import PlayerTable from '../components/plantilla/PlayerTable';
 import playersData from '../data/players.json';
-import { dtClub } from '../data/mockData';
+import { useAuthStore } from '../store/authStore';
+import { useDataStore } from '../store/dataStore';
 import usePersistentState from '../hooks/usePersistentState';
 
 interface Player {
@@ -24,6 +25,9 @@ const Plantilla = () => {
     'vz_players',
     playersData as Player[]
   );
+  const { user } = useAuthStore();
+  const { clubs } = useDataStore();
+  const club = clubs.find(c => c.id === user?.clubId);
   const [active, setActive] = useState<Player | null>(null);
   const [search, setSearch] = useState('');
 
@@ -31,7 +35,7 @@ const Plantilla = () => {
     <div>
       <PageHeader title="Plantilla" subtitle="Jugadores registrados en tu plantilla." />
       <div className="container mx-auto px-4 py-8">
-        <ResumenClub club={{ name: dtClub.name, logo: dtClub.logo }} players={players} />
+        <ResumenClub club={club} players={players} />
         <div className="mt-6">
           <input
             data-cy="player-search"

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -18,8 +18,6 @@ import {
   faqs,
   storeItems,
   posts,
-  dtClub,
-  dtFixtures,
   dtMarket,
   dtObjectives,
   dtTasks,
@@ -50,6 +48,23 @@ import {
   DtEvent,
   DtRanking
 } from '../types';
+
+const initialClubs = getClubs();
+const initialUser = useAuthStore.getState().user;
+const baseClub = initialClubs.find(c => c.id === initialUser?.clubId) || initialClubs[0];
+const initialClub: DtClub = {
+  id: baseClub.id,
+  name: baseClub.name,
+  slug: baseClub.slug,
+  logo: baseClub.logo,
+  formation: '4-3-3',
+  budget: baseClub.budget,
+  players: players.filter(p => p.clubId === baseClub.id)
+};
+const initialFixtures = tournaments[0].matches
+  .filter(m => m.homeTeam === initialClub.name || m.awayTeam === initialClub.name)
+  .slice(0, 6)
+  .map(m => ({ ...m, played: m.status === 'finished' }));
 
 interface DataState {
   clubs: Club[];
@@ -103,7 +118,7 @@ interface DataState {
 }
 
 export const useDataStore = create<DataState>((set) => ({
-  clubs: getClubs(),
+  clubs: initialClubs,
   players,
   tournaments,
   transfers,
@@ -115,8 +130,8 @@ export const useDataStore = create<DataState>((set) => ({
   storeItems,
   posts,
   marketStatus,
-  club: dtClub,
-  fixtures: dtFixtures,
+  club: initialClub,
+  fixtures: initialFixtures,
   market: dtMarket,
   objectives: dtObjectives,
   tasks: dtTasks,

--- a/tests/e2e/plantilla_edit.cy.ts
+++ b/tests/e2e/plantilla_edit.cy.ts
@@ -1,8 +1,25 @@
 /// <reference types="cypress" />
 
+const dtUser = {
+  id: '3',
+  username: 'entrenador',
+  role: 'dt',
+  xp: 500,
+  clubId: 'club4',
+  status: 'active',
+  notifications: true,
+  lastLogin: new Date().toISOString(),
+  followers: 0,
+  following: 0
+};
+
 describe('Plantilla editing', () => {
   it('saves player details to localStorage', () => {
-    cy.visit('/liga-master/plantilla');
+    cy.visit('/liga-master/plantilla', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('vz_current_user', JSON.stringify(dtUser));
+      }
+    });
 
     cy.get('[data-cy="edit-player"]').first().click();
     cy.get('[data-cy="player-name-input"]').clear().type('Updated Name');
@@ -15,7 +32,11 @@ describe('Plantilla editing', () => {
   });
 
   it('filters players by search', () => {
-    cy.visit('/liga-master/plantilla');
+    cy.visit('/liga-master/plantilla', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('vz_current_user', JSON.stringify(dtUser));
+      }
+    });
 
     cy.get('[data-cy="player-search"]').type('Juan');
     cy.get('tbody tr').should('have.length', 1);

--- a/tests/e2e/player_sort_filter.cy.ts
+++ b/tests/e2e/player_sort_filter.cy.ts
@@ -1,8 +1,25 @@
 /// <reference types="cypress" />
 
+const dtUser = {
+  id: '3',
+  username: 'entrenador',
+  role: 'dt',
+  xp: 500,
+  clubId: 'club4',
+  status: 'active',
+  notifications: true,
+  lastLogin: new Date().toISOString(),
+  followers: 0,
+  following: 0
+};
+
 describe('Player table sorting and filtering', () => {
   beforeEach(() => {
-    cy.visit('/liga-master/plantilla');
+    cy.visit('/liga-master/plantilla', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('vz_current_user', JSON.stringify(dtUser));
+      }
+    });
   });
 
   it('filters players by search term', () => {

--- a/tests/e2e/tactics_persist.cy.ts
+++ b/tests/e2e/tactics_persist.cy.ts
@@ -1,8 +1,25 @@
 /// <reference types="cypress" />
 
+const dtUser = {
+  id: '3',
+  username: 'entrenador',
+  role: 'dt',
+  xp: 500,
+  clubId: 'club4',
+  status: 'active',
+  notifications: true,
+  lastLogin: new Date().toISOString(),
+  followers: 0,
+  following: 0
+};
+
 describe('Tactics pitch', () => {
   it('persists player positions to vz_tactics', () => {
-    cy.visit('/liga-master/tacticas');
+    cy.visit('/liga-master/tacticas', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('vz_current_user', JSON.stringify(dtUser));
+      }
+    });
 
     // Example drag action assuming draggable players and pitch slots exist
     cy.get('[data-cy="player"]').first().trigger('dragstart');


### PR DESCRIPTION
## Summary
- derive DT club/fixtures in `DtDashboard` from the logged user
- look up club in `Plantilla` and pass to `ResumenClub`
- make `ResumenClub` read club budget and allow undefined club
- initialize club/fixtures in data store dynamically
- remove obsolete `dtClub` mock
- update e2e tests to set a DT user before visiting pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860526c971c833399eb00ff9b792b93