### PR TITLE
Add admin user e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run preview
 ```
 ## Tests
 
-Run the Cypress test suite:
+Run the Cypress test suite (which now includes an admin user flow test):
 
 ```bash
 npm run test
@@ -48,6 +48,12 @@ headless mode. To open the interactive Cypress UI instead, execute:
 
 ```bash
 npx cypress open
+
+To execute only the admin user flow test, specify its path:
+
+```bash
+npx cypress run --spec tests/e2e/admin_user_flow.cy.ts
+```
 ```
 
 Ensure the development server is running on `http://localhost:5173` before

--- a/tests/e2e/admin_user_flow.cy.ts
+++ b/tests/e2e/admin_user_flow.cy.ts
@@ -1,0 +1,23 @@
+/// <reference types="cypress" />
+
+describe('Admin user management flow', () => {
+  it('creates a new user from the admin panel', () => {
+    cy.visit('/login');
+
+    cy.get('input[type="text"]').first().type('admin');
+    cy.get('input[type="password"]').type('password');
+    cy.get('button[type="submit"]').click();
+
+    cy.url().should('include', '/usuario');
+
+    cy.visit('/admin/usuarios');
+
+    cy.contains('button', 'Nuevo Usuario').click();
+    cy.get('input[placeholder="Usuario"]').type('testuser');
+    cy.get('input[placeholder="Email"]').type('testuser@example.com');
+    cy.get('select').select('user');
+    cy.contains('button', 'Crear').click();
+
+    cy.contains('td', 'testuser');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      reporter: ['text', 'json']
+    }
   },
 });


### PR DESCRIPTION
## Summary
- add an admin user flow Cypress spec
- enable coverage collection in Vitest
- document how to run the new e2e spec

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686064bae364833381c1721b0ae4846f