### PR TITLE
Add user profile route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const Calendario = lazy(() => import("./pages/Calendario"));
 const Login = lazy(() => import("./pages/Login"));
 const Register = lazy(() => import("./pages/Register"));
 const UserPanel = lazy(() => import("./pages/UserPanel"));
+const UserProfile = lazy(() => import("./pages/UserProfile"));
 
 const Tournaments = lazy(() => import("./pages/Tournaments"));
 const TournamentDetail = lazy(() => import("./pages/TournamentDetail"));
@@ -52,6 +53,7 @@ function App() {
             <Route path="login" element={<Login />} />
             <Route path="registro" element={<Register />} />
             <Route path="usuario" element={<UserPanel />} />
+            <Route path="usuarios/:username" element={<UserProfile />} />
             <Route path="dt-dashboard" element={<DtDashboard />} />
             <Route path="admin/*" element={<Admin />} />
 


### PR DESCRIPTION
## Summary
- add a lazy loaded `UserProfile` page import
- route `usuarios/:username` to `UserProfile`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606a06da348333985780377e9fd077