### PR TITLE
Fix DropdownMenu import path

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -3,7 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useState } from 'react';
 import StatsCard from '../components/admin/StatsCard';
 import Card from '../../components/common/Card';
-import DropdownMenu from '../components/admin/DropdownMenu';
+import DropdownMenu from '../../components/common/DropdownMenu';
 import CreateTournamentWizard from '../wizards/CreateTournament';
 import { Tournament } from '../types';
 import useCan from '../../hooks/useCan';


### PR DESCRIPTION
## Summary
- fix incorrect admin dropdown import path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864aa01d6f08333b638f728a3b9ef20