### PR TITLE
Enable external subscriptions to admin store

### DIFF
--- a/src/adminPanel/components/SidebarAdmin.tsx
+++ b/src/adminPanel/components/SidebarAdmin.tsx
@@ -1,13 +1,22 @@
 import  { useState, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Menu, X, Home, Users, Globe, User, ShoppingBag, Award, FileText, MessageCircle, Activity, BarChart, Calendar } from 'lucide-react';
-import { useGlobalStore } from '../store/globalStore';
+import { useGlobalStore, subscribe as subscribeGlobal } from '../store/globalStore';
 
 const SidebarAdmin = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const { transfers } = useGlobalStore();
-  
-  const pendingTransfers = transfers.filter(t => t.status === 'pending').length;
+  const transfers = useGlobalStore(state => state.transfers);
+  const [pendingTransfers, setPendingTransfers] = useState(
+    transfers.filter(t => t.status === 'pending').length
+  );
+
+  useEffect(() => {
+    const unsub = subscribeGlobal(
+      state => state.transfers.filter(t => t.status === 'pending').length,
+      setPendingTransfers
+    );
+    return () => unsub();
+  }, []);
 
   const menuItems = [
     { name: 'Dashboard', href: '/admin', icon: Home },

--- a/src/adminPanel/pages/admin/Mercado.tsx
+++ b/src/adminPanel/pages/admin/Mercado.tsx
@@ -1,19 +1,28 @@
-import  { useState } from 'react';
+import  { useState, useEffect } from 'react';
 import { Check, X, Filter } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { useGlobalStore } from '../../store/globalStore';
+import { useGlobalStore, subscribe as subscribeGlobal } from '../../store/globalStore';
 
 const Mercado = () => {
   const { transfers, approveTransfer, rejectTransfer } = useGlobalStore();
   const [filter, setFilter] = useState('pending');
   const [rejectModal, setRejectModal] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
-
-  const filteredTransfers = transfers.filter(transfer => 
-    filter === 'all' || transfer.status === filter
+  const [pendingCount, setPendingCount] = useState(
+    transfers.filter(t => t.status === 'pending').length
   );
 
-  const pendingCount = transfers.filter(t => t.status === 'pending').length;
+  useEffect(() => {
+    const unsub = subscribeGlobal(
+      state => state.transfers.filter(t => t.status === 'pending').length,
+      setPendingCount
+    );
+    return () => unsub();
+  }, []);
+
+  const filteredTransfers = transfers.filter(transfer =>
+    filter === 'all' || transfer.status === filter
+  );
 
   const handleApprove = (id: string) => {
     approveTransfer(id);

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
 import {
   User,
   Club,
@@ -169,7 +170,8 @@ const defaultData: AdminData = {
   ]
 };
 
-export const useGlobalStore = create<GlobalStore>((set, get) => {
+export const useGlobalStore = create<GlobalStore>()(
+  subscribeWithSelector<GlobalStore>((set, get) => {
   const initial = loadAdminData(defaultData);
 
   const persist = () =>
@@ -388,5 +390,7 @@ export const useGlobalStore = create<GlobalStore>((set, get) => {
       persist();
     }
   };
-});
+}));
+
+export const subscribe = useGlobalStore.subscribe;
  


### PR DESCRIPTION
## Summary
- add `subscribeWithSelector` when creating the admin panel global store
- export the store's `subscribe` function
- subscribe to pending transfer updates in SidebarAdmin
- subscribe to pending transfer updates in Mercado page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686064be60148333aeee52a433e281ee