### PR TITLE
Use clubId for dashboard lookups

### DIFF
--- a/src/components/dt-dashboard/FinanzasTab.tsx
+++ b/src/components/dt-dashboard/FinanzasTab.tsx
@@ -8,7 +8,7 @@ const formatCurrency= (amount: number) => `€${amount.toLocaleString()}`;
 export default function FinanzasTab() {
   const { club, players } = useDataStore();
 
-  const clubPlayers = players.filter(p => p.club === club?.name);
+  const clubPlayers = players.filter(p => p.clubId === club?.id);
   const totalSalaries = clubPlayers.reduce((sum, p) => sum + (p.contract?.salary || 0), 0);
   const avgPlayerValue = clubPlayers.reduce((sum, p) => sum + p.marketValue, 0) / clubPlayers.length || 0;
 

--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -17,7 +17,7 @@ interface MarketOffer {
 
 export default function MercadoTab() {
   const { user } = useAuthStore();
-  const { players, club } = useDataStore();
+  const { players, club, clubs } = useDataStore();
   const [search, setSearch] = useState('');
   const [positionFilter, setPositionFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'value' | 'overall' | 'age'>('value');
@@ -44,7 +44,7 @@ export default function MercadoTab() {
 
   const availablePlayers = useMemo(() => {
     return players
-      .filter(p => p.club !== club?.name)
+      .filter(p => p.clubId !== club?.id)
       .filter(p => positionFilter === 'all' || p.position === positionFilter)
       .filter(p => p.name.toLowerCase().includes(search.toLowerCase()))
       .sort((a, b) => {
@@ -55,7 +55,12 @@ export default function MercadoTab() {
           default: return 0;
         }
       });
-  }, [players, club?.name, positionFilter, search, sortBy]);
+  }, [players, club?.id, positionFilter, search, sortBy]);
+
+  const getClubName = (clubId: string) => {
+    const found = clubs.find(c => c.id === clubId);
+    return found ? found.name : 'Desconocido';
+  };
 
   const handleMakeOffer = (player: Player) => {
     toast.success(`Oferta enviada por ${player.name}`);
@@ -180,7 +185,7 @@ export default function MercadoTab() {
                 
                 <div className="p-4">
                   <h3 className="font-bold text-lg mb-1">{player.name}</h3>
-                  <p className="text-sm text-gray-400 mb-3">{player.club} • {player.age} años</p>
+                  <p className="text-sm text-gray-400 mb-3">{getClubName(player.clubId)} • {player.age} años</p>
                   
                   <div className="flex items-center justify-between mb-4">
                     <span className="text-primary font-bold">

--- a/src/components/dt-dashboard/PlantillaTab.tsx
+++ b/src/components/dt-dashboard/PlantillaTab.tsx
@@ -16,9 +16,10 @@ export default function PlantillaTab() {
     return players.filter(player => {
       const matchesSearch = player.name.toLowerCase().includes(search.toLowerCase());
       const matchesPosition = selectedPosition === 'all' || player.position === selectedPosition;
-      return matchesSearch && matchesPosition && player.club === club?.name;
+      const matchesClub = player.clubId === club?.id;
+      return matchesSearch && matchesPosition && matchesClub;
     });
-  }, [players, search, selectedPosition, club?.name]);
+  }, [players, search, selectedPosition, club?.id]);
 
   const handlePlayerClick = (player: Player) => {
     setSelectedPlayer(player);

--- a/src/components/dt-dashboard/TacticasTab.tsx
+++ b/src/components/dt-dashboard/TacticasTab.tsx
@@ -33,7 +33,7 @@ export default function TacticasTab() {
   const [draggedPlayer, setDraggedPlayer] = useState<number | null>(null);
   const pitchRef = useRef<HTMLDivElement>(null);
 
-  const clubPlayers = players.filter(p => p.club === club?.name);
+  const clubPlayers = players.filter(p => p.clubId === club?.id);
   const startingEleven = clubPlayers.slice(0, 11);
 
   useEffect(() => {

--- a/src/pages/HallOfFame.tsx
+++ b/src/pages/HallOfFame.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import { useDataStore } from '../store/dataStore';
 import { Link } from 'react-router-dom';
 import { Award, ChevronLeft, Star, Shield, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 
 const HallOfFame = () => {
   const [activeSection, setActiveSection] = useState('clubs');
+  const { clubs } = useDataStore();
   
   // Mock legendary clubs
   const legendaryClubs = [
@@ -54,7 +56,7 @@ const HallOfFame = () => {
       name: 'Carlos García',
       image: 'https://ui-avatars.com/api/?name=CG&background=1e293b&color=fff&size=128',
       position: 'ST',
-      club: 'Rayo Digital FC',
+      clubId: 'club1',
       nationality: 'España',
       activeYears: '2023-Presente',
       achievements: 'Máximo goleador histórico con 42 goles. Bicampeón de la Liga Master.',
@@ -65,7 +67,7 @@ const HallOfFame = () => {
       name: 'Diego López',
       image: 'https://ui-avatars.com/api/?name=DL&background=1e293b&color=fff&size=128',
       position: 'CAM',
-      club: 'Neón FC',
+      clubId: 'club4',
       nationality: 'Argentina',
       activeYears: '2023-Presente',
       achievements: 'MVP de la temporada 2024. Campeón de Liga Master.',
@@ -76,7 +78,7 @@ const HallOfFame = () => {
       name: 'Victor Pérez',
       image: 'https://ui-avatars.com/api/?name=VP&background=1e293b&color=fff&size=128',
       position: 'CB',
-      club: 'Glitchers 404',
+      clubId: 'club6',
       nationality: 'España',
       activeYears: '2023-Presente',
       achievements: 'Defensa del año en 2023 y 2024. Campeón de Copa.',
@@ -87,7 +89,7 @@ const HallOfFame = () => {
       name: 'Lucas Sánchez',
       image: 'https://ui-avatars.com/api/?name=LS&background=1e293b&color=fff&size=128',
       position: 'GK',
-      club: 'Pixel Galaxy',
+      clubId: 'club10',
       nationality: 'México',
       activeYears: '2023-Presente',
       achievements: 'Portero con más porterías a cero (24). Supercampeón 2023.',
@@ -98,13 +100,18 @@ const HallOfFame = () => {
       name: 'Marcos Rodríguez',
       image: 'https://ui-avatars.com/api/?name=MR&background=1e293b&color=fff&size=128',
       position: 'CDM',
-      club: 'Atlético Pixelado',
+      clubId: 'club2',
       nationality: 'Colombia',
       activeYears: '2023-Presente',
       achievements: 'Centrocampista con más recuperaciones. Finalista de Copa 2024.',
       stats: { goals: 12, assists: 18, matches: 52 }
     }
   ];
+
+  const getClubName = (clubId: string) => {
+    const club = clubs.find(c => c.id === clubId);
+    return club ? club.name : 'Desconocido';
+  };
   
   // Mock legendary managers
   const legendaryManagers = [
@@ -311,7 +318,7 @@ const HallOfFame = () => {
                     <div className="p-6">
                       <div className="flex items-center mb-4">
                         <span className="text-gray-400 mr-1">Club:</span>
-                        <span className="font-medium">{player.club}</span>
+                        <span className="font-medium">{getClubName(player.clubId)}</span>
                       </div>
                       
                       <p className="text-gray-300 mb-4">


### PR DESCRIPTION
## Summary
- use player.clubId to match player club
- fetch club name from clubs list
- fix HallOfFame with clubId lookup

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861dc43cfe48333bb02e5315276aaea