### PR TITLE
Add createdAt to admin panel player type

### DIFF
--- a/src/adminPanel/components/admin/EditPlayerModal.tsx
+++ b/src/adminPanel/components/admin/EditPlayerModal.tsx
@@ -1,5 +1,5 @@
 import  { useState, useRef, useEffect } from 'react';
-import { Player } from '../../types/shared';
+import { Player } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 
 interface Props {

--- a/src/adminPanel/components/admin/NewPlayerModal.tsx
+++ b/src/adminPanel/components/admin/NewPlayerModal.tsx
@@ -1,5 +1,5 @@
 import  { useState, useRef, useEffect } from 'react';
-import { Player } from '../../types/shared';
+import { Player } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 
 interface Props {

--- a/src/adminPanel/pages/admin/Jugadores.tsx
+++ b/src/adminPanel/pages/admin/Jugadores.tsx
@@ -5,7 +5,7 @@ import { useGlobalStore } from '../../store/globalStore';
 import NewPlayerModal from '../../components/admin/NewPlayerModal';
 import EditPlayerModal from '../../components/admin/EditPlayerModal';
 import ConfirmDeleteModal from '../../components/admin/ConfirmDeleteModal';
-import { Player } from '../../types/shared';
+import { Player } from '../../types';
 
 const Jugadores = () => {
   const { players, clubs, addPlayer, updatePlayer, removePlayer, setLoading } = useGlobalStore();
@@ -65,7 +65,8 @@ const Jugadores = () => {
       goals: 0,
       assists: 0,
       appearances: 0,
-      price: playerData.price || 0
+      price: playerData.price || 0,
+      createdAt: new Date().toISOString()
     };
     
     addPlayer(newPlayer);

--- a/src/adminPanel/store/dataStore.ts
+++ b/src/adminPanel/store/dataStore.ts
@@ -1,6 +1,7 @@
 import  { create } from 'zustand';
 import { Tournament, NewsItem, Transfer, Standing } from '../types';
-import { User, Club, Player } from '../types/shared';
+import { User, Club } from '../types/shared';
+import { Player } from '../types';
 
 interface DataStore {
   users: User[];

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -10,7 +10,8 @@ import {
   ActivityLog,
   Comment,
 } from '../types';
-import { User, Club, Player } from '../types/shared';
+import { User, Club } from '../types/shared';
+import { Player } from '../types';
 import {
   loadAdminData,
   saveAdminData,
@@ -128,7 +129,8 @@ const defaultData: AdminData = {
       position: 'DEL',
       clubId: '1',
       overall: 93,
-      price: 25000000
+      price: 25000000,
+      createdAt: '2023-01-01T00:00:00.000Z'
     },
     {
       id: '2',
@@ -136,7 +138,8 @@ const defaultData: AdminData = {
       position: 'DEL',
       clubId: '2',
       overall: 91,
-      price: 20000000
+      price: 20000000,
+      createdAt: '2023-01-01T00:00:00.000Z'
     }
   ],
   matches: [

--- a/src/adminPanel/types.ts
+++ b/src/adminPanel/types.ts
@@ -2,12 +2,16 @@ import {
   User as SharedUser,
   Club,
   Title,
-  Player,
+  Player as SharedPlayer,
   PlayerAttributes,
   PlayerContract,
 } from '../types/shared';
 
-export { Club, Title, Player, PlayerAttributes, PlayerContract } from '../types/shared';
+export { Club, Title, PlayerAttributes, PlayerContract } from '../types/shared';
+
+export interface Player extends SharedPlayer {
+  createdAt?: string;
+}
 
 export interface User extends SharedUser {
   role: 'admin' | 'dt' | 'user';

--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -8,7 +8,7 @@ import {
 export interface AdminData {
   users: import('../types/shared').User[];
   clubs: import('../types/shared').Club[];
-  players: import('../types/shared').Player[];
+  players: import('../types').Player[];
   matches: import('../types').Fixture[];
   tournaments: import('../types').Tournament[];
   newsItems: import('../types').NewsItem[];


### PR DESCRIPTION
## Summary
- extend `Player` type in admin panel to hold `createdAt`
- include `createdAt` in default player entries
- persist created date when creating new players
- update imports and admin storage types

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686447b38e1883338b1ac8cc4abfaf40