### PR TITLE
Fix duplicate matches field

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -11,7 +11,6 @@ import {
   Standing,
   ActivityLog,
   Comment,
-  Fixture
 } from '../types';
 import {
   loadAdminData,
@@ -25,7 +24,6 @@ interface GlobalStore {
   players: Player[];
   matches: Fixture[];
   tournaments: Tournament[];
-  matches: Fixture[];
   newsItems: NewsItem[];
   transfers: Transfer[];
   standings: Standing[];


### PR DESCRIPTION
## Summary
- remove extra Fixture import from the admin panel store
- clean up duplicate `matches` property in the store interface

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861aad6016c833382a1d962931771fe