### PR TITLE
Use useDataStore for squad and finances

### DIFF
--- a/src/components/finanzas/IncomeVsExpensesChart.tsx
+++ b/src/components/finanzas/IncomeVsExpensesChart.tsx
@@ -11,16 +11,27 @@ import {
 } from "recharts";
 import financeHistory from "../../data/financeHistory.json";
 
+export interface FinanceHistoryEntry {
+  month: string;
+  income: number;
+  expenses: number;
+}
+
+interface Props {
+  data?: FinanceHistoryEntry[];
+}
+
 const ranges = {
   "3m": 3,
   "6m": 6,
   "12m": 12,
 } as const;
 
-const IncomeVsExpensesChart: React.FC = () => {
+const IncomeVsExpensesChart: React.FC<Props> = ({ data }) => {
   const [range, setRange] = useState<"3m" | "6m" | "12m">("6m");
 
-  const data = financeHistory.slice(-ranges[range]);
+  const source = data ?? financeHistory;
+  const chartData = source.slice(-ranges[range]);
 
   return (
     <div className="rounded bg-zinc-800 p-4">
@@ -37,7 +48,7 @@ const IncomeVsExpensesChart: React.FC = () => {
         </select>
       </div>
       <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={data}>
+        <BarChart data={chartData}>
           <XAxis dataKey="month" />
           <YAxis />
           <Tooltip />

--- a/src/pages/Plantilla.tsx
+++ b/src/pages/Plantilla.tsx
@@ -2,12 +2,13 @@ import { lazy, useState } from 'react';
 import PageHeader from '../components/common/PageHeader';
 import ResumenClub from '../components/plantilla/ResumenClub';
 import PlayerTable from '../components/plantilla/PlayerTable';
-import playersData from '../data/players.json';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
-import usePersistentState from '../hooks/usePersistentState';
+import { Player as FullPlayer } from '../types';
 
-interface Player {
+const PlayerDrawer = lazy(() => import('../components/plantilla/PlayerDrawer'));
+
+interface TablePlayer {
   id: string | number;
   number: number;
   name: string;
@@ -16,26 +17,53 @@ interface Player {
   age: number;
   contractYears: number;
   salary: number;
+  full: FullPlayer;
 }
 
-const PlayerDrawer = lazy(() => import('../components/plantilla/PlayerDrawer'));
-
 const Plantilla = () => {
-  const [players, setPlayers] = usePersistentState<Player[]>(
-    'vz_players',
-    playersData as Player[]
-  );
   const { user } = useAuthStore();
-  const { clubs } = useDataStore();
+  const { clubs, players: allPlayers, updatePlayerEntry } = useDataStore();
   const club = clubs.find(c => c.id === user?.clubId);
-  const [active, setActive] = useState<Player | null>(null);
+  const currentYear = new Date().getFullYear();
+  const players: TablePlayer[] = allPlayers
+    .filter(p => p.clubId === club?.id)
+    .map(p => ({
+      id: p.id,
+      number: p.dorsal,
+      name: p.name,
+      position: p.position,
+      ovr: p.overall,
+      age: p.age,
+      contractYears: p.contract ? new Date(p.contract.expires).getFullYear() - currentYear : 0,
+      salary: p.contract?.salary ?? 0,
+      full: p
+    }));
+  const [active, setActive] = useState<FullPlayer | null>(null);
   const [search, setSearch] = useState('');
+
+  const updatePlayers: React.Dispatch<React.SetStateAction<TablePlayer[]>> =
+    updater => {
+      const next = typeof updater === 'function' ? updater(players) : updater;
+      next.forEach(p => {
+        const updated = {
+          ...p.full,
+          name: p.name,
+          dorsal: p.number,
+          overall: p.ovr,
+          age: p.age,
+          contract: p.full.contract
+            ? { ...p.full.contract, salary: p.salary }
+            : { expires: `${currentYear + p.contractYears}-06-30`, salary: p.salary }
+        };
+        updatePlayerEntry(updated);
+      });
+    };
 
   return (
     <div>
       <PageHeader title="Plantilla" subtitle="Jugadores registrados en tu plantilla." />
       <div className="container mx-auto px-4 py-8">
-        <ResumenClub club={club} players={players} />
+        <ResumenClub club={club} players={players.map(p => p.full)} />
         <div className="mt-6">
           <input
             data-cy="player-search"
@@ -48,8 +76,8 @@ const Plantilla = () => {
           <PlayerTable
             players={players}
             search={search}
-            setPlayers={setPlayers}
-            onSelectPlayer={setActive}
+            setPlayers={updatePlayers}
+            onSelectPlayer={p => setActive(p.full)}
           />
         </div>
         {active && <PlayerDrawer player={active} onClose={() => setActive(null)} />}


### PR DESCRIPTION
## Summary
- leverage useDataStore in Plantilla page
- add data prop to IncomeVsExpensesChart
- compute finances from store data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686064bd46608333b5250fdff648e9c9