### PR TITLE
Fix create tournament wizard ID import path

### DIFF
--- a/src/adminPanel/wizards/CreateTournament/index.tsx
+++ b/src/adminPanel/wizards/CreateTournament/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Tournament } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
-import { generateId } from '../../utils/id';
+import { generateId } from '../../../utils/id';
 import StepBasics from './Steps/StepBasics';
 import StepFormat from './Steps/StepFormat';
 import StepSchedule from './Steps/StepSchedule';


### PR DESCRIPTION
## Summary
- correct relative path for `generateId` in `CreateTournament` wizard

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635d4be78483339021562bbd18d97e