### PR TITLE
Fix duplicate matches property

### DIFF
--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -11,7 +11,6 @@ export interface AdminData {
   players: import('../types').Player[];
   matches: import('../types').Fixture[];
   tournaments: import('../types').Tournament[];
-  matches: import('../types').Fixture[];
   newsItems: import('../types').NewsItem[];
   transfers: import('../types').Transfer[];
   standings: import('../types').Standing[];


### PR DESCRIPTION
## Summary
- clean up AdminData type by removing duplicate `matches` declaration

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a98f3cf0833386b3480a71a03c1b