### PR TITLE
Fix login handler and neon-fc link

### DIFF
--- a/src/pages/TestMarket.tsx
+++ b/src/pages/TestMarket.tsx
@@ -9,7 +9,7 @@ const TestMarket = () => {
   const [error, setError] = useState<string | null>(null);
   const [loginSuccess, setLoginSuccess] = useState(false);
   
-  const handleLogin = async (e: React.FormEvent) => {
+  const handleLogin = (e: React.FormEvent) => {
     e.preventDefault();
     
     if (!username) {
@@ -18,7 +18,7 @@ const TestMarket = () => {
     }
     
     try {
-  await login(username, password || 'password'); // The password for test accounts is fixed
+      login(username, password || 'password'); // The password for test accounts is fixed
       setError(null);
       setLoginSuccess(true);
       
@@ -193,7 +193,7 @@ const TestMarket = () => {
             <div>
               <h4 className="font-bold text-primary mb-2">3. Revisa la Plantilla de tu Club</h4>
               <p className="text-gray-300 text-sm">
-                Ve a <a href="/liga-master/club/neón-fc" className="text-primary hover:underline">/liga-master/club/neón-fc</a> para ver tu plantilla actual y las finanzas del club.
+                Ve a <a href="/liga-master/club/neon-fc" className="text-primary hover:underline">/liga-master/club/neon-fc</a> para ver tu plantilla actual y las finanzas del club.
               </p>
             </div>
             


### PR DESCRIPTION
## Summary
- correct TestMarket club link to slugified neon-fc
- remove async usage from TestMarket login handler

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686158dd9ba48333a6ccce6e1cf2741b