### PR TITLE
Add match actions to admin store

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -10,8 +10,7 @@ import {
   Transfer,
   Standing,
   ActivityLog,
-  Comment,
-  Match
+  Comment
 } from '../types';
 import {
   loadAdminData,
@@ -25,7 +24,6 @@ interface GlobalStore {
   players: Player[];
   matches: Match[];
   tournaments: Tournament[];
-  matches: Match[];
   newsItems: NewsItem[];
   transfers: Transfer[];
   standings: Standing[];
@@ -48,10 +46,15 @@ interface GlobalStore {
   // Players
   addPlayer: (player: Player) => void;
   updatePlayer: (player: Player) => void;
-    removePlayer: (id: string) => void;
+  removePlayer: (id: string) => void;
 
-    // Tournaments
-    updateTournamentStatus: (id: string, status: Tournament['status']) => void;
+  // Matches
+  addMatch: (match: Match) => void;
+  updateMatch: (match: Match) => void;
+  removeMatch: (id: string) => void;
+
+  // Tournaments
+  updateTournamentStatus: (id: string, status: Tournament['status']) => void;
   
   // Transfers
   approveTransfer: (id: string) => void;
@@ -126,8 +129,6 @@ const defaultData: AdminData = {
       price: 20000000
     }
   ],
-  matches: [],
-  tournaments: [],
   matches: [
     {
       id: 'match1',
@@ -166,6 +167,7 @@ const defaultData: AdminData = {
       status: 'scheduled'
     }
   ],
+  tournaments: [],
   newsItems: [
     {
       id: '1',
@@ -221,19 +223,18 @@ export const useGlobalStore = create<GlobalStore>()(
   const initial = loadAdminData(defaultData);
 
   const persist = () =>
-    saveAdminData({
-      users: get().users,
-      clubs: get().clubs,
-      players: get().players,
-      matches: get().matches,
-      tournaments: get().tournaments,
-      matches: get().matches,
-      newsItems: get().newsItems,
-      transfers: get().transfers,
-      standings: get().standings,
-      activities: get().activities,
-      comments: get().comments
-    });
+      saveAdminData({
+        users: get().users,
+        clubs: get().clubs,
+        players: get().players,
+        matches: get().matches,
+        tournaments: get().tournaments,
+        newsItems: get().newsItems,
+        transfers: get().transfers,
+        standings: get().standings,
+        activities: get().activities,
+        comments: get().comments
+      });
 
   return {
     ...initial,
@@ -362,6 +363,21 @@ export const useGlobalStore = create<GlobalStore>()(
 
     removePlayer: id => {
       set(state => ({ players: state.players.filter(p => p.id !== id) }));
+      persist();
+    },
+
+    addMatch: match => {
+      set(state => ({ matches: [...state.matches, match] }));
+      persist();
+    },
+
+    updateMatch: match => {
+      set(state => ({ matches: state.matches.map(m => (m.id === match.id ? match : m)) }));
+      persist();
+    },
+
+    removeMatch: id => {
+      set(state => ({ matches: state.matches.filter(m => m.id !== id) }));
       persist();
     },
 

--- a/src/adminPanel/types.ts
+++ b/src/adminPanel/types.ts
@@ -53,17 +53,6 @@ export interface Transfer {
   createdAt: string;
 }
 
-export interface Match {
-  id: string;
-  home: string;
-  away: string;
-  date: string;
-  time: string;
-  round: number;
-  status: 'scheduled' | 'live' | 'finished';
-  homeScore?: number;
-  awayScore?: number;
-}
 
 export interface Standing {
   id: string;

--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -11,7 +11,6 @@ export interface AdminData {
   players: import('../types').Player[];
   matches: import('../types').Match[];
   tournaments: import('../types').Tournament[];
-  matches: import('../types').Match[];
   newsItems: import('../types').NewsItem[];
   transfers: import('../types').Transfer[];
   standings: import('../types').Standing[];
@@ -27,13 +26,12 @@ const OLD_KEYS = {
   clubs: `${PREFIX}clubs_admin`,
   players: `${PREFIX}players_admin`,
   tournaments: `${PREFIX}tournaments_admin`,
-  matches: `${PREFIX}matches_admin`,
+  matches: `${PREFIX}fixtures_admin`,
   newsItems: `${PREFIX}news_admin`,
   transfers: `${PREFIX}transfers_admin`,
   standings: `${PREFIX}standings_admin`,
   activities: `${PREFIX}activities_admin`,
-  comments: `${PREFIX}comments_admin`,
-  matches: `${PREFIX}fixtures_admin`
+  comments: `${PREFIX}comments_admin`
 } as const;
 
 // Updated keys aligned with the main application
@@ -43,7 +41,6 @@ const keys = {
   players: VZ_PLAYERS_KEY,
   matches: VZ_FIXTURES_KEY,
   tournaments: OLD_KEYS.tournaments,
-  matches: OLD_KEYS.matches,
   newsItems: OLD_KEYS.newsItems,
   transfers: OLD_KEYS.transfers,
   standings: OLD_KEYS.standings,

--- a/tests/e2e/match_management.cy.ts
+++ b/tests/e2e/match_management.cy.ts
@@ -1,0 +1,22 @@
+/// <reference types="cypress" />
+
+describe('Admin match management', () => {
+  it('creates and edits a match', () => {
+    cy.visit('/admin/calendario');
+
+    cy.contains('button', 'Programar Jornada').click();
+    cy.get('select').first().select('Barcelona FC');
+    cy.get('select').eq(1).select('Real Madrid');
+    cy.get('input[type="date"]').type('2023-12-20');
+    cy.get('input[type="time"]').type('20:00');
+    cy.get('input[type="number"]').clear().type('1');
+    cy.contains('button', 'Crear').click();
+
+    cy.contains('div', 'Barcelona FC').parent().contains('Real Madrid');
+
+    cy.contains('button', 'Editar').first().click();
+    cy.get('select').first().select('PSG');
+    cy.contains('button', 'Guardar').click();
+    cy.contains('div', 'PSG');
+  });
+});


### PR DESCRIPTION
## Summary
- clean up match interface and default data
- allow adding, updating and removing matches in globalStore
- fix admin storage definitions
- add Cypress test covering match management

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a18a6ad08333b036740f570804ae