### PR TITLE
Fix admin dashboard card import path

### DIFF
--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -1,6 +1,6 @@
 import  { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line } from 'recharts';
 import { Users, Globe, User, ShoppingBag } from 'lucide-react';
-import Card from '../../components/ui/Card';
+import Card from '../../../components/ui/Card';
 import StatsCard from '../../components/admin/StatsCard';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';


### PR DESCRIPTION
## Summary
- fix import path for Card component in `Dashboard.tsx`

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861727a218083339605326347862e65