### PR TITLE
Fix savePlayers localStorage check

### DIFF
--- a/src/utils/playerService.ts
+++ b/src/utils/playerService.ts
@@ -15,5 +15,6 @@ export const getPlayers = (): Player[] => {
 };
 
 export const savePlayers = (data: Player[]): void => {
+  if (typeof localStorage === 'undefined') return;
   localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(data));
 };


### PR DESCRIPTION
## Summary
- add missing localStorage guard in `savePlayers`

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686324e0e5f88333a525b59680142cab