### PR TITLE
Add admin selectors

### DIFF
--- a/src/adminPanel/__tests__/selectors.test.ts
+++ b/src/adminPanel/__tests__/selectors.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  useGlobalStore,
+  getPlayersRegisteredToday,
+  getMatchesScheduledTomorrow,
+  getAvgGoalsLast7Days
+} from '../store/globalStore';
+
+describe('global store selectors', () => {
+  beforeEach(() => {
+    // Reset store state for each test
+    useGlobalStore.setState({
+      users: [],
+      clubs: [],
+      players: [],
+      matches: [],
+      tournaments: [],
+      newsItems: [],
+      transfers: [],
+      standings: [],
+      activities: [],
+      comments: [],
+      loading: false
+    });
+  });
+
+  it('getPlayersRegisteredToday returns today users with role user', () => {
+    const today = new Date().toISOString();
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    useGlobalStore.setState(state => ({
+      users: [
+        { id: '1', username: 'a', email: 'a', role: 'user', status: 'active', createdAt: today },
+        { id: '2', username: 'b', email: 'b', role: 'user', status: 'active', createdAt: yesterday },
+        { id: '3', username: 'c', email: 'c', role: 'dt', status: 'active', createdAt: today }
+      ]
+    }));
+
+    const result = getPlayersRegisteredToday();
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('getMatchesScheduledTomorrow returns matches in the next day', () => {
+    const now = new Date();
+    const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 12).toISOString();
+    const twoDays = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 2, 12).toISOString();
+
+    useGlobalStore.setState(state => ({
+      matches: [
+        { id: '1', tournamentId: 't1', round: 1, date: tomorrow, homeTeam: 'A', awayTeam: 'B', status: 'scheduled' },
+        { id: '2', tournamentId: 't1', round: 1, date: twoDays, homeTeam: 'C', awayTeam: 'D', status: 'scheduled' },
+        { id: '3', tournamentId: 't1', round: 1, date: tomorrow, homeTeam: 'E', awayTeam: 'F', status: 'scheduled' }
+      ]
+    }));
+
+    const result = getMatchesScheduledTomorrow();
+    expect(result.map(m => m.id)).toEqual(['1', '3']);
+  });
+
+  it('getAvgGoalsLast7Days calculates average goals', () => {
+    const now = Date.now();
+    const within = (days: number) => new Date(now - days * 24 * 60 * 60 * 1000).toISOString();
+
+    useGlobalStore.setState(state => ({
+      matches: [
+        { id: '1', tournamentId: 't', round: 1, date: within(1), homeTeam: 'A', awayTeam: 'B', homeScore: 2, awayScore: 1, status: 'finished' },
+        { id: '2', tournamentId: 't', round: 1, date: within(3), homeTeam: 'C', awayTeam: 'D', homeScore: 0, awayScore: 0, status: 'finished' },
+        { id: '3', tournamentId: 't', round: 1, date: within(6), homeTeam: 'E', awayTeam: 'F', homeScore: 3, awayScore: 2, status: 'finished' },
+        { id: '4', tournamentId: 't', round: 1, date: within(10), homeTeam: 'G', awayTeam: 'H', homeScore: 5, awayScore: 1, status: 'finished' }
+      ]
+    }));
+
+    const avg = getAvgGoalsLast7Days();
+    expect(avg).toBeCloseTo(8 / 3, 5);
+  });
+});
+

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -65,6 +65,11 @@ interface GlobalStore {
   getUpcoming: () => Tournament[];
   getActive: () => Tournament[];
   getFinished: () => Tournament[];
+
+  // Dashboard selectors
+  getPlayersRegisteredToday: () => User[];
+  getMatchesScheduledTomorrow: () => Fixture[];
+  getAvgGoalsLast7Days: () => number;
   
   // Transfers
   approveTransfer: (id: string) => void;
@@ -464,6 +469,41 @@ export const useGlobalStore = create<GlobalStore>()(
     getActive: () => get().tournaments.filter(t => t.status === 'active'),
     getFinished: () => get().tournaments.filter(t => t.status === 'completed'),
 
+    getPlayersRegisteredToday: () => {
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+      const end = new Date();
+      end.setHours(23, 59, 59, 999);
+      return get().users.filter(u => {
+        if (!u.createdAt) return false;
+        const d = new Date(u.createdAt);
+        return d >= start && d <= end && u.role === 'user';
+      });
+    },
+
+    getMatchesScheduledTomorrow: () => {
+      const now = new Date();
+      const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+      const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 2);
+      return get().matches.filter(m => {
+        const d = new Date(m.date);
+        return d >= start && d < end;
+      });
+    },
+
+    getAvgGoalsLast7Days: () => {
+      const now = Date.now();
+      const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
+      const recent = get().matches.filter(m => {
+        const d = new Date(m.date).getTime();
+        return d >= weekAgo && d <= now &&
+          typeof m.homeScore === 'number' && typeof m.awayScore === 'number';
+      });
+      if (recent.length === 0) return 0;
+      const totalGoals = recent.reduce((sum, m) => sum + (m.homeScore ?? 0) + (m.awayScore ?? 0), 0);
+      return totalGoals / recent.length;
+    },
+
     approveTransfer: id => {
       set(state => ({
         transfers: state.transfers.map(t => (t.id === id ? { ...t, status: 'approved' as const } : t)),
@@ -540,3 +580,9 @@ export const useGlobalStore = create<GlobalStore>()(
 }));
 
 export const subscribe = useGlobalStore.subscribe;
+export const getPlayersRegisteredToday = () =>
+  useGlobalStore.getState().getPlayersRegisteredToday();
+export const getMatchesScheduledTomorrow = () =>
+  useGlobalStore.getState().getMatchesScheduledTomorrow();
+export const getAvgGoalsLast7Days = () =>
+  useGlobalStore.getState().getAvgGoalsLast7Days();


### PR DESCRIPTION
## Summary
- add dashboard selectors and exports in global store
- cover selectors with unit tests

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686447b452348333be5bdbf17fe93f7d