### PR TITLE
Add admin club creation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run preview
 ```
 ## Tests
 
-Run the Cypress test suite (which now includes an admin user flow test):
+Run the Cypress test suite (which now includes admin user flow and club creation tests):
 
 ```bash
 npm run test
@@ -54,6 +54,10 @@ To execute only the admin user flow test, specify its path:
 ```bash
 npx cypress run --spec tests/e2e/admin_user_flow.cy.ts
 ```
+To execute only the admin club creation test, run:
+
+```bash
+npx cypress run --spec tests/e2e/admin_club_creation.cy.ts
 ```
 
 Ensure the development server is running on `http://localhost:5173` before

--- a/tests/e2e/admin_club_creation.cy.ts
+++ b/tests/e2e/admin_club_creation.cy.ts
@@ -1,0 +1,35 @@
+/// <reference types="cypress" />
+
+describe('Admin club creation flow', () => {
+  it('creates a new club from the admin panel', () => {
+    // Confirm the home page loads
+    cy.visit('/');
+    cy.contains('LA VIRTUAL ZONE');
+
+    // Log in as admin
+    cy.visit('/login');
+    cy.get('input[type="text"]').first().type('admin');
+    cy.get('input[type="password"]').type('password');
+    cy.get('button[type="submit"]').click();
+    cy.url().should('include', '/usuario');
+
+    // Create a DT user to assign to the club
+    cy.visit('/admin/usuarios');
+    cy.contains('button', 'Nuevo Usuario').click();
+    cy.get('input[placeholder="Usuario"]').type('testdt');
+    cy.get('input[placeholder="Email"]').type('testdt@example.com');
+    cy.get('select').select('dt');
+    cy.contains('button', 'Crear').click();
+    cy.contains('td', 'testdt');
+
+    // Create the club
+    cy.visit('/admin/clubes');
+    cy.contains('button', 'Nuevo Club').click();
+    cy.get('input[placeholder="Nombre del club"]').type('Test Club');
+    cy.get('select').select('testdt');
+    cy.contains('button', 'Crear').click();
+
+    // Verify the club appears in the table
+    cy.contains('td', 'Test Club');
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress test for creating clubs via admin panel
- document new test in README

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861509de1e483338a26d483b036f33a