### PR TITLE
Add optional club and marketValue fields to Player

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -301,6 +301,8 @@ function generatePlayers(): Player[] {
         position,
         nationality,
         dorsal: i,
+        club: club.name,
+        marketValue: transferValue,
         clubId: club.id,
         overall,
         potential: overall + Math.floor(Math.random() * 10),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,8 @@ export interface Player {
   position: string;
   nationality: string;
   dorsal: number;
+  club?: string;
+  marketValue?: number;
   clubId: string;
   overall: number;
   potential: number;


### PR DESCRIPTION
## Summary
- extend `Player` type with `club` and `marketValue`
- populate new fields when generating mock players

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861dc4483488333bc500deb531c3bb1