### PR TITLE
Fix admin panel hover color class

### DIFF
--- a/src/adminPanel/index.css
+++ b/src/adminPanel/index.css
@@ -42,7 +42,7 @@ html:not(.dark) {
 
 @layer components {
   .btn-primary {
-    @apply bg-vz-primary hover:bg-vz-primary/90 text-white px-6 py-3 rounded-xl font-heading font-semibold transition-all duration-300 shadow-lg hover:shadow-vz-primary/25 hover:scale-105;
+    @apply bg-vz-primary hover:bg-primary-light text-white px-6 py-3 rounded-xl font-heading font-semibold transition-all duration-300 shadow-lg hover:shadow-vz-primary/25 hover:scale-105;
   }
 
   .btn-outline {


### PR DESCRIPTION
## Summary
- fix admin panel button style by replacing unsupported `hover:bg-vz-primary/90`

## Testing
- `npx tailwindcss --help` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68616979c1a48333853b59350ece21a5