### PR TITLE
Standardize admin page headers

### DIFF
--- a/src/adminPanel/pages/admin/Actividad.tsx
+++ b/src/adminPanel/pages/admin/Actividad.tsx
@@ -17,14 +17,14 @@ const Actividad = () => {
 
   return (
        <div className="p-8 space-y-8">
-      <div>
-        <h1 className="text-4xl font-bold gradient-text">Actividad del Sistema</h1>
-        <p className="text-gray-400 mt-2">Monitorea todas las acciones en tiempo real</p>
-      </div> 
+      <header className="bg-vz-surface p-6 rounded">
+        <h1 className="text-4xl font-heading font-bold gradient-text">Actividad del Sistema</h1>
+        <p className="text-secondary mt-2">Monitorea todas las acciones en tiempo real</p>
+      </header>
       
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="relative">
-          <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+          <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 text-secondary" size={20} />
           <input
             type="date"
             className="input pl-10"
@@ -53,19 +53,19 @@ const Actividad = () => {
                 <div className="flex-1">
                   <div className="flex items-center justify-between">
                     <h4 className="font-medium">{activity.action}</h4>
-                    <span className="text-sm text-gray-400">
+                    <span className="text-sm text-secondary">
                       {new Date(activity.date).toLocaleString()}
                     </span>
                   </div>
-                  <p className="text-gray-400 text-sm mt-1">{activity.details}</p>
-                  <p className="text-xs text-gray-500 mt-2">Usuario: {activity.userId}</p>
+                  <p className="text-secondary text-sm mt-1">{activity.details}</p>
+                  <p className="text-xs text-secondary mt-2">Usuario: {activity.userId}</p>
                 </div>
               </div>
             </div>
           ))
         ) : (
           <div className="card text-center py-8">
-            <p className="text-gray-400">No se encontró actividad para los filtros seleccionados</p>
+            <p className="text-secondary">No se encontró actividad para los filtros seleccionados</p>
           </div>
         )}
       </div>

--- a/src/adminPanel/pages/admin/Clubes.tsx
+++ b/src/adminPanel/pages/admin/Clubes.tsx
@@ -74,23 +74,23 @@ const Clubes = () => {
 
   return (
        <div className="p-8 space-y-8">
-      <div className="flex justify-between items-center">
+      <header className="flex justify-between items-center bg-vz-surface p-6 rounded">
         <div>
-          <h1 className="text-4xl font-bold gradient-text">Clubes</h1>
-          <p className="text-gray-400 mt-2">Administra todos los clubes de la liga</p>
+          <h1 className="text-4xl font-heading font-bold gradient-text">Clubes</h1>
+          <p className="text-secondary mt-2">Administra todos los clubes de la liga</p>
         </div>
-        <button 
+        <button
           className="btn-primary flex items-center space-x-2"
           onClick={() => setShowNew(true)}
         >
           <Plus size={20} />
           <span>Nuevo Club</span>
         </button>
-      </div> 
+      </header>
 
       {/* Search */}
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-secondary" size={20} />
         <input
           type="text"
           placeholder="Buscar clubes..."
@@ -115,7 +115,7 @@ const Clubes = () => {
           <tbody>
             {filteredClubs.length > 0 ? (
               filteredClubs.map((club) => (
-                <tr key={club.id} className="border-t border-gray-700">
+                <tr key={club.id} className="border-t border-dark-light">
                   <td className="table-cell font-medium">{club.name}</td>
                   <td className="table-cell">{getManagerName(club)}</td>
                   <td className="table-cell">${club.budget.toLocaleString()}</td>
@@ -142,7 +142,7 @@ const Clubes = () => {
               ))
             ) : (
               <tr>
-                <td colSpan={5} className="table-cell text-center py-8 text-gray-400">
+                <td colSpan={5} className="table-cell text-center py-8 text-secondary">
                   No se encontraron clubes
                 </td>
               </tr>

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -30,25 +30,25 @@ const Dashboard = () => {
 
   return (
        <div className="p-8 space-y-8">
-      <div className="flex items-center justify-between">
+      <header className="flex items-center justify-between bg-vz-surface p-6 rounded">
         <div>
-          <h1 className="text-4xl font-bold gradient-text">Dashboard</h1>
-          <p className="text-gray-400 mt-2">Bienvenido al panel de administración de La Virtual Zone</p>
+          <h1 className="text-4xl font-heading font-bold gradient-text">Dashboard</h1>
+          <p className="text-secondary mt-2">Bienvenido al panel de administración de La Virtual Zone</p>
         </div>
         <div className="flex items-center space-x-4">
           <div className="glass-panel p-3">
-            <p className="text-sm text-gray-300">Última actualización</p>
-            <p className="text-xs text-gray-400">{new Date().toLocaleString()}</p>
+            <p className="text-sm text-secondary">Última actualización</p>
+            <p className="text-xs text-secondary">{new Date().toLocaleString()}</p>
           </div>
         </div>
-      </div> 
+      </header>
       
            {/* KPI Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <div className="kpi-card group">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-400 text-sm font-medium">Usuarios Activos</p>
+              <p className="text-secondary text-sm font-medium">Usuarios Activos</p>
               <p className="text-3xl font-bold gradient-text">{users.length}</p>
               <p className="text-green-400 text-xs mt-1">+12% este mes</p>
             </div>
@@ -61,7 +61,7 @@ const Dashboard = () => {
         <div className="kpi-card group">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-400 text-sm font-medium">Total Clubes</p>
+              <p className="text-secondary text-sm font-medium">Total Clubes</p>
               <p className="text-3xl font-bold text-emerald-400">{clubs.length}</p>
               <p className="text-green-400 text-xs mt-1">+5% este mes</p>
             </div>
@@ -74,7 +74,7 @@ const Dashboard = () => {
         <div className="kpi-card group">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-400 text-sm font-medium">Total Jugadores</p>
+              <p className="text-secondary text-sm font-medium">Total Jugadores</p>
               <p className="text-3xl font-bold text-purple-400">{players.length}</p>
               <p className="text-green-400 text-xs mt-1">+8% este mes</p>
             </div>
@@ -87,7 +87,7 @@ const Dashboard = () => {
         <div className="kpi-card group">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-400 text-sm font-medium">Fichajes Pendientes</p>
+              <p className="text-secondary text-sm font-medium">Fichajes Pendientes</p>
               <p className="text-3xl font-bold text-orange-400">{pendingTransfers}</p>
               <p className="text-red-400 text-xs mt-1">Requiere atención</p>
             </div>
@@ -130,13 +130,13 @@ const Dashboard = () => {
                   <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
                   <div className="flex-1">
                     <p className="text-sm font-medium">{activity.action}</p>
-                    <p className="text-xs text-gray-400">{activity.details}</p>
-                    <p className="text-xs text-gray-500">{new Date(activity.date).toLocaleString()}</p>
+                    <p className="text-xs text-secondary">{activity.details}</p>
+                    <p className="text-xs text-secondary">{new Date(activity.date).toLocaleString()}</p>
                   </div>
                 </div>
               ))
             ) : (
-              <p className="text-gray-400 text-center py-4">No hay actividad reciente</p>
+              <p className="text-secondary text-center py-4">No hay actividad reciente</p>
             )}
           </div>
         </div>
@@ -154,9 +154,9 @@ const Dashboard = () => {
             <span className="text-sm">Jornada Actual</span>
             <span className="text-blue-400 text-sm font-medium">15</span>
           </div>
-          <div className="flex items-center justify-between p-3 bg-gray-800 border border-gray-700 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-gray-800 border border-dark-light rounded-lg">
             <span className="text-sm">Último Backup</span>
-            <span className="text-gray-400 text-sm">Hace 2h</span>
+            <span className="text-secondary text-sm">Hace 2h</span>
           </div>
         </div>
       </div>

--- a/src/adminPanel/pages/admin/Estadisticas.tsx
+++ b/src/adminPanel/pages/admin/Estadisticas.tsx
@@ -29,10 +29,10 @@ const Estadisticas = () => {
 
    return (
     <div className="p-8 space-y-8">
-      <div className="flex justify-between items-center">
+      <header className="flex justify-between items-center bg-vz-surface p-6 rounded">
         <div>
-          <h1 className="text-4xl font-bold gradient-text">Estadísticas</h1>
-          <p className="text-gray-400 mt-2">Análisis detallado del rendimiento del sistema</p>
+          <h1 className="text-4xl font-heading font-bold gradient-text">Estadísticas</h1>
+          <p className="text-secondary mt-2">Análisis detallado del rendimiento del sistema</p>
         </div>
         <div className="glass-panel p-3">
           <select
@@ -51,22 +51,22 @@ const Estadisticas = () => {
       {/* KPI Grid */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
         <div className="card text-center">
-          <h3 className="text-lg font-semibold text-gray-400">Total Usuarios</h3>
+          <h3 className="text-lg font-semibold text-secondary">Total Usuarios</h3>
           <p className="text-3xl font-bold text-blue-500 mt-2">{users.length}</p>
         </div>
         <div className="card text-center">
-          <h3 className="text-lg font-semibold text-gray-400">Total Clubes</h3>
+          <h3 className="text-lg font-semibold text-secondary">Total Clubes</h3>
           <p className="text-3xl font-bold text-green-500 mt-2">{clubs.length}</p>
         </div>
         <div className="card text-center">
-          <h3 className="text-lg font-semibold text-gray-400">Total Jugadores</h3>
+          <h3 className="text-lg font-semibold text-secondary">Total Jugadores</h3>
           <p className="text-3xl font-bold text-purple-500 mt-2">{players.length}</p>
         </div>
         <div className="card text-center">
-          <h3 className="text-lg font-semibold text-gray-400">Transferencias</h3>
+          <h3 className="text-lg font-semibold text-secondary">Transferencias</h3>
           <p className="text-3xl font-bold text-orange-500 mt-2">{transfers.length}</p>
         </div>
-      </div>
+      </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Users by Role */}

--- a/src/adminPanel/pages/admin/Jugadores.tsx
+++ b/src/adminPanel/pages/admin/Jugadores.tsx
@@ -71,24 +71,24 @@ const Jugadores = () => {
 
   return (
        <div className="p-8 space-y-8">
-      <div className="flex justify-between items-center">
+      <header className="flex justify-between items-center bg-vz-surface p-6 rounded">
         <div>
-          <h1 className="text-4xl font-bold gradient-text">Jugadores</h1>
-          <p className="text-gray-400 mt-2">Base de datos completa de jugadores</p>
+          <h1 className="text-4xl font-heading font-bold gradient-text">Jugadores</h1>
+          <p className="text-secondary mt-2">Base de datos completa de jugadores</p>
         </div>
-        <button 
+        <button
           className="btn-primary flex items-center space-x-2"
           onClick={() => setShowNew(true)}
         >
           <Plus size={20} />
           <span>Nuevo Jugador</span>
         </button>
-      </div> 
+      </header>
 
       {/* Filters */}
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-secondary" size={20} />
           <input
             type="text"
             placeholder="Buscar jugadores..."
@@ -136,7 +136,7 @@ const Jugadores = () => {
           <tbody>
             {filteredPlayers.length > 0 ? (
               filteredPlayers.map((player) => (
-                <tr key={player.id} className="border-t border-gray-700">
+                <tr key={player.id} className="border-t border-dark-light">
                   <td className="table-cell font-medium">{player.name}</td>
                   <td className="table-cell">
                     <span className={`px-2 py-1 rounded-full text-xs ${
@@ -156,7 +156,7 @@ const Jugadores = () => {
                     <span className={`font-medium ${
                       player.overall >= 85 ? 'text-green-400' :
                       player.overall >= 75 ? 'text-yellow-400' :
-                      'text-gray-400'
+                      'text-secondary'
                     }`}>
                       {player.overall}
                     </span>
@@ -182,7 +182,7 @@ const Jugadores = () => {
               ))
             ) : (
               <tr>
-                <td colSpan={6} className="table-cell text-center py-8 text-gray-400">
+                <td colSpan={6} className="table-cell text-center py-8 text-secondary">
                   No se encontraron jugadores
                 </td>
               </tr>

--- a/src/adminPanel/pages/admin/Mercado.tsx
+++ b/src/adminPanel/pages/admin/Mercado.tsx
@@ -40,19 +40,19 @@ const Mercado = () => {
 
   return (
        <div className="p-8 space-y-8">
-      <div className="flex justify-between items-center">
+      <header className="flex justify-between items-center bg-vz-surface p-6 rounded">
         <div>
-          <h1 className="text-4xl font-bold gradient-text">Mercado de Fichajes</h1>
-          <p className="text-gray-400 mt-2">Centro de control de transferencias</p>
+          <h1 className="text-4xl font-heading font-bold gradient-text">Mercado de Fichajes</h1>
+          <p className="text-secondary mt-2">Centro de control de transferencias</p>
           {pendingCount > 0 && (
             <div className="flex items-center mt-3">
               <span className="bg-gradient-to-r from-red-600 to-pink-600 text-white px-3 py-1.5 rounded-full text-sm font-bold shadow-lg animate-pulse">
                 {pendingCount}
               </span>
-              <span className="ml-3 text-gray-300 text-sm font-medium">ofertas requieren tu atención</span>
+              <span className="ml-3 text-secondary text-sm font-medium">ofertas requieren tu atención</span>
             </div>
           )}
-        </div> 
+        </div>
         <select
           className="input"
           value={filter}
@@ -63,7 +63,7 @@ const Mercado = () => {
           <option value="rejected">Rechazadas</option>
           <option value="all">Todas</option>
         </select>
-      </div>
+      </header>
 
       <div className="space-y-4">
         {filteredTransfers.length > 0 ? (
@@ -72,10 +72,10 @@ const Mercado = () => {
               <div className="flex items-center justify-between">
                 <div className="flex-1">
                   <p className="font-medium">Transferencia #{transfer.id}</p>
-                  <p className="text-sm text-gray-400">
+                  <p className="text-sm text-secondary">
                     Jugador ID: {transfer.playerId} | De: {transfer.fromClubId} → A: {transfer.toClubId}
                   </p>
-                  <p className="text-sm text-gray-400">
+                  <p className="text-sm text-secondary">
                     Monto: ${transfer.amount.toLocaleString()} | {new Date(transfer.createdAt).toLocaleDateString()}
                   </p>
                 </div>
@@ -114,7 +114,7 @@ const Mercado = () => {
           ))
         ) : (
           <div className="card text-center py-8">
-            <p className="text-gray-400">No hay transferencias para mostrar</p>
+            <p className="text-secondary">No hay transferencias para mostrar</p>
           </div>
         )}
       </div>
@@ -124,7 +124,7 @@ const Mercado = () => {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-gray-800 p-6 rounded-lg max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold mb-4">Rechazar Transferencia</h3>
-            <p className="text-gray-400 mb-4">Indica el motivo del rechazo:</p>
+            <p className="text-secondary mb-4">Indica el motivo del rechazo:</p>
             <textarea
               className="input w-full h-24 resize-none"
               placeholder="Motivo del rechazo..."

--- a/src/adminPanel/pages/admin/Usuarios.tsx
+++ b/src/adminPanel/pages/admin/Usuarios.tsx
@@ -73,24 +73,24 @@ const Usuarios = () => {
 
   return (
        <div className="p-8 space-y-8">
-      <div className="flex justify-between items-center">
+      <header className="flex justify-between items-center bg-vz-surface p-6 rounded">
         <div>
-          <h1 className="text-4xl font-bold gradient-text">Usuarios</h1>
-          <p className="text-gray-400 mt-2">Gestiona todos los usuarios del sistema</p>
+          <h1 className="text-4xl font-heading font-bold gradient-text">Usuarios</h1>
+          <p className="text-secondary mt-2">Gestiona todos los usuarios del sistema</p>
         </div>
-        <button 
+        <button
           className="btn-primary flex items-center space-x-2"
           onClick={() => setShowNew(true)}
         >
           <Plus size={20} />
           <span>Nuevo Usuario</span>
         </button>
-      </div> 
+      </header>
 
       {/* Filters */}
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-secondary" size={20} />
           <input
             type="text"
             placeholder="Buscar usuarios..."
@@ -127,7 +127,7 @@ const Usuarios = () => {
           <tbody>
             {paginatedUsers.length > 0 ? (
               paginatedUsers.map((user) => (
-                <tr key={user.id} className="border-t border-gray-700">
+                <tr key={user.id} className="border-t border-dark-light">
                   <td className="table-cell font-medium">{user.username}</td>
                   <td className="table-cell">{user.email}</td>
                   <td className="table-cell">
@@ -136,7 +136,7 @@ const Usuarios = () => {
                         ? 'bg-red-900/20 text-red-300' 
                         : user.role === 'dt'
                         ? 'bg-blue-900/20 text-blue-300'
-                        : 'bg-gray-700 text-gray-300'
+                        : 'bg-dark-light text-secondary'
                     }`}>
                       {user.role.toUpperCase()}
                     </span>
@@ -173,7 +173,7 @@ const Usuarios = () => {
               ))
             ) : (
               <tr>
-                <td colSpan={6} className="table-cell text-center py-8 text-gray-400">
+                <td colSpan={6} className="table-cell text-center py-8 text-secondary">
                   No se encontraron usuarios
                 </td>
               </tr>
@@ -190,8 +190,8 @@ const Usuarios = () => {
               key={page}
               className={`px-3 py-1 rounded ${
                 currentPage === page 
-                  ? 'bg-blue-600 text-white' 
-                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-dark-light text-secondary hover:bg-dark-lighter'
               }`}
               onClick={() => setCurrentPage(page)}
             >


### PR DESCRIPTION
## Summary
- apply consistent header styling across admin pages
- use font-heading and token colors instead of gray utilities

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614a0d3f888333bc8f49e82d1420ea