### PR TITLE
Fix match import in global store

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -6,6 +6,7 @@ import {
   Player,
   Tournament,
   Fixture,
+  Match,
   NewsItem,
   Transfer,
   Standing,


### PR DESCRIPTION
## Summary
- add missing `Match` import in `globalStore`

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861d43121b88333b72c18aec0fc6ece