### PR TITLE
Add tournament tests

### DIFF
--- a/tests/addTournament.test.ts
+++ b/tests/addTournament.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const createMockStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  delete (global as any).localStorage;
+});
+
+describe('useGlobalStore addTournament', () => {
+  it('updates state and persists through adminStorage', async () => {
+    const mockStorage = createMockStorage();
+    (global as any).localStorage = mockStorage;
+    const { useGlobalStore } = await import('../src/adminPanel/store/globalStore');
+
+    const tournament = {
+      id: 't1',
+      name: 'Test Tournament',
+      status: 'upcoming' as const,
+      currentRound: 0,
+      totalRounds: 2,
+    };
+
+    useGlobalStore.getState().addTournament(tournament);
+
+    expect(useGlobalStore.getState().tournaments).toContainEqual(tournament);
+
+    const stored = JSON.parse(mockStorage.getItem('vz_tournaments_admin') || '[]');
+    expect(stored).toContainEqual(tournament);
+
+    vi.resetModules();
+    const { useGlobalStore: reloaded } = await import('../src/adminPanel/store/globalStore');
+    expect(reloaded.getState().tournaments).toContainEqual(tournament);
+  });
+});

--- a/tests/e2e/tournament_admin_flow.cy.ts
+++ b/tests/e2e/tournament_admin_flow.cy.ts
@@ -1,0 +1,26 @@
+/// <reference types="cypress" />
+
+describe('Admin tournament management', () => {
+  it('creates, starts and deletes a tournament', () => {
+    cy.visit('/login');
+    cy.get('input[type="text"]').first().type('admin');
+    cy.get('input[type="password"]').type('password');
+    cy.get('button[type="submit"]').click();
+    cy.url().should('include', '/usuario');
+
+    cy.visit('/admin/torneos');
+
+    cy.contains('button', 'Nuevo Torneo').click();
+    cy.get('input[placeholder="Nombre del torneo"]').type('Cypress Cup');
+    cy.get('input[placeholder="Total de jornadas"]').clear().type('3');
+    cy.contains('button', 'Crear').click();
+
+    cy.contains('.card', 'Cypress Cup').within(() => {
+      cy.get('button').eq(1).click();
+      cy.contains('Activo');
+      cy.get('button[title="Eliminar"]').click();
+    });
+    cy.contains('button', 'Eliminar').click();
+    cy.contains('Cypress Cup').should('not.exist');
+  });
+});


### PR DESCRIPTION
## Summary
- test that addTournament persists tournaments via adminStorage
- cover admin UI tournament flow in a new E2E test

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686311a57ca88333aa83a9c7617ed18e