### PR TITLE
Fix duplicate identifier in TorneosDashboard

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -8,12 +8,8 @@ import { useGlobalStore } from '../store/globalStore';
 const TorneosDashboard = () => {
   const navigate = useNavigate();
   const {
-    getUpcoming,
-    getActive,
-    getFinished,
     duplicateLastTournament,
     generateTournamentsReport,
-    tournaments
   } = useGlobalStore();
   const canModify = useCan(['super', 'gestor']);
 


### PR DESCRIPTION
## Summary
- remove duplicated `tournaments` variable from TorneosDashboard page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647d033e6483339f0db22c3db8d6f0