### PR TITLE
Rename Match interface

### DIFF
--- a/src/adminPanel/components/admin/CalendarAdminPanel.tsx
+++ b/src/adminPanel/components/admin/CalendarAdminPanel.tsx
@@ -1,6 +1,6 @@
 import  { useState } from 'react';
 import { useGlobalStore } from '../../store/globalStore';
-import { Match } from '../../types';
+import { Fixture } from '../../types';
 import NewMatchModal from './NewMatchModal';
 import EditMatchModal from './EditMatchModal';
 import ResultMatchModal from './ResultMatchModal';
@@ -12,7 +12,7 @@ const CalendarAdminPanel = () => {
 
   const { matches, addMatch, updateMatch } = useGlobalStore();
   const [showNew, setShowNew] = useState(false);
-  const [editing, setEditing] = useState<null | { match: Match; reschedule?: boolean }>(null);
+  const [editing, setEditing] = useState<null | { match: Fixture; reschedule?: boolean }>(null);
   const [showResults, setShowResults] = useState(false);
 
   const roundMatches = matches.filter(m => m.round === selectedRound);
@@ -146,7 +146,7 @@ const CalendarAdminPanel = () => {
               status: 'scheduled',
               ...data,
               date: `${data.date}T${data.time}`
-            } as Match);
+            } as Fixture);
             setShowNew(false);
           }}
         />

--- a/src/adminPanel/components/admin/EditMatchModal.tsx
+++ b/src/adminPanel/components/admin/EditMatchModal.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
-import { Match } from '../../types';
+import { Fixture } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 
 interface Props {
-  match: Match;
+  match: Fixture;
   onClose: () => void;
-  onSave: (match: Match) => void;
+  onSave: (match: Fixture) => void;
   allowDateEdit?: boolean;
 }
 

--- a/src/adminPanel/components/admin/NewMatchModal.tsx
+++ b/src/adminPanel/components/admin/NewMatchModal.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
-import { Match } from '../../types';
+import { Fixture } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 
 interface Props {
   onClose: () => void;
-  onSave: (data: Partial<Match>) => void;
+  onSave: (data: Partial<Fixture>) => void;
 }
 
 const NewMatchModal = ({ onClose, onSave }: Props) => {

--- a/src/adminPanel/components/admin/ResultMatchModal.tsx
+++ b/src/adminPanel/components/admin/ResultMatchModal.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
-import { Match } from '../../types';
+import { Fixture } from '../../types';
 
 interface Props {
-  matches: Match[];
+  matches: Fixture[];
   onClose: () => void;
-  onSave: (match: Match) => void;
+  onSave: (match: Fixture) => void;
 }
 
 const ResultMatchModal = ({ matches, onClose, onSave }: Props) => {

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -5,13 +5,13 @@ import {
   Club,
   Player,
   Tournament,
-  Match,
+  Fixture,
   NewsItem,
   Transfer,
   Standing,
   ActivityLog,
   Comment,
-  Match
+  Fixture
 } from '../types';
 import {
   loadAdminData,
@@ -23,9 +23,9 @@ interface GlobalStore {
   users: User[];
   clubs: Club[];
   players: Player[];
-  matches: Match[];
+  matches: Fixture[];
   tournaments: Tournament[];
-  matches: Match[];
+  matches: Fixture[];
   newsItems: NewsItem[];
   transfers: Transfer[];
   standings: Standing[];

--- a/src/adminPanel/types.ts
+++ b/src/adminPanel/types.ts
@@ -90,7 +90,7 @@ export interface Comment {
   createdAt: string;
 }
 
-export interface Match {
+export interface Fixture {
   id: string;
   tournamentId: string;
   round: number;

--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -9,9 +9,9 @@ export interface AdminData {
   users: import('../types').User[];
   clubs: import('../types').Club[];
   players: import('../types').Player[];
-  matches: import('../types').Match[];
+  matches: import('../types').Fixture[];
   tournaments: import('../types').Tournament[];
-  matches: import('../types').Match[];
+  matches: import('../types').Fixture[];
   newsItems: import('../types').NewsItem[];
   transfers: import('../types').Transfer[];
   standings: import('../types').Standing[];


### PR DESCRIPTION
## Summary
- rename the tournament `Match` interface to `Fixture`
- update component imports and types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a1896ae083339b0e64c335447527