### PR TITLE
Fix import path for generateId

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -5,7 +5,7 @@ import { Tournament } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 import NewTournamentModal from './NewTournamentModal';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
-import { generateId } from '../../utils/id';
+import { generateId } from '../../../utils/id';
 
 const TournamentsAdminPanel = () => {
   const { tournaments, updateTournamentStatus, addTournament, removeTournament } = useGlobalStore();


### PR DESCRIPTION
## Summary
- correct `generateId` import path in `TournamentsAdminPanel.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68631a037f0c8333af50f90c14a5dadc