### PR TITLE
Add match support to admin panel

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -9,7 +9,8 @@ import {
   Transfer,
   Standing,
   ActivityLog,
-  Comment
+  Comment,
+  Match
 } from '../types';
 import {
   loadAdminData,
@@ -21,6 +22,7 @@ interface GlobalStore {
   users: User[];
   clubs: Club[];
   players: Player[];
+  matches: Match[];
   tournaments: Tournament[];
   newsItems: NewsItem[];
   transfers: Transfer[];
@@ -45,6 +47,11 @@ interface GlobalStore {
   addPlayer: (player: Player) => void;
   updatePlayer: (player: Player) => void;
   removePlayer: (id: string) => void;
+
+  // Matches
+  addMatch: (match: Match) => void;
+  updateMatch: (match: Match) => void;
+  removeMatch: (id: string) => void;
   
   // Transfers
   approveTransfer: (id: string) => void;
@@ -119,6 +126,7 @@ const defaultData: AdminData = {
       price: 20000000
     }
   ],
+  matches: [],
   tournaments: [],
   newsItems: [
     {
@@ -179,6 +187,7 @@ export const useGlobalStore = create<GlobalStore>()(
       users: get().users,
       clubs: get().clubs,
       players: get().players,
+      matches: get().matches,
       tournaments: get().tournaments,
       newsItems: get().newsItems,
       transfers: get().transfers,
@@ -314,6 +323,21 @@ export const useGlobalStore = create<GlobalStore>()(
 
     removePlayer: id => {
       set(state => ({ players: state.players.filter(p => p.id !== id) }));
+      persist();
+    },
+
+    addMatch: match => {
+      set(state => ({ matches: [...state.matches, match] }));
+      persist();
+    },
+
+    updateMatch: match => {
+      set(state => ({ matches: state.matches.map(m => (m.id === match.id ? match : m)) }));
+      persist();
+    },
+
+    removeMatch: id => {
+      set(state => ({ matches: state.matches.filter(m => m.id !== id) }));
       persist();
     },
 

--- a/src/adminPanel/types.ts
+++ b/src/adminPanel/types.ts
@@ -53,6 +53,18 @@ export interface Transfer {
   createdAt: string;
 }
 
+export interface Match {
+  id: string;
+  home: string;
+  away: string;
+  date: string;
+  time: string;
+  round: number;
+  status: 'scheduled' | 'live' | 'finished';
+  homeScore?: number;
+  awayScore?: number;
+}
+
 export interface Standing {
   id: string;
   clubId: string;

--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -1,13 +1,15 @@
 import {
   VZ_USERS_KEY,
   VZ_CLUBS_KEY,
-  VZ_PLAYERS_KEY
+  VZ_PLAYERS_KEY,
+  VZ_FIXTURES_KEY
 } from '../../utils/storageKeys';
 
 export interface AdminData {
   users: import('../types').User[];
   clubs: import('../types').Club[];
   players: import('../types').Player[];
+  matches: import('../types').Match[];
   tournaments: import('../types').Tournament[];
   newsItems: import('../types').NewsItem[];
   transfers: import('../types').Transfer[];
@@ -28,7 +30,8 @@ const OLD_KEYS = {
   transfers: `${PREFIX}transfers_admin`,
   standings: `${PREFIX}standings_admin`,
   activities: `${PREFIX}activities_admin`,
-  comments: `${PREFIX}comments_admin`
+  comments: `${PREFIX}comments_admin`,
+  matches: `${PREFIX}fixtures_admin`
 } as const;
 
 // Updated keys aligned with the main application
@@ -36,6 +39,7 @@ const keys = {
   users: VZ_USERS_KEY,
   clubs: VZ_CLUBS_KEY,
   players: VZ_PLAYERS_KEY,
+  matches: VZ_FIXTURES_KEY,
   tournaments: OLD_KEYS.tournaments,
   newsItems: OLD_KEYS.newsItems,
   transfers: OLD_KEYS.transfers,

--- a/tests/adminStorage.test.ts
+++ b/tests/adminStorage.test.ts
@@ -6,6 +6,7 @@ const defaults: AdminData = {
   users: [],
   clubs: [],
   players: [],
+  matches: [],
   tournaments: [],
   newsItems: [],
   transfers: [],


### PR DESCRIPTION
## Summary
- create a Match interface for the admin panel
- persist matches in admin storage
- store matches in global admin store with add/update/remove helpers
- adjust unit tests for new matches array

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619c79cf488333839a63edc01631e6