### PR TITLE
Add reusable ID generator

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -5,6 +5,7 @@ import { Tournament } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 import NewTournamentModal from './NewTournamentModal';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
+import { generateId } from '../../utils/id';
 
 const TournamentsAdminPanel = () => {
   const { tournaments, updateTournamentStatus, addTournament, removeTournament } = useGlobalStore();
@@ -152,7 +153,7 @@ const TournamentsAdminPanel = () => {
         <NewTournamentModal
           onClose={() => setShowNew(false)}
           onSave={(data) => {
-            addTournament({ id: Date.now().toString(), ...data });
+            addTournament({ id: generateId(), ...data });
             setShowNew(false);
           }}
         />

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -19,6 +19,7 @@ import {
 import { saveClubs } from '../../utils/clubService';
 import { savePlayers } from '../../utils/playerService';
 import { useDataStore } from '../../store/dataStore';
+import { generateId } from '../../utils/id';
 
 interface GlobalStore {
   users: User[];
@@ -254,7 +255,7 @@ export const useGlobalStore = create<GlobalStore>()(
         activities: [
           ...state.activities,
           {
-            id: Date.now().toString(),
+            id: generateId(),
             userId: 'admin',
             action: 'User Created',
             details: `Created user: ${user.username}`,
@@ -271,7 +272,7 @@ export const useGlobalStore = create<GlobalStore>()(
         activities: [
           ...state.activities,
           {
-            id: Date.now().toString(),
+            id: generateId(),
             userId: 'admin',
             action: 'User Updated',
             details: `Updated user: ${user.username}`,
@@ -288,7 +289,7 @@ export const useGlobalStore = create<GlobalStore>()(
         activities: [
           ...state.activities,
           {
-            id: Date.now().toString(),
+            id: generateId(),
             userId: 'admin',
             action: 'User Deleted',
             details: `Deleted user with ID: ${id}`,
@@ -312,7 +313,7 @@ export const useGlobalStore = create<GlobalStore>()(
           activities: [
             ...state.activities,
             {
-              id: Date.now().toString(),
+              id: generateId(),
               userId: 'admin',
               action: 'Club Created',
               details: `Created club: ${club.name}`,
@@ -414,7 +415,7 @@ export const useGlobalStore = create<GlobalStore>()(
         activities: [
           ...state.activities,
           {
-            id: Date.now().toString(),
+            id: generateId(),
             userId: 'admin',
             action: 'Tournament Created',
             details: `Created tournament: ${tournament.name}`,
@@ -445,7 +446,7 @@ export const useGlobalStore = create<GlobalStore>()(
         activities: [
           ...state.activities,
           {
-            id: Date.now().toString(),
+            id: generateId(),
             userId: 'admin',
             action: 'Transfer Approved',
             details: `Approved transfer with ID: ${id}`,
@@ -462,7 +463,7 @@ export const useGlobalStore = create<GlobalStore>()(
         activities: [
           ...state.activities,
           {
-            id: Date.now().toString(),
+            id: generateId(),
             userId: 'admin',
             action: 'Transfer Rejected',
             details: `Rejected transfer: ${reason}`,

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,8 @@
+export const generateId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+};
+
+export default generateId;


### PR DESCRIPTION
## Summary
- create `generateId` helper
- use `generateId` in tournaments admin panel
- use `generateId` in global store for activity IDs

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686311a486748333b060a4663eb2403c