### PR TITLE
Remove duplicated matches fields

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -10,8 +10,7 @@ import {
   Transfer,
   Standing,
   ActivityLog,
-  Comment,
-  Match
+  Comment
 } from '../types';
 import {
   loadAdminData,
@@ -25,7 +24,6 @@ interface GlobalStore {
   players: Player[];
   matches: Match[];
   tournaments: Tournament[];
-  matches: Match[];
   newsItems: NewsItem[];
   transfers: Transfer[];
   standings: Standing[];
@@ -126,7 +124,6 @@ const defaultData: AdminData = {
       price: 20000000
     }
   ],
-  matches: [],
   tournaments: [],
   matches: [
     {
@@ -227,7 +224,6 @@ export const useGlobalStore = create<GlobalStore>()(
       players: get().players,
       matches: get().matches,
       tournaments: get().tournaments,
-      matches: get().matches,
       newsItems: get().newsItems,
       transfers: get().transfers,
       standings: get().standings,

--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -11,7 +11,6 @@ export interface AdminData {
   players: import('../types').Player[];
   matches: import('../types').Match[];
   tournaments: import('../types').Tournament[];
-  matches: import('../types').Match[];
   newsItems: import('../types').NewsItem[];
   transfers: import('../types').Transfer[];
   standings: import('../types').Standing[];
@@ -32,8 +31,7 @@ const OLD_KEYS = {
   transfers: `${PREFIX}transfers_admin`,
   standings: `${PREFIX}standings_admin`,
   activities: `${PREFIX}activities_admin`,
-  comments: `${PREFIX}comments_admin`,
-  matches: `${PREFIX}fixtures_admin`
+  comments: `${PREFIX}comments_admin`
 } as const;
 
 // Updated keys aligned with the main application
@@ -43,7 +41,6 @@ const keys = {
   players: VZ_PLAYERS_KEY,
   matches: VZ_FIXTURES_KEY,
   tournaments: OLD_KEYS.tournaments,
-  matches: OLD_KEYS.matches,
   newsItems: OLD_KEYS.newsItems,
   transfers: OLD_KEYS.transfers,
   standings: OLD_KEYS.standings,


### PR DESCRIPTION
## Summary
- remove repeated `Match` import
- remove duplicate `matches` fields from admin storage and store
- keep persistence logic using the single `matches` property

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a188807c8333a7b718c5aeaed292