### PR TITLE
Replace div links with Card component

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -1,6 +1,7 @@
 import { Clock, Play, Award, Trophy, MoreHorizontal } from 'lucide-react';
 import { useNavigate, Link } from 'react-router-dom';
 import StatsCard from '../components/admin/StatsCard';
+import Card from '../../components/common/Card';
 import DropdownMenu from '../components/admin/DropdownMenu';
 import useCan from '../../hooks/useCan';
 import { useGlobalStore } from '../store/globalStore';
@@ -102,9 +103,9 @@ const TorneosDashboard = () => {
       )}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div
-            className="group relative cursor-pointer"
+          <Card
             onClick={() => navigate('/admin/torneos/list?status=upcoming')}
+            className="group relative cursor-pointer"
           >
             <StatsCard
               title="Próximos"
@@ -128,10 +129,10 @@ const TorneosDashboard = () => {
                 <MoreHorizontal size={16} />
               </button>
             </DropdownMenu>
-          </div>
-          <div
-            className="group relative cursor-pointer"
+          </Card>
+          <Card
             onClick={() => navigate('/admin/torneos/list?status=active')}
+            className="group relative cursor-pointer"
           >
             <StatsCard
               title="En Juego"
@@ -159,10 +160,10 @@ const TorneosDashboard = () => {
                 <MoreHorizontal size={16} />
               </button>
             </DropdownMenu>
-          </div>
-          <div
-            className="group relative cursor-pointer"
+          </Card>
+          <Card
             onClick={() => navigate('/admin/torneos/list?status=completed')}
+            className="group relative cursor-pointer"
           >
             <StatsCard
               title="Cerrados"
@@ -196,7 +197,7 @@ const TorneosDashboard = () => {
                 <MoreHorizontal size={16} />
               </button>
             </DropdownMenu>
-          </div>
+          </Card>
         </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- import Card into `TorneosDashboard`
- wrap tournament navigation sections with `Card` and pass navigation handler to `onClick`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864a6005324833395a4d754c398b49a