### PR TITLE
Add tournament creation modal

### DIFF
--- a/src/adminPanel/components/admin/NewTournamentModal.tsx
+++ b/src/adminPanel/components/admin/NewTournamentModal.tsx
@@ -1,0 +1,94 @@
+import { useState, useRef, useEffect } from 'react';
+import { Tournament } from '../../types';
+
+interface Props {
+  onClose: () => void;
+  onSave: (data: Partial<Tournament>) => void;
+}
+
+const NewTournamentModal = ({ onClose, onSave }: Props) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    totalRounds: 1,
+    status: 'upcoming' as Tournament['status'],
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    modalRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {};
+    if (!formData.name.trim()) newErrors.name = 'Nombre requerido';
+    if (formData.totalRounds <= 0) newErrors.totalRounds = 'Rondas inválidas';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validate()) {
+      onSave({
+        ...formData,
+        currentRound: 0,
+      });
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div
+        ref={modalRef}
+        className="bg-gray-800 p-6 rounded-lg max-w-md w-full mx-4"
+        tabIndex={-1}
+      >
+        <h3 className="text-lg font-semibold mb-4">Nuevo Torneo</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input
+              className={`input w-full ${errors.name ? 'border-red-500' : ''}`}
+              placeholder="Nombre del torneo"
+              value={formData.name}
+              onChange={e => setFormData({ ...formData, name: e.target.value })}
+            />
+            {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className={`input w-full ${errors.totalRounds ? 'border-red-500' : ''}`}
+              placeholder="Total de jornadas"
+              value={formData.totalRounds}
+              onChange={e => setFormData({ ...formData, totalRounds: Number(e.target.value) })}
+            />
+            {errors.totalRounds && (
+              <p className="text-red-500 text-sm mt-1">{errors.totalRounds}</p>
+            )}
+          </div>
+          <select
+            className="input w-full"
+            value={formData.status}
+            onChange={e => setFormData({ ...formData, status: e.target.value as Tournament['status'] })}
+          >
+            <option value="upcoming">Próximo</option>
+            <option value="active">Activo</option>
+            <option value="completed">Completado</option>
+          </select>
+          <div className="flex space-x-3 justify-end mt-6">
+            <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>
+            <button type="submit" className="btn-primary">Crear</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default NewTournamentModal;

--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -2,9 +2,10 @@ import  { useState } from 'react';
 import { Plus, Play, Pause, Award } from 'lucide-react';
 import { Tournament } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
+import NewTournamentModal from './NewTournamentModal';
 
 const TournamentsAdminPanel = () => {
-  const { tournaments, updateTournamentStatus } = useGlobalStore();
+  const { tournaments, updateTournamentStatus, addTournament } = useGlobalStore();
   const [showNew, setShowNew] = useState(false);
   const [selected, setSelected] = useState<Tournament | null>(null);
 
@@ -131,6 +132,15 @@ const TournamentsAdminPanel = () => {
           </div>
         </div>
       </div>
+      {showNew && (
+        <NewTournamentModal
+          onClose={() => setShowNew(false)}
+          onSave={(data) => {
+            addTournament({ id: Date.now().toString(), ...data });
+            setShowNew(false);
+          }}
+        />
+      )}
       {selected && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-gray-800 p-6 rounded-lg max-w-sm w-full mx-4">

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -51,6 +51,7 @@ interface GlobalStore {
     removePlayer: (id: string) => void;
 
     // Tournaments
+    addTournament: (tournament: Tournament) => void;
     updateTournamentStatus: (id: string, status: Tournament['status']) => void;
   
   // Transfers
@@ -362,6 +363,11 @@ export const useGlobalStore = create<GlobalStore>()(
 
     removePlayer: id => {
       set(state => ({ players: state.players.filter(p => p.id !== id) }));
+      persist();
+    },
+
+    addTournament: tournament => {
+      set(state => ({ tournaments: [...state.tournaments, tournament] }));
       persist();
     },
 


### PR DESCRIPTION
## Summary
- implement `addTournament` in `globalStore`
- create `NewTournamentModal` for creating tournaments
- connect the modal in `TournamentsAdminPanel`

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a18b0f4c8333b795921557ced08a