### PR TITLE
Expand admin models

### DIFF
--- a/src/adminPanel/components/admin/EditClubModal.tsx
+++ b/src/adminPanel/components/admin/EditClubModal.tsx
@@ -1,6 +1,7 @@
 import  { useState, useRef, useEffect } from 'react';
 import { Club } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
+import { slugify } from '../../utils/helpers';
 
 interface Props {
   club: Club;
@@ -11,8 +12,16 @@ interface Props {
 const EditClubModal = ({ club, onClose, onSave }: Props) => {
   const [formData, setFormData] = useState({
     name: club.name,
+    slug: club.slug,
+    logo: club.logo,
+    foundedYear: club.foundedYear,
+    stadium: club.stadium,
     managerId: club.managerId || '',
-    budget: club.budget
+    budget: club.budget,
+    playStyle: club.playStyle,
+    primaryColor: club.primaryColor,
+    secondaryColor: club.secondaryColor,
+    description: club.description
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const users = useGlobalStore(state => state.users);
@@ -27,9 +36,14 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
+  useEffect(() => {
+    setFormData(prev => ({ ...prev, slug: slugify(prev.name) }));
+  }, [formData.name]);
+
   const validate = () => {
     const newErrors: Record<string, string> = {};
     if (!formData.name.trim()) newErrors.name = 'Nombre requerido';
+    if (!formData.stadium.trim()) newErrors.stadium = 'Estadio requerido';
     if (!formData.managerId) newErrors.managerId = 'Entrenador requerido';
     if (formData.budget <= 0) newErrors.budget = 'Presupuesto debe ser mayor a 0';
     setErrors(newErrors);
@@ -39,7 +53,9 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave({ ...club, ...formData });
+      const logo = formData.logo ||
+        `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=111827&color=fff&size=128&bold=true`;
+      onSave({ ...club, ...formData, logo, slug: slugify(formData.name) });
     }
   };
 
@@ -60,6 +76,15 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
               onChange={(e) => setFormData({...formData, name: e.target.value})}
             />
             {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          </div>
+          <div>
+            <input
+              className="input w-full"
+              placeholder="Estadio"
+              value={formData.stadium}
+              onChange={e => setFormData({ ...formData, stadium: e.target.value })}
+            />
+            {errors.stadium && <p className="text-red-500 text-sm mt-1">{errors.stadium}</p>}
           </div>
           <div>
             <select
@@ -85,6 +110,45 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
               onChange={(e) => setFormData({...formData, budget: Number(e.target.value)})}
             />
             {errors.budget && <p className="text-red-500 text-sm mt-1">{errors.budget}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className="input w-full"
+              placeholder="Año de fundación"
+              value={formData.foundedYear}
+              onChange={e => setFormData({ ...formData, foundedYear: Number(e.target.value) })}
+            />
+          </div>
+          <div>
+            <input
+              className="input w-full"
+              placeholder="Estilo de juego"
+              value={formData.playStyle}
+              onChange={e => setFormData({ ...formData, playStyle: e.target.value })}
+            />
+          </div>
+          <div>
+            <textarea
+              className="input w-full"
+              placeholder="Descripción"
+              value={formData.description}
+              onChange={e => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+          <div className="flex space-x-2">
+            <input
+              type="color"
+              className="input"
+              value={formData.primaryColor}
+              onChange={e => setFormData({ ...formData, primaryColor: e.target.value })}
+            />
+            <input
+              type="color"
+              className="input"
+              value={formData.secondaryColor}
+              onChange={e => setFormData({ ...formData, secondaryColor: e.target.value })}
+            />
           </div>
           <div className="flex space-x-3 justify-end mt-6">
             <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>

--- a/src/adminPanel/components/admin/EditPlayerModal.tsx
+++ b/src/adminPanel/components/admin/EditPlayerModal.tsx
@@ -12,10 +12,16 @@ const EditPlayerModal = ({ player, onClose, onSave }: Props) => {
   const { clubs } = useGlobalStore();
   const [formData, setFormData] = useState({
     name: player.name,
+    age: player.age,
+    nationality: player.nationality,
+    dorsal: player.dorsal,
     position: player.position,
     clubId: player.clubId,
     overall: player.overall,
-    price: player.price
+    potential: player.potential,
+    price: player.value,
+    contractExpires: player.contract.expires,
+    salary: player.contract.salary
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const modalRef = useRef<HTMLDivElement>(null);
@@ -32,6 +38,8 @@ const EditPlayerModal = ({ player, onClose, onSave }: Props) => {
   const validate = () => {
     const newErrors: Record<string, string> = {};
     if (!formData.name.trim()) newErrors.name = 'Nombre requerido';
+    if (!formData.nationality.trim()) newErrors.nationality = 'Nacionalidad requerida';
+    if (formData.age < 15) newErrors.age = 'Edad inválida';
     if (!formData.clubId) newErrors.clubId = 'Club requerido';
     if (formData.overall < 40 || formData.overall > 99) newErrors.overall = 'Overall debe estar entre 40-99';
     if (formData.price <= 0) newErrors.price = 'Precio debe ser mayor a 0';
@@ -42,7 +50,14 @@ const EditPlayerModal = ({ player, onClose, onSave }: Props) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave({ ...player, ...formData });
+      const image = player.image || `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=1e293b&color=fff&size=128`;
+      onSave({
+        ...player,
+        ...formData,
+        image,
+        contract: { expires: formData.contractExpires, salary: formData.salary },
+        value: formData.price
+      });
     }
   };
 
@@ -63,6 +78,34 @@ const EditPlayerModal = ({ player, onClose, onSave }: Props) => {
               onChange={(e) => setFormData({...formData, name: e.target.value})}
             />
             {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className={`input w-full ${errors.age ? 'border-red-500' : ''}`}
+              placeholder="Edad"
+              value={formData.age}
+              onChange={e => setFormData({ ...formData, age: Number(e.target.value) })}
+            />
+            {errors.age && <p className="text-red-500 text-sm mt-1">{errors.age}</p>}
+          </div>
+          <div>
+            <input
+              className={`input w-full ${errors.nationality ? 'border-red-500' : ''}`}
+              placeholder="Nacionalidad"
+              value={formData.nationality}
+              onChange={e => setFormData({ ...formData, nationality: e.target.value })}
+            />
+            {errors.nationality && <p className="text-red-500 text-sm mt-1">{errors.nationality}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className="input w-full"
+              placeholder="Dorsal"
+              value={formData.dorsal}
+              onChange={e => setFormData({ ...formData, dorsal: Number(e.target.value) })}
+            />
           </div>
           <select
             className="input w-full"
@@ -102,12 +145,38 @@ const EditPlayerModal = ({ player, onClose, onSave }: Props) => {
           <div>
             <input
               type="number"
+              className="input w-full"
+              placeholder="Potencial"
+              value={formData.potential}
+              onChange={e => setFormData({ ...formData, potential: Number(e.target.value) })}
+            />
+          </div>
+          <div>
+            <input
+              type="number"
               className={`input w-full ${errors.price ? 'border-red-500' : ''}`}
               placeholder="Precio"
               value={formData.price}
               onChange={(e) => setFormData({...formData, price: Number(e.target.value)})}
             />
             {errors.price && <p className="text-red-500 text-sm mt-1">{errors.price}</p>}
+          </div>
+          <div>
+            <input
+              className="input w-full"
+              placeholder="Contrato hasta"
+              value={formData.contractExpires}
+              onChange={e => setFormData({ ...formData, contractExpires: e.target.value })}
+            />
+          </div>
+          <div>
+            <input
+              type="number"
+              className="input w-full"
+              placeholder="Salario"
+              value={formData.salary}
+              onChange={e => setFormData({ ...formData, salary: Number(e.target.value) })}
+            />
           </div>
           <div className="flex space-x-3 justify-end mt-6">
             <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>

--- a/src/adminPanel/components/admin/NewClubModal.tsx
+++ b/src/adminPanel/components/admin/NewClubModal.tsx
@@ -1,6 +1,7 @@
 import  { useState, useRef, useEffect } from 'react';
 import { Club } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
+import { slugify } from '../../utils/helpers';
 
 interface Props {
   onClose: () => void;
@@ -10,12 +11,24 @@ interface Props {
 const NewClubModal = ({ onClose, onSave }: Props) => {
   const [formData, setFormData] = useState({
     name: '',
+    slug: '',
+    logo: '',
+    foundedYear: new Date().getFullYear(),
+    stadium: '',
     managerId: '',
-    budget: 1000000
+    budget: 1000000,
+    playStyle: '',
+    primaryColor: '#ffffff',
+    secondaryColor: '#000000',
+    description: ''
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const users = useGlobalStore(state => state.users);
   const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setFormData(prev => ({ ...prev, slug: slugify(prev.name) }));
+  }, [formData.name]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -29,6 +42,7 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
   const validate = () => {
     const newErrors: Record<string, string> = {};
     if (!formData.name.trim()) newErrors.name = 'Nombre requerido';
+    if (!formData.stadium.trim()) newErrors.stadium = 'Estadio requerido';
     if (!formData.managerId) newErrors.managerId = 'Entrenador requerido';
     if (formData.budget <= 0) newErrors.budget = 'Presupuesto debe ser mayor a 0';
     setErrors(newErrors);
@@ -38,7 +52,9 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave(formData);
+      const logo = formData.logo ||
+        `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=111827&color=fff&size=128&bold=true`;
+      onSave({ ...formData, logo, slug: slugify(formData.name) });
     }
   };
 
@@ -59,6 +75,15 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
               onChange={(e) => setFormData({...formData, name: e.target.value})}
             />
             {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          </div>
+          <div>
+            <input
+              className="input w-full"
+              placeholder="Estadio"
+              value={formData.stadium}
+              onChange={(e) => setFormData({...formData, stadium: e.target.value})}
+            />
+            {errors.stadium && <p className="text-red-500 text-sm mt-1">{errors.stadium}</p>}
           </div>
           <div>
             <select
@@ -84,6 +109,45 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
               onChange={(e) => setFormData({...formData, budget: Number(e.target.value)})}
             />
             {errors.budget && <p className="text-red-500 text-sm mt-1">{errors.budget}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className="input w-full"
+              placeholder="Año de fundación"
+              value={formData.foundedYear}
+              onChange={e => setFormData({ ...formData, foundedYear: Number(e.target.value) })}
+            />
+          </div>
+          <div>
+            <input
+              className="input w-full"
+              placeholder="Estilo de juego"
+              value={formData.playStyle}
+              onChange={e => setFormData({ ...formData, playStyle: e.target.value })}
+            />
+          </div>
+          <div>
+            <textarea
+              className="input w-full"
+              placeholder="Descripción"
+              value={formData.description}
+              onChange={e => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+          <div className="flex space-x-2">
+            <input
+              type="color"
+              className="input"
+              value={formData.primaryColor}
+              onChange={e => setFormData({ ...formData, primaryColor: e.target.value })}
+            />
+            <input
+              type="color"
+              className="input"
+              value={formData.secondaryColor}
+              onChange={e => setFormData({ ...formData, secondaryColor: e.target.value })}
+            />
           </div>
           <div className="flex space-x-3 justify-end mt-6">
             <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>

--- a/src/adminPanel/components/admin/NewPlayerModal.tsx
+++ b/src/adminPanel/components/admin/NewPlayerModal.tsx
@@ -11,10 +11,16 @@ const NewPlayerModal = ({ onClose, onSave }: Props) => {
   const { clubs } = useGlobalStore();
   const [formData, setFormData] = useState({
     name: '',
+    age: 18,
+    nationality: '',
+    dorsal: 1,
     position: 'DEL',
     clubId: '',
     overall: 75,
-    price: 100000
+    potential: 80,
+    price: 100000,
+    contractExpires: '',
+    salary: 0
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const modalRef = useRef<HTMLDivElement>(null);
@@ -31,6 +37,8 @@ const NewPlayerModal = ({ onClose, onSave }: Props) => {
   const validate = () => {
     const newErrors: Record<string, string> = {};
     if (!formData.name.trim()) newErrors.name = 'Nombre requerido';
+    if (!formData.nationality.trim()) newErrors.nationality = 'Nacionalidad requerida';
+    if (formData.age < 15) newErrors.age = 'Edad inválida';
     if (!formData.clubId) newErrors.clubId = 'Club requerido';
     if (formData.overall < 40 || formData.overall > 99) newErrors.overall = 'Overall debe estar entre 40-99';
     if (formData.price <= 0) newErrors.price = 'Precio debe ser mayor a 0';
@@ -41,7 +49,21 @@ const NewPlayerModal = ({ onClose, onSave }: Props) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave(formData);
+      const image = `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=1e293b&color=fff&size=128`;
+      onSave({
+        ...formData,
+        image,
+        contract: { expires: formData.contractExpires, salary: formData.salary },
+        attributes: { pace: 50, shooting: 50, passing: 50, dribbling: 50, defending: 50, physical: 50 },
+        transferListed: false,
+        matches: 0,
+        transferValue: formData.price,
+        value: formData.price,
+        form: 1,
+        goals: 0,
+        assists: 0,
+        appearances: 0
+      });
     }
   };
 
@@ -62,6 +84,34 @@ const NewPlayerModal = ({ onClose, onSave }: Props) => {
               onChange={(e) => setFormData({...formData, name: e.target.value})}
             />
             {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className={`input w-full ${errors.age ? 'border-red-500' : ''}`}
+              placeholder="Edad"
+              value={formData.age}
+              onChange={e => setFormData({ ...formData, age: Number(e.target.value) })}
+            />
+            {errors.age && <p className="text-red-500 text-sm mt-1">{errors.age}</p>}
+          </div>
+          <div>
+            <input
+              className={`input w-full ${errors.nationality ? 'border-red-500' : ''}`}
+              placeholder="Nacionalidad"
+              value={formData.nationality}
+              onChange={e => setFormData({ ...formData, nationality: e.target.value })}
+            />
+            {errors.nationality && <p className="text-red-500 text-sm mt-1">{errors.nationality}</p>}
+          </div>
+          <div>
+            <input
+              type="number"
+              className="input w-full"
+              placeholder="Dorsal"
+              value={formData.dorsal}
+              onChange={e => setFormData({ ...formData, dorsal: Number(e.target.value) })}
+            />
           </div>
           <select
             className="input w-full"
@@ -101,12 +151,38 @@ const NewPlayerModal = ({ onClose, onSave }: Props) => {
           <div>
             <input
               type="number"
+              className="input w-full"
+              placeholder="Potencial"
+              value={formData.potential}
+              onChange={e => setFormData({ ...formData, potential: Number(e.target.value) })}
+            />
+          </div>
+          <div>
+            <input
+              type="number"
               className={`input w-full ${errors.price ? 'border-red-500' : ''}`}
               placeholder="Precio"
               value={formData.price}
               onChange={(e) => setFormData({...formData, price: Number(e.target.value)})}
             />
             {errors.price && <p className="text-red-500 text-sm mt-1">{errors.price}</p>}
+          </div>
+          <div>
+            <input
+              className="input w-full"
+              placeholder="Contrato hasta"
+              value={formData.contractExpires}
+              onChange={e => setFormData({ ...formData, contractExpires: e.target.value })}
+            />
+          </div>
+          <div>
+            <input
+              type="number"
+              className="input w-full"
+              placeholder="Salario"
+              value={formData.salary}
+              onChange={e => setFormData({ ...formData, salary: Number(e.target.value) })}
+            />
           </div>
           <div className="flex space-x-3 justify-end mt-6">
             <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>

--- a/src/adminPanel/pages/admin/Clubes.tsx
+++ b/src/adminPanel/pages/admin/Clubes.tsx
@@ -32,9 +32,21 @@ const Clubes = () => {
     const newClub: Club = {
       id: Date.now().toString(),
       name: clubData.name || '',
+      slug: clubData.slug || '',
+      logo: clubData.logo || '',
+      foundedYear: clubData.foundedYear || new Date().getFullYear(),
+      stadium: clubData.stadium || '',
+      budget: clubData.budget || 1000000,
       manager: managerUser ? managerUser.username : '',
       managerId: clubData.managerId,
-      budget: clubData.budget || 1000000,
+      playStyle: clubData.playStyle || '',
+      primaryColor: clubData.primaryColor || '#ffffff',
+      secondaryColor: clubData.secondaryColor || '#000000',
+      description: clubData.description || '',
+      titles: [],
+      reputation: 50,
+      fanBase: 0,
+      morale: 50,
       createdAt: new Date().toISOString()
     };
     

--- a/src/adminPanel/pages/admin/Jugadores.tsx
+++ b/src/adminPanel/pages/admin/Jugadores.tsx
@@ -35,10 +35,37 @@ const Jugadores = () => {
     const newPlayer: Player = {
       id: Date.now().toString(),
       name: playerData.name || '',
+      age: playerData.age || 18,
+      nationality: playerData.nationality || '',
+      dorsal: playerData.dorsal || 1,
       position: playerData.position || 'DEL',
       clubId: playerData.clubId || '',
       overall: playerData.overall || 75,
-      price: playerData.price || 100000
+      potential: playerData.potential || 80,
+      transferListed: false,
+      matches: 0,
+      transferValue: playerData.price || 0,
+      value: playerData.price || 0,
+      image:
+        playerData.image ||
+        `https://ui-avatars.com/api/?name=${encodeURIComponent(playerData.name || '')}&background=1e293b&color=fff&size=128`,
+      attributes: {
+        pace: 50,
+        shooting: 50,
+        passing: 50,
+        dribbling: 50,
+        defending: 50,
+        physical: 50
+      },
+      contract: {
+        expires: playerData.contract?.expires || '',
+        salary: playerData.contract?.salary || 0
+      },
+      form: 1,
+      goals: 0,
+      assists: 0,
+      appearances: 0,
+      price: playerData.price || 0
     };
     
     addPlayer(newPlayer);

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -18,6 +18,8 @@ import {
   saveAdminData,
   AdminData
 } from '../utils/adminStorage';
+import { saveClubs } from '../../utils/clubService';
+import { savePlayers } from '../../utils/playerService';
 
 interface GlobalStore {
   users: User[];
@@ -300,9 +302,11 @@ export const useGlobalStore = create<GlobalStore>()(
         const updatedUsers = state.users.map(u =>
           u.id === club.managerId ? { ...u, clubId: club.id } : u
         );
+        const updatedClubs = [...state.clubs, club];
+        saveClubs(updatedClubs);
         return {
           users: updatedUsers,
-          clubs: [...state.clubs, club],
+          clubs: updatedClubs,
           activities: [
             ...state.activities,
             {
@@ -332,9 +336,11 @@ export const useGlobalStore = create<GlobalStore>()(
             u.id === club.managerId ? { ...u, clubId: club.id } : u
           );
         }
+        const updatedClubs = state.clubs.map(c => (c.id === club.id ? club : c));
+        saveClubs(updatedClubs);
         return {
           users: updatedUsers,
-          clubs: state.clubs.map(c => (c.id === club.id ? club : c))
+          clubs: updatedClubs
         };
       });
       persist();
@@ -348,23 +354,37 @@ export const useGlobalStore = create<GlobalStore>()(
               u.id === club.managerId ? { ...u, clubId: undefined } : u
             )
           : state.users;
-        return { users: updatedUsers, clubs: state.clubs.filter(c => c.id !== id) };
+        const updatedClubs = state.clubs.filter(c => c.id !== id);
+        saveClubs(updatedClubs);
+        return { users: updatedUsers, clubs: updatedClubs };
       });
       persist();
     },
 
     addPlayer: player => {
-      set(state => ({ players: [...state.players, player] }));
+      set(state => {
+        const updated = [...state.players, player];
+        savePlayers(updated);
+        return { players: updated };
+      });
       persist();
     },
 
     updatePlayer: player => {
-      set(state => ({ players: state.players.map(p => (p.id === player.id ? player : p)) }));
+      set(state => {
+        const updated = state.players.map(p => (p.id === player.id ? player : p));
+        savePlayers(updated);
+        return { players: updated };
+      });
       persist();
     },
 
     removePlayer: id => {
-      set(state => ({ players: state.players.filter(p => p.id !== id) }));
+      set(state => {
+        const updated = state.players.filter(p => p.id !== id);
+        savePlayers(updated);
+        return { players: updated };
+      });
       persist();
     },
 

--- a/src/adminPanel/types.ts
+++ b/src/adminPanel/types.ts
@@ -11,19 +11,67 @@ export  interface User {
 export interface Club {
   id: string;
   name: string;
+  slug: string;
+  logo: string;
+  foundedYear: number;
+  stadium: string;
+  budget: number;
   manager: string;
   managerId?: string;
-  budget: number;
-  createdAt: string;
+  playStyle: string;
+  primaryColor: string;
+  secondaryColor: string;
+  description: string;
+  titles: Title[];
+  reputation: number;
+  fanBase: number;
+  morale: number;
+  createdAt?: string;
+}
+
+export interface Title {
+  id: string;
+  name: string;
+  year: number;
+  type: 'league' | 'cup' | 'supercup' | 'other';
 }
 
 export interface Player {
   id: string;
   name: string;
+  age: number;
   position: string;
+  nationality: string;
+  dorsal: number;
   clubId: string;
   overall: number;
+  potential: number;
+  transferListed: boolean;
+  matches: number;
+  transferValue: number;
+  value: number;
+  image: string;
+  attributes: PlayerAttributes;
+  contract: PlayerContract;
+  form: number;
+  goals: number;
+  assists: number;
+  appearances: number;
   price?: number;
+}
+
+export interface PlayerAttributes {
+  pace: number;
+  shooting: number;
+  passing: number;
+  dribbling: number;
+  defending: number;
+  physical: number;
+}
+
+export interface PlayerContract {
+  expires: string;
+  salary: number;
 }
 
 export interface Tournament {

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -7,7 +7,7 @@ import {
   deleteUser as persistDeleteUser
 } from '../utils/authService';
 import {
-  players,
+  players as seedPlayers,
   tournaments,
   transfers,
   offers,
@@ -27,6 +27,7 @@ import {
   dtRankings
 } from '../data/mockData';
 import { getClubs, saveClubs } from '../utils/clubService';
+import { getPlayers, savePlayers } from '../utils/playerService';
 import {
   Club,
   Player,
@@ -50,6 +51,7 @@ import {
 } from '../types';
 
 const initialClubs = getClubs();
+const initialPlayers = getPlayers();
 const initialUser = useAuthStore.getState().user;
 const baseClub = initialClubs.find(c => c.id === initialUser?.clubId) || initialClubs[0];
 const initialClub: DtClub = {
@@ -59,7 +61,7 @@ const initialClub: DtClub = {
   logo: baseClub.logo,
   formation: '4-3-3',
   budget: baseClub.budget,
-  players: players.filter(p => p.clubId === baseClub.id)
+  players: initialPlayers.filter(p => p.clubId === baseClub.id)
 };
 const initialFixtures = tournaments[0].matches
   .filter(m => m.homeTeam === initialClub.name || m.awayTeam === initialClub.name)
@@ -119,7 +121,7 @@ interface DataState {
 
 export const useDataStore = create<DataState>((set) => ({
   clubs: initialClubs,
-  players,
+  players: initialPlayers,
   tournaments,
   transfers,
   offers,
@@ -194,9 +196,12 @@ export const useDataStore = create<DataState>((set) => ({
       return { clubs: updated };
     }),
 
-  addPlayer: (player) => set((state) => ({
-    players: [...state.players, player]
-  })),
+  addPlayer: (player) =>
+    set((state) => {
+      const updated = [...state.players, player];
+      savePlayers(updated);
+      return { players: updated };
+    }),
 
   updateUserEntry: (user) =>
     set((state) => {
@@ -248,13 +253,19 @@ export const useDataStore = create<DataState>((set) => ({
       return { clubs: updated };
     }),
 
-  updatePlayerEntry: (player) => set((state) => ({
-    players: state.players.map(p => (p.id === player.id ? player : p))
-  })),
+  updatePlayerEntry: (player) =>
+    set((state) => {
+      const updated = state.players.map(p => (p.id === player.id ? player : p));
+      savePlayers(updated);
+      return { players: updated };
+    }),
 
-  removePlayer: (id) => set((state) => ({
-    players: state.players.filter(p => p.id !== id)
-  })),
+  removePlayer: (id) =>
+    set((state) => {
+      const updated = state.players.filter(p => p.id !== id);
+      savePlayers(updated);
+      return { players: updated };
+    }),
 
   addTournament: (tournament) =>
     set((state) => {

--- a/src/utils/playerService.ts
+++ b/src/utils/playerService.ts
@@ -1,0 +1,19 @@
+import { Player } from '../types';
+import { VZ_PLAYERS_KEY } from './storageKeys';
+import { players as defaultPlayers } from '../data/mockData';
+
+export const getPlayers = (): Player[] => {
+  const json = localStorage.getItem(VZ_PLAYERS_KEY);
+  if (json) {
+    try {
+      return JSON.parse(json) as Player[];
+    } catch {
+      // ignore
+    }
+  }
+  return defaultPlayers as Player[];
+};
+
+export const savePlayers = (data: Player[]): void => {
+  localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(data));
+};


### PR DESCRIPTION
## Summary
- expand admin interfaces for Club and Player
- collect more data when creating or editing clubs and players
- persist players using new playerService
- load players from storage in main data store

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861aad654a483339428d6ad8465c860