### PR TITLE
Implement addTournament handler

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -56,6 +56,7 @@ interface GlobalStore {
   removeMatch: (id: string) => void;
 
   // Tournaments
+  addTournament: (tournament: Tournament) => void;
   updateTournamentStatus: (id: string, status: Tournament['status']) => void;
   
   // Transfers
@@ -403,6 +404,23 @@ export const useGlobalStore = create<GlobalStore>()(
 
     removeMatch: id => {
       set(state => ({ matches: state.matches.filter(m => m.id !== id) }));
+      persist();
+    },
+
+    addTournament: tournament => {
+      set(state => ({
+        tournaments: [...state.tournaments, tournament],
+        activities: [
+          ...state.activities,
+          {
+            id: Date.now().toString(),
+            userId: 'admin',
+            action: 'Tournament Created',
+            details: `Created tournament: ${tournament.name}`,
+            date: new Date().toISOString()
+          }
+        ]
+      }));
       persist();
     },
 


### PR DESCRIPTION
## Summary
- add `addTournament` method to GlobalStore interface
- implement adding tournaments with activity log

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862f7ecaefc8333bbcd817a4d5e456c