### PR TITLE
Add logging when deleting tournaments

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -435,7 +435,19 @@ export const useGlobalStore = create<GlobalStore>()(
     },
 
     removeTournament: id => {
-      set(state => ({ tournaments: state.tournaments.filter(t => t.id !== id) }));
+      set(state => ({
+        tournaments: state.tournaments.filter(t => t.id !== id),
+        activities: [
+          ...state.activities,
+          {
+            id: Date.now().toString(),
+            userId: 'admin',
+            action: 'Tournament Deleted',
+            details: `Deleted tournament with ID: ${id}`,
+            date: new Date().toISOString()
+          }
+        ]
+      }));
       persist();
     },
 


### PR DESCRIPTION
## Summary
- log an admin activity when a tournament is removed

## Testing
- `npm test --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686311a51e48833399d005334ad00d32