### PR TITLE
Fix adminStorage for environments without localStorage

### DIFF
--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -60,6 +60,9 @@ const migrateOldKeys = () => {
 };
 
 export const loadAdminData = (defaults: AdminData): AdminData => {
+  if (typeof localStorage === 'undefined') {
+    return defaults;
+  }
   const data: AdminData = { ...defaults };
   migrateOldKeys();
   Object.entries(keys).forEach(([prop, key]) => {
@@ -76,6 +79,9 @@ export const loadAdminData = (defaults: AdminData): AdminData => {
 };
 
 export const saveAdminData = (data: AdminData): void => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
   Object.entries(keys).forEach(([prop, key]) => {
     const value = (data as any)[prop];
     try {

--- a/tests/adminStorage.test.ts
+++ b/tests/adminStorage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadAdminData, saveAdminData, AdminData } from '../src/adminPanel/utils/adminStorage';
+import { VZ_USERS_KEY } from '../src/utils/storageKeys';
+
+const defaults: AdminData = {
+  users: [],
+  clubs: [],
+  players: [],
+  tournaments: [],
+  newsItems: [],
+  transfers: [],
+  standings: [],
+  activities: [],
+  comments: []
+};
+
+const createMockStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    }
+  } as Storage;
+};
+
+beforeEach(() => {
+  delete (global as any).localStorage;
+});
+
+describe('adminStorage', () => {
+  it('returns defaults when localStorage is undefined', () => {
+    const data = loadAdminData(defaults);
+    expect(data).toEqual(defaults);
+  });
+
+  it('loads data from localStorage when available', () => {
+    const mock = createMockStorage();
+    mock.setItem(VZ_USERS_KEY, JSON.stringify([{ id: '1' }]));
+    (global as any).localStorage = mock;
+
+    const data = loadAdminData(defaults);
+    expect(data.users).toEqual([{ id: '1' }]);
+  });
+
+  it('saveAdminData does nothing when localStorage is undefined', () => {
+    expect(() => saveAdminData(defaults)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing `localStorage` when loading/saving admin panel data
- add basic tests for `loadAdminData`/`saveAdminData`

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686199caaf4083338a2dae18d8d7321c