### PR TITLE
Add duplicate tournament editing flow

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -1,7 +1,10 @@
 import { Clock, Play, Award, Trophy, MoreHorizontal } from 'lucide-react';
 import { useNavigate, Link } from 'react-router-dom';
+import { useState } from 'react';
 import StatsCard from '../components/admin/StatsCard';
 import DropdownMenu from '../components/admin/DropdownMenu';
+import CreateTournamentWizard from '../wizards/CreateTournament';
+import { Tournament } from '../types';
 import useCan from '../../hooks/useCan';
 import { useGlobalStore } from '../store/globalStore';
 import {
@@ -18,6 +21,18 @@ const TorneosDashboard = () => {
     generateTournamentsReport,
   } = useGlobalStore();
   const canModify = useCan(['super', 'gestor']);
+
+  const [duplicateData, setDuplicateData] = useState<Partial<Tournament> | null>(
+    null
+  );
+
+  const handleDuplicate = () => {
+    const copy = duplicateLastTournament();
+    if (copy) {
+      const { id, ...rest } = copy;
+      setDuplicateData(rest);
+    }
+  };
 
   const tournaments = useGlobalStore(state => state.tournaments);
   const players = useGlobalStore(state => state.players);
@@ -178,7 +193,7 @@ const TorneosDashboard = () => {
                 },
                 {
                   label: 'Duplicar último torneo',
-                  onSelect: duplicateLastTournament,
+                  onSelect: handleDuplicate,
                   hidden: !canModify
                 },
                 {
@@ -198,6 +213,12 @@ const TorneosDashboard = () => {
             </DropdownMenu>
           </div>
         </div>
+        {duplicateData && (
+          <CreateTournamentWizard
+            initialData={duplicateData}
+            onClose={() => setDuplicateData(null)}
+          />
+        )}
     </div>
   );
 };

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -65,7 +65,7 @@ interface GlobalStore {
   // Tournament selectors
 
   // Extras
-  duplicateLastTournament: () => void;
+  duplicateLastTournament: () => Tournament | undefined;
   generateTournamentsReport: () => void;
   
   // Transfers
@@ -569,31 +569,18 @@ export const useGlobalStore = create<GlobalStore>()(
     },
 
     duplicateLastTournament: () => {
-      set(state => {
-        const last = [...state.tournaments].reverse().find(t => t.status === 'completed');
-        if (!last) return state;
-        const copy = {
-          ...last,
-          id: generateId(),
-          name: `${last.name} (copia)`,
-          status: 'upcoming' as const,
-          currentRound: 0
-        };
-        return {
-          tournaments: [...state.tournaments, copy],
-          activities: [
-            ...state.activities,
-            {
-              id: generateId(),
-              userId: 'admin',
-              action: 'Tournament Duplicated',
-              details: `Duplicated tournament: ${last.name}`,
-              date: new Date().toISOString()
-            }
-          ]
-        };
-      });
-      persist();
+      const last = [...get().tournaments]
+        .reverse()
+        .find(t => t.status === 'completed');
+      if (!last) return undefined;
+      const copy: Tournament = {
+        ...last,
+        id: generateId(),
+        name: `${last.name} (copia)`,
+        status: 'upcoming',
+        currentRound: 0
+      };
+      return copy;
     },
 
     generateTournamentsReport: () => {

--- a/src/adminPanel/wizards/CreateTournament/Steps/StepBasics.tsx
+++ b/src/adminPanel/wizards/CreateTournament/Steps/StepBasics.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Tournament } from '../../../types';
 
 interface Props {
@@ -12,6 +12,11 @@ const StepBasics = ({ data, onNext }: Props) => {
     (data.status as Tournament['status']) || 'upcoming'
   );
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    setName(data.name || '');
+    setStatus((data.status as Tournament['status']) || 'upcoming');
+  }, [data]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/adminPanel/wizards/CreateTournament/Steps/StepFormat.tsx
+++ b/src/adminPanel/wizards/CreateTournament/Steps/StepFormat.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Tournament } from '../../../types';
 
 interface Props {
@@ -10,6 +10,10 @@ interface Props {
 const StepFormat = ({ data, onNext, onBack }: Props) => {
   const [totalRounds, setTotalRounds] = useState(data.totalRounds || 1);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    setTotalRounds(data.totalRounds || 1);
+  }, [data.totalRounds]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/adminPanel/wizards/CreateTournament/Steps/StepSchedule.tsx
+++ b/src/adminPanel/wizards/CreateTournament/Steps/StepSchedule.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Tournament } from '../../../types';
 
 interface Props {
@@ -11,6 +11,10 @@ const StepSchedule = ({ data, onNext, onBack }: Props) => {
   const [status, setStatus] = useState<Tournament['status']>(
     (data.status as Tournament['status']) || 'upcoming'
   );
+
+  useEffect(() => {
+    setStatus((data.status as Tournament['status']) || 'upcoming');
+  }, [data.status]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/adminPanel/wizards/CreateTournament/index.tsx
+++ b/src/adminPanel/wizards/CreateTournament/index.tsx
@@ -9,20 +9,24 @@ import StepConfirm from './Steps/StepConfirm';
 
 interface Props {
   onClose: () => void;
+  initialData?: Partial<Tournament>;
 }
 
 const STORAGE_KEY = 'wizard.tournament.draft';
 
-const CreateTournamentWizard = ({ onClose }: Props) => {
+const CreateTournamentWizard = ({ onClose, initialData }: Props) => {
   const addTournament = useGlobalStore(state => state.addTournament);
   const [step, setStep] = useState(0);
-  const [data, setData] = useState<Partial<Tournament>>({
-    name: '',
-    totalRounds: 1,
-    status: 'upcoming',
-  });
+  const [data, setData] = useState<Partial<Tournament>>(() =>
+    initialData || {
+      name: '',
+      totalRounds: 1,
+      status: 'upcoming',
+    }
+  );
 
   useEffect(() => {
+    if (initialData) return;
     const json = localStorage.getItem(STORAGE_KEY);
     if (json) {
       try {
@@ -32,11 +36,13 @@ const CreateTournamentWizard = ({ onClose }: Props) => {
         // ignore
       }
     }
-  }, []);
+  }, [initialData]);
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-  }, [data]);
+    if (!initialData) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    }
+  }, [data, initialData]);
 
   const handleFinish = () => {
     addTournament({
@@ -46,7 +52,9 @@ const CreateTournamentWizard = ({ onClose }: Props) => {
       status: (data.status as Tournament['status']) || 'upcoming',
       currentRound: 0,
     });
-    localStorage.removeItem(STORAGE_KEY);
+    if (!initialData) {
+      localStorage.removeItem(STORAGE_KEY);
+    }
     onClose();
   };
 


### PR DESCRIPTION
## Summary
- update `duplicateLastTournament` to return the duplicated object
- allow duplicating tournaments directly from the dashboard
- preload duplicated data into `CreateTournamentWizard`
- keep wizard fields in sync with prop changes

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a5fd664883339a5644329003903e