### PR TITLE
Fix blank tournaments page

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -3,7 +3,10 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useState } from 'react';
 import StatsCard from '../components/admin/StatsCard';
 import Card from '../../components/common/Card';
-import DropdownMenu from '../../components/common/DropdownMenu';
+import DropdownMenu, {
+  DropdownMenuTrigger,
+  DropdownMenuItem,
+} from '../../components/common/DropdownMenu';
 import CreateTournamentWizard from '../wizards/CreateTournament';
 import { Tournament } from '../types';
 import useCan from '../../hooks/useCan';


### PR DESCRIPTION
## Summary
- fix admin tournaments dashboard by importing `DropdownMenuTrigger` and `DropdownMenuItem`

## Testing
- `npm test` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864aac3e2fc83338314d2d3edd445d8