### PR TITLE
Update tournament admin test for wizard flow

### DIFF
--- a/tests/e2e/tournament_admin_flow.cy.ts
+++ b/tests/e2e/tournament_admin_flow.cy.ts
@@ -10,9 +10,24 @@ describe('Admin tournament management', () => {
 
     cy.visit('/admin/torneos');
 
+    // Navigate from the dashboard to the tournaments list
+    cy.contains('Próximos').click();
+    cy.url().should('include', '/admin/torneos/list');
+
     cy.contains('button', 'Nuevo Torneo').click();
+
+    // Step 1 - basics
     cy.get('input[placeholder="Nombre del torneo"]').type('Cypress Cup');
+    cy.contains('button', 'Siguiente').click();
+
+    // Step 2 - format
     cy.get('input[placeholder="Total de jornadas"]').clear().type('3');
+    cy.contains('button', 'Siguiente').click();
+
+    // Step 3 - schedule
+    cy.contains('button', 'Siguiente').click();
+
+    // Step 4 - confirm
     cy.contains('button', 'Crear').click();
 
     cy.contains('.card', 'Cypress Cup').within(() => {


### PR DESCRIPTION
## Summary
- update the tournament admin flow e2e test
  - navigate from dashboard to tournament list
  - handle the four step wizard when creating a tournament

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863598a8944833395d1f5960c82bf59