### PR TITLE
Fix missing bracket in TorneosDashboard

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -73,7 +73,7 @@ const TorneosDashboard = () => {
             Guía rápida
           </a>
         </div>
-      )
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div


### PR DESCRIPTION
## Summary
- fix JSX by closing the empty state block in `TorneosDashboard`

## Testing
- `npx tsc --project tsconfig.app.json --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6864885b75408333be611f25cd361e6f