### PR TITLE
Implement Torneos dashboard

### DIFF
--- a/src/adminPanel/App.tsx
+++ b/src/adminPanel/App.tsx
@@ -9,6 +9,7 @@ const Usuarios = lazy(() => import('./pages/admin/Usuarios'));
 const Clubes = lazy(() => import('./pages/admin/Clubes'));
 const Jugadores = lazy(() => import('./pages/admin/Jugadores'));
 const Mercado = lazy(() => import('./pages/admin/Mercado'));
+const TorneosDashboard = lazy(() => import('./pages/TorneosDashboard'));
 const Torneos = lazy(() => import('./pages/admin/Torneos'));
 const Noticias = lazy(() => import('./pages/admin/Noticias'));
 const Comentarios = lazy(() => import('./pages/admin/Comentarios'));
@@ -52,7 +53,8 @@ const AdminLayout = () => {
             <Route path="clubes" element={<Clubes />} />
             <Route path="jugadores" element={<Jugadores />} />
             <Route path="mercado" element={<Mercado />} />
-            <Route path="torneos" element={<Torneos />} />
+            <Route path="torneos" element={<TorneosDashboard />} />
+            <Route path="torneos/list" element={<Torneos />} />
             <Route path="noticias" element={<Noticias />} />
             <Route path="comentarios" element={<Comentarios />} />
             <Route path="actividad" element={<Actividad />} />

--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -7,8 +7,13 @@ import NewTournamentModal from './NewTournamentModal';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
 import { generateId } from '../../../utils/id';
 
-const TournamentsAdminPanel = () => {
+interface Props {
+  status?: Tournament['status'];
+}
+
+const TournamentsAdminPanel = ({ status }: Props) => {
   const { tournaments, updateTournamentStatus, addTournament, removeTournament } = useGlobalStore();
+  const filtered = status ? tournaments.filter(t => t.status === status) : tournaments;
   const [showNew, setShowNew] = useState(false);
   const [selected, setSelected] = useState<Tournament | null>(null);
   const [deleteTournament, setDeleteTournament] = useState<Tournament | null>(null);
@@ -40,8 +45,8 @@ const TournamentsAdminPanel = () => {
       </div> 
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {tournaments.length > 0 ? (
-          tournaments.map((tournament) => (
+        {filtered.length > 0 ? (
+          filtered.map((tournament) => (
             <div key={tournament.id} className="card">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="font-semibold text-lg">{tournament.name}</h3>
@@ -102,7 +107,7 @@ const TournamentsAdminPanel = () => {
           ))
         ) : (
           <div className="col-span-full card text-center py-8">
-            <p className="text-gray-400">No hay torneos creados</p>
+            <p className="text-gray-400">No hay torneos</p>
           </div>
         )}
       </div>

--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -1,0 +1,61 @@
+import { Clock, Play, Award } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import StatsCard from '../components/admin/StatsCard';
+import { useGlobalStore } from '../store/globalStore';
+
+const TorneosDashboard = () => {
+  const navigate = useNavigate();
+  const { getUpcoming, getActive, getFinished } = useGlobalStore();
+
+  const upcoming = getUpcoming();
+  const active = getActive();
+  const finished = getFinished();
+
+  return (
+    <div className="p-8 space-y-8">
+      <div>
+        <h1 className="text-4xl font-bold gradient-text">Torneos</h1>
+        <p className="text-gray-400 mt-2">Resumen general de torneos</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div
+          className="cursor-pointer"
+          onClick={() => navigate('/admin/torneos/list?status=upcoming')}
+        >
+          <StatsCard
+            title="Próximos"
+            value={upcoming.length}
+            icon={Clock}
+            gradient="bg-gradient-to-r from-gray-600 to-gray-800"
+          />
+        </div>
+        <div
+          className="cursor-pointer"
+          onClick={() => navigate('/admin/torneos/list?status=active')}
+        >
+          <StatsCard
+            title="En Juego"
+            value={active.length}
+            icon={Play}
+            gradient="bg-gradient-to-r from-emerald-600 to-green-600"
+          />
+        </div>
+        <div
+          className="cursor-pointer"
+          onClick={() => navigate('/admin/torneos/list?status=completed')}
+        >
+          <StatsCard
+            title="Cerrados"
+            value={finished.length}
+            icon={Award}
+            gradient="bg-gradient-to-r from-blue-600 to-purple-600"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TorneosDashboard;
+

--- a/src/adminPanel/pages/admin/Torneos.tsx
+++ b/src/adminPanel/pages/admin/Torneos.tsx
@@ -1,9 +1,15 @@
-import  TournamentsAdminPanel from '../../components/admin/TournamentsAdminPanel';
+import { useLocation } from 'react-router-dom';
+import TournamentsAdminPanel from '../../components/admin/TournamentsAdminPanel';
+import { Tournament } from '../../types';
 
 const Torneos = () => {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const statusParam = params.get('status') as Tournament['status'] | null;
+
   return (
     <div className="p-6">
-      <TournamentsAdminPanel />
+      <TournamentsAdminPanel status={statusParam || undefined} />
     </div>
   );
 };

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -60,6 +60,11 @@ interface GlobalStore {
   addTournament: (tournament: Tournament) => void;
   updateTournamentStatus: (id: string, status: Tournament['status']) => void;
   removeTournament: (id: string) => void;
+
+  // Tournament selectors
+  getUpcoming: () => Tournament[];
+  getActive: () => Tournament[];
+  getFinished: () => Tournament[];
   
   // Transfers
   approveTransfer: (id: string) => void;
@@ -452,6 +457,10 @@ export const useGlobalStore = create<GlobalStore>()(
       }));
       persist();
     },
+
+    getUpcoming: () => get().tournaments.filter(t => t.status === 'upcoming'),
+    getActive: () => get().tournaments.filter(t => t.status === 'active'),
+    getFinished: () => get().tournaments.filter(t => t.status === 'completed'),
 
     approveTransfer: id => {
       set(state => ({


### PR DESCRIPTION
## Summary
- add a new tournaments dashboard page
- wire dashboard route and keep list under `/admin/torneos/list`
- enable filtering on tournament list page
- add selectors in global store for upcoming/active/finished tournaments

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863302fb924833390757ea88eb576e3