### PR TITLE
Add axe accessibility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ npx cypress run --spec tests/e2e/admin_user_flow.cy.ts
 Ensure the development server is running on `http://localhost:5173` before
 starting the E2E tests.
 
+### Accessibility Test
+
+Run the WCAG A and AA accessibility check with [axe-core](https://github.com/dequelabs/axe-core):
+
+```bash
+npm run test:a11y
+```
+
+This command executes a Vitest script that fails if any violations above level AA are found on the main page.
+
 ## Admin Panel
 
 To access the administrator interface:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "cypress:open": "cypress open",
     "test:unit": "vitest run",
+    "test:a11y": "vitest run tests/a11y.test.ts",
     "test": "npm run lint && npm run build && npm run test:unit && (npx cypress run || echo \"Skipping e2e tests: Cypress not installed\")"
   },
   "dependencies": {
@@ -51,6 +52,8 @@
     "vite": "^6.3.5",
     "vitest": "^3.2.4",
     "@testing-library/react": "^13.4.0",
-    "@testing-library/jest-dom": "^6.1.4"
+    "@testing-library/jest-dom": "^6.1.4",
+    "axe-core": "^4.7.2",
+    "jsdom": "^23.2.0"
   }
 }

--- a/tests/a11y.test.ts
+++ b/tests/a11y.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+import axe from 'axe-core';
+
+// Check the main entry page for WCAG 2.0 A and AA compliance
+
+test('index.html has no WCAG A/AA accessibility violations', async () => {
+  const html = readFileSync('index.html', 'utf8');
+  const { window } = new JSDOM(html);
+
+  const results = await axe.run(window.document, {
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa'],
+    },
+  });
+
+  expect(results.violations).toHaveLength(0);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,5 +7,5 @@
     "module": "CommonJS",
     "outDir": "tests/build"
   },
-  "include": ["src/**/*", "tests/helpers.test.ts"]
+  "include": ["src/**/*", "tests/helpers.test.ts", "tests/a11y.test.ts"]
 }


### PR DESCRIPTION
## Summary
- add axe-core and jsdom dev dependencies
- create a11y Vitest script and register `npm run test:a11y`
- document how to run the accessibility test in the README
- compile a11y test in tsconfig.test.json

## Testing
- `npm run test:a11y` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860796191bc83338d7fca71331d805a