### PR TITLE
Add versioned seed initialization

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,14 +7,21 @@ import './index.css';
 import seed from './data/seed.json';
 import { VZ_CLUBS_KEY, VZ_PLAYERS_KEY, VZ_FIXTURES_KEY } from './utils/storageKeys';
 
-if (typeof localStorage !== 'undefined' && !localStorage.getItem('vz_initialized')) {
-  try {
-    localStorage.setItem(VZ_CLUBS_KEY, JSON.stringify(seed.clubs));
-    localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(seed.players));
-    localStorage.setItem(VZ_FIXTURES_KEY, JSON.stringify(seed.fixtures));
-    localStorage.setItem('vz_initialized', 'true');
-  } catch {
-    // ignore write errors
+// Update this value when modifying seed.json to force re-seeding
+const SEED_VERSION_KEY = 'vz_seed_version';
+const SEED_VERSION = '1';
+
+if (typeof localStorage !== 'undefined') {
+  const storedVersion = localStorage.getItem(SEED_VERSION_KEY);
+  if (storedVersion !== SEED_VERSION) {
+    try {
+      localStorage.setItem(VZ_CLUBS_KEY, JSON.stringify(seed.clubs));
+      localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(seed.players));
+      localStorage.setItem(VZ_FIXTURES_KEY, JSON.stringify(seed.fixtures));
+      localStorage.setItem(SEED_VERSION_KEY, SEED_VERSION);
+    } catch {
+      // ignore write errors
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add constants for seed version and key
- reseed `localStorage` when version changes

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686199c8f5148333a3b4f8988aaf4db0