### PR TITLE
Fix loading loop for DT users without club

### DIFF
--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -57,10 +57,18 @@ export default function DtDashboard() {
     toast.dismiss();
   };
 
-  if (!user || !club) {
+  if (!user) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!club) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-8 text-center">
+        <p>No tienes un club asignado. Contacta a un administrador.</p>
       </div>
     );
   }

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -23,7 +23,17 @@ const LigaMaster = () => {
   const { clubs, tournaments, players, standings, marketStatus } = useDataStore();
 
   if (user?.role === 'dt') {
-    return <DtDashboard />;
+    if (user.clubId) {
+      const assignedClub = clubs.find(c => c.id === user.clubId);
+      if (assignedClub) {
+        return <DtDashboard />;
+      }
+    }
+    return (
+      <div className="p-8 text-center">
+        <p>No tienes un club asignado. Contacta a un administrador.</p>
+      </div>
+    );
   }
   
   // Get active tournament (Liga Master)


### PR DESCRIPTION
## Summary
- show message when a DT user lacks a club instead of spinner
- same handling on Liga Master entry point

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a70fa4a08333814f8e58a6e2f494