### PR TITLE
Add auth redirect for admin views

### DIFF
--- a/src/adminPanel/components/SidebarAdmin.tsx
+++ b/src/adminPanel/components/SidebarAdmin.tsx
@@ -1,13 +1,22 @@
 import  { useState, useEffect } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { Menu, X, Home, Users, Globe, User, ShoppingBag, Award, FileText, MessageCircle, Activity, BarChart, Calendar } from 'lucide-react';
 import { useGlobalStore } from '../store/globalStore';
+import { useAuth } from '../contexts/AuthContext';
 
 const SidebarAdmin = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { transfers } = useGlobalStore();
-  
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
   const pendingTransfers = transfers.filter(t => t.status === 'pending').length;
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/login', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
 
   const menuItems = [
     { name: 'Dashboard', href: '/admin', icon: Home },

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -1,9 +1,20 @@
 import  { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line } from 'recharts';
 import { Users, Globe, User, ShoppingBag } from 'lucide-react';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
 import { useGlobalStore } from '../../store/globalStore';
 
 const Dashboard = () => {
   const { users, clubs, players, transfers, activities } = useGlobalStore();
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/login', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
 
   const kpiData = [
     { name: 'Ene', users: 4, revenue: 2400 },


### PR DESCRIPTION
## Summary
- guard admin sidebar and dashboard using `useAuth`
- redirect to `/login` if not authenticated

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686064becdd8833385d352f6073bcc67