### PR TITLE
Update admin tables with shared styles

### DIFF
--- a/src/adminPanel/components/admin/StatsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/StatsAdminPanel.tsx
@@ -14,12 +14,12 @@ const StatsAdminPanel = () => {
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">Estadísticas</h2>
-      <div className="bg-gray-800 rounded-lg overflow-hidden">
-        <table className="w-full">
+      <div className="rounded-lg border border-vz-overlay overflow-x-auto">
+        <table className="min-w-full text-sm">
           <tbody>
             {standings.map(row => (
-              <tr key={row.clubId}>
-                <td className="px-4 py-3">
+              <tr key={row.clubId} className="border-t border-vz-overlay even:bg-vz-overlay/50">
+                <td className="table-cell">
                   <input
                     type="number"
                     className="input w-20 text-center"

--- a/src/adminPanel/index.css
+++ b/src/adminPanel/index.css
@@ -46,11 +46,11 @@
   }
   
   .table-header {
-    @apply bg-gradient-to-r from-gray-700 to-gray-800 text-left text-xs font-bold text-gray-200 uppercase tracking-wider px-6 py-4 rounded-t-xl;
+    @apply px-s-3 py-s-2 text-left font-heading;
   }
-  
+
   .table-cell {
-    @apply px-6 py-4 whitespace-nowrap text-sm text-gray-300 border-b border-gray-700/50;
+    @apply px-s-3 py-s-2 text-sm border-b border-vz-overlay;
   }
   
   .kpi-card {

--- a/src/adminPanel/pages/admin/Clubes.tsx
+++ b/src/adminPanel/pages/admin/Clubes.tsx
@@ -101,9 +101,9 @@ const Clubes = () => {
       </div>
 
       {/* Clubs Table */}
-      <div className="bg-gray-800 rounded-lg overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-gray-700">
+      <div className="rounded-lg border border-vz-overlay overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-vz-overlay">
             <tr>
               <th className="table-header">Club</th>
               <th className="table-header">Entrenador</th>
@@ -115,7 +115,7 @@ const Clubes = () => {
           <tbody>
             {filteredClubs.length > 0 ? (
               filteredClubs.map((club) => (
-                <tr key={club.id} className="border-t border-gray-700">
+                <tr key={club.id} className="border-t border-vz-overlay even:bg-vz-overlay/50">
                   <td className="table-cell font-medium">{club.name}</td>
                   <td className="table-cell">{getManagerName(club)}</td>
                   <td className="table-cell">${club.budget.toLocaleString()}</td>

--- a/src/adminPanel/pages/admin/Jugadores.tsx
+++ b/src/adminPanel/pages/admin/Jugadores.tsx
@@ -121,9 +121,9 @@ const Jugadores = () => {
       </div>
 
       {/* Players Table */}
-      <div className="bg-gray-800 rounded-lg overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-gray-700">
+      <div className="rounded-lg border border-vz-overlay overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-vz-overlay">
             <tr>
               <th className="table-header">Nombre</th>
               <th className="table-header">Posición</th>
@@ -136,7 +136,7 @@ const Jugadores = () => {
           <tbody>
             {filteredPlayers.length > 0 ? (
               filteredPlayers.map((player) => (
-                <tr key={player.id} className="border-t border-gray-700">
+                <tr key={player.id} className="border-t border-vz-overlay even:bg-vz-overlay/50">
                   <td className="table-cell font-medium">{player.name}</td>
                   <td className="table-cell">
                     <span className={`px-2 py-1 rounded-full text-xs ${

--- a/src/adminPanel/pages/admin/Usuarios.tsx
+++ b/src/adminPanel/pages/admin/Usuarios.tsx
@@ -112,9 +112,9 @@ const Usuarios = () => {
       </div>
 
       {/* Users Table */}
-      <div className="bg-gray-800 rounded-lg overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-gray-700">
+      <div className="rounded-lg border border-vz-overlay overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-vz-overlay">
             <tr>
               <th className="table-header">Usuario</th>
               <th className="table-header">Email</th>
@@ -127,7 +127,7 @@ const Usuarios = () => {
           <tbody>
             {paginatedUsers.length > 0 ? (
               paginatedUsers.map((user) => (
-                <tr key={user.id} className="border-t border-gray-700">
+                <tr key={user.id} className="border-t border-vz-overlay even:bg-vz-overlay/50">
                   <td className="table-cell font-medium">{user.username}</td>
                   <td className="table-cell">{user.email}</td>
                   <td className="table-cell">


### PR DESCRIPTION
## Summary
- use token-based table styles in Users, Clubs, Players pages
- match `Table` component styles in stats panel and global CSS

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68614a0f099c8333b648623394248469