### PR TITLE
Fix Cypress docs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ headless mode. To open the interactive Cypress UI instead, execute:
 
 ```bash
 npx cypress open
+```
 
 To execute only the admin user flow test, specify its path:
 
 ```bash
 npx cypress run --spec tests/e2e/admin_user_flow.cy.ts
-```
 ```
 
 Ensure the development server is running on `http://localhost:5173` before


### PR DESCRIPTION
## Summary
- close the Cypress code block properly in README
- move explanatory text outside the fenced blocks
- show the command to run a single E2E spec in its own fenced block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686324d6740c833380e58c78c989354a