### PR TITLE
Define primary RGB vars

### DIFF
--- a/src/adminPanel/index.css
+++ b/src/adminPanel/index.css
@@ -5,6 +5,7 @@
 :root {
   /* Design tokens */
   --vz-primary: #7f39fb;
+  --vz-primary-rgb: 127 57 251;
   --vz-accent: #3ff;
   --vz-bg-surface: #18181f;
   --vz-bg-overlay: rgba(255, 255, 255, 0.05);
@@ -12,6 +13,7 @@
 
   /* Backwards compatibility */
   --primary: var(--vz-primary);
+  --primary-rgb: var(--vz-primary-rgb);
   --primary-light: #9f65fd;
   --primary-dark: #5f2cb8;
   --accent: var(--vz-accent);

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@
 :root {
   /* Design tokens */
   --vz-primary: #7f39fb;
+  --vz-primary-rgb: 127 57 251;
   --vz-accent: #3ff;
   --vz-bg-surface: #18181f;
   --vz-bg-overlay: rgba(255, 255, 255, 0.05);
@@ -12,6 +13,7 @@
 
   /* Backwards compatibility */
   --primary: var(--vz-primary);
+  --primary-rgb: var(--vz-primary-rgb);
   --primary-light: #9f65fd;
   --primary-dark: #5f2cb8;
   --accent: var(--vz-accent);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        'vz-primary': 'var(--vz-primary)',
+        'vz-primary': 'rgb(var(--vz-primary-rgb) / <alpha-value>)',
         'vz-accent': 'var(--vz-accent)',
         'vz-bg': 'var(--vz-bg-surface)',
         'vz-surface': 'var(--vz-bg-surface)',
@@ -14,7 +14,7 @@ export default {
         'neon-blue': 'var(--neon-blue)',
         'neon-green': 'var(--neon-green)',
         'neon-yellow': 'var(--neon-yellow)',
-        primary: 'var(--primary)',
+        primary: 'rgb(var(--primary-rgb) / <alpha-value>)',
         'primary-light': 'var(--primary-light)',
         'primary-dark': 'var(--primary-dark)',
         dark: '#1a1a24',


### PR DESCRIPTION
## Summary
- set `--vz-primary-rgb` and `--primary-rgb` CSS variables
- use `rgb(var(--vz-primary-rgb) / <alpha-value>)` for Tailwind `vz-primary`
- use `rgb(var(--primary-rgb) / <alpha-value>)` for Tailwind `primary`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616dec950c8333b0ad38bf072a6a6a