### PR TITLE
Add route for new tournament wizard

### DIFF
--- a/src/adminPanel/App.tsx
+++ b/src/adminPanel/App.tsx
@@ -11,6 +11,7 @@ const Jugadores = lazy(() => import('./pages/admin/Jugadores'));
 const Mercado = lazy(() => import('./pages/admin/Mercado'));
 const TorneosDashboard = lazy(() => import('./pages/TorneosDashboard'));
 const Torneos = lazy(() => import('./pages/admin/Torneos'));
+const NuevoTorneo = lazy(() => import('./pages/admin/NuevoTorneo'));
 const ResultadosPendientes = lazy(() => import('./pages/ResultadosPendientes'));
 const Noticias = lazy(() => import('./pages/admin/Noticias'));
 const Comentarios = lazy(() => import('./pages/admin/Comentarios'));
@@ -56,6 +57,7 @@ const AdminLayout = () => {
             <Route path="mercado" element={<Mercado />} />
             <Route path="resultados" element={<ResultadosPendientes />} />
             <Route path="torneos" element={<TorneosDashboard />} />
+            <Route path="torneos/nuevo" element={<NuevoTorneo />} />
             <Route path="torneos/list" element={<Torneos />} />
             <Route path="noticias" element={<Noticias />} />
             <Route path="comentarios" element={<Comentarios />} />

--- a/src/adminPanel/pages/admin/NuevoTorneo.tsx
+++ b/src/adminPanel/pages/admin/NuevoTorneo.tsx
@@ -1,0 +1,9 @@
+import { useNavigate } from 'react-router-dom';
+import CreateTournamentWizard from '../../wizards/CreateTournament';
+
+const NuevoTorneo = () => {
+  const navigate = useNavigate();
+  return <CreateTournamentWizard onClose={() => navigate(-1)} />;
+};
+
+export default NuevoTorneo;


### PR DESCRIPTION
## Summary
- create `NuevoTorneo` page that renders `CreateTournamentWizard`
- register route `/admin/torneos/nuevo`

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686481ee073083339af84e4fa0acf065