### PR TITLE
Add lineup and finances widgets to user profile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const ClubFinances = lazy(() => import("./pages/ClubFinances"));
 const ClubSquad = lazy(() => import("./pages/ClubSquad"));
 const Admin = lazy(() => import("./pages/Admin"));
 const StyleGuide = lazy(() => import("./pages/StyleGuide"));
+const UserProfile = lazy(() => import("./pages/UserProfile"));
 
 function App() {
   return (
@@ -52,6 +53,7 @@ function App() {
             <Route path="login" element={<Login />} />
             <Route path="registro" element={<Register />} />
             <Route path="usuario" element={<UserPanel />} />
+            <Route path="usuarios/:username" element={<UserProfile />} />
             <Route path="dt-dashboard" element={<DtDashboard />} />
             <Route path="admin/*" element={<Admin />} />
 

--- a/src/components/common/CircularProgress.tsx
+++ b/src/components/common/CircularProgress.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface Props {
+  /** Progress value between 0 and 100 */
+  value: number;
+  /** Diameter in pixels */
+  size?: number;
+  /** Optional label shown in the center */
+  label?: React.ReactNode;
+}
+
+const CircularProgress = ({ value, size = 80, label }: Props) => {
+  const radius = size / 2 - 4;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (value / 100) * circumference;
+
+  return (
+    <div className="relative inline-block" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="transform -rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          strokeWidth="4"
+          className="text-dark"
+          stroke="currentColor"
+          fill="transparent"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          strokeWidth="4"
+          className="text-primary transition-all duration-500"
+          stroke="currentColor"
+          fill="transparent"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+        />
+      </svg>
+      {label && (
+        <span className="absolute inset-0 flex items-center justify-center text-sm font-bold">
+          {label}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default CircularProgress;

--- a/src/components/profile/FinancesWidget.tsx
+++ b/src/components/profile/FinancesWidget.tsx
@@ -1,0 +1,34 @@
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts';
+
+// TODO: Replace mock data with real user finances
+const data = [
+  { month: 'Ene', income: 120000, expenses: 90000 },
+  { month: 'Feb', income: 95000, expenses: 85000 },
+  { month: 'Mar', income: 110000, expenses: 97000 },
+];
+
+const FinancesWidget = () => (
+  <div className="card p-4">
+    <h3 className="font-bold mb-3">Finanzas</h3>
+    <div className="h-48">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <XAxis dataKey="month" stroke="#9ca3af" />
+          <YAxis stroke="#9ca3af" />
+          <Tooltip formatter={(v: number) => [`€${v.toLocaleString()}`, '']} />
+          <Bar dataKey="income" fill="#10B981" />
+          <Bar dataKey="expenses" fill="#EF4444" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  </div>
+);
+
+export default FinancesWidget;

--- a/src/components/profile/LineupWidget.tsx
+++ b/src/components/profile/LineupWidget.tsx
@@ -1,0 +1,27 @@
+import { useDataStore } from '../../store/dataStore';
+
+interface Props {
+  clubId: string;
+}
+
+const LineupWidget = ({ clubId }: Props) => {
+  const { players } = useDataStore();
+  const squad = players.filter(p => p.clubId === clubId).slice(0, 11);
+
+  return (
+    <div className="card p-4">
+      <h3 className="font-bold mb-3">Alineación actual</h3>
+      <ul className="space-y-1 text-sm">
+        {squad.map(player => (
+          <li key={player.id} className="flex justify-between">
+            <span className="text-gray-400 mr-2 w-10">{player.position}</span>
+            <span className="font-medium flex-1">{player.name}</span>
+            <span className="text-gray-400">{player.overall}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default LineupWidget;

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,8 +1,11 @@
 import { useParams, Link } from 'react-router-dom';
 import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
+import CircularProgress from '../components/common/CircularProgress';
+import LineupWidget from '../components/profile/LineupWidget';
+import FinancesWidget from '../components/profile/FinancesWidget';
 import { useDataStore } from '../store/dataStore';
-import { slugify } from '../utils/helpers';
+import { slugify, xpForNextLevel } from '../utils/helpers';
 
 const UserProfile = () => {
   const { username } = useParams<{ username: string }>();
@@ -42,6 +45,10 @@ const UserProfile = () => {
   
   // Find club
   const club = clubs.find(c => c.name === user.club);
+
+  const currentLevelXp = xpForNextLevel(user.level - 1);
+  const nextLevelXp = xpForNextLevel(user.level);
+  const levelProgress = ((user.xp - currentLevelXp) / (nextLevelXp - currentLevelXp)) * 100;
   
   if (!username) {
     return (
@@ -98,17 +105,8 @@ const UserProfile = () => {
                 <button className="btn-outline text-sm px-3 py-1">Mensaje</button>
               </div>
               
-              <div className="bg-dark-lighter rounded-lg p-3 mb-4">
-                <div className="flex justify-between mb-1 text-sm">
-                  <span className="text-gray-400">Nivel {user.level}</span>
-                  <span className="text-gray-400">{user.xp} XP</span>
-                </div>
-                <div className="w-full h-2 bg-dark rounded-full overflow-hidden">
-                  <div 
-                    className="h-full bg-gradient-to-r from-primary to-secondary"
-                    style={{ width: `${(user.xp / (user.level * 1000)) * 100}%` }}
-                  ></div>
-                </div>
+              <div className="mb-4 flex justify-center">
+                <CircularProgress value={levelProgress} label={`Lvl ${user.level}`} />
               </div>
               
               <div className="space-y-2 text-sm text-left">
@@ -435,24 +433,27 @@ const UserProfile = () => {
                       </div>
                     </div>
                     
-                    <div className="bg-dark-lighter p-3 rounded-lg">
-                      <h4 className="font-medium mb-2">Formación habitual</h4>
-                      <p className="text-center text-xl font-bold">4-3-3</p>
-                      <div className="flex justify-center mt-2">
-                        <div className="text-xs text-gray-400">
-                          Estilo ofensivo con extremos abiertos
-                        </div>
-                      </div>
-                    </div>
+              <div className="bg-dark-lighter p-3 rounded-lg">
+                <h4 className="font-medium mb-2">Formación habitual</h4>
+                <p className="text-center text-xl font-bold">4-3-3</p>
+                <div className="flex justify-center mt-2">
+                  <div className="text-xs text-gray-400">
+                    Estilo ofensivo con extremos abiertos
                   </div>
                 </div>
-              )}
+              </div>
             </div>
           </div>
-        </div>
+        )}
+        {user.role === 'dt' && club && (
+          <LineupWidget clubId={club.id} />
+        )}
+        <FinancesWidget />
       </div>
     </div>
-  );
+  </div>
+</div>
+);
 };
 
 // Helper functions


### PR DESCRIPTION
## Summary
- create `CircularProgress` component for radial progress indicators
- show user level with new circular progress component
- add `LineupWidget` to display current lineup
- add `FinancesWidget` with mock recharts bar chart
- register `/usuarios/:username` route for `UserProfile`

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68606a04cb148333ab960fdee961cc41