### PR TITLE
Fix blank tournaments page

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -3,7 +3,10 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useState } from 'react';
 import StatsCard from '../components/admin/StatsCard';
 import Card from '../../components/common/Card';
-import DropdownMenu from '../../components/common/DropdownMenu';
+import DropdownMenu, {
+  DropdownMenuTrigger,
+  DropdownMenuItem,
+} from '../../components/common/DropdownMenu';
 import CreateTournamentWizard from '../wizards/CreateTournament';
 import { Tournament } from '../types';
 import useCan from '../../hooks/useCan';
@@ -130,23 +133,7 @@ const TorneosDashboard = () => {
               icon={Clock}
               gradient="bg-gradient-to-r from-gray-600 to-gray-800"
             />
-            <DropdownMenu
-              items={[
-                {
-                  label: 'Ver lista completa',
-                  onSelect: () => {
-                    addActivity({
-                      id: generateId(),
-                      userId: 'admin',
-                      action: 'Tournament List Viewed',
-                      details: 'Viewed upcoming tournaments list',
-                      date: new Date().toISOString(),
-                    });
-                    navigate('/admin/torneos/list?status=upcoming');
-                  }
-                }
-              ]}
-            >
+            <DropdownMenu>
               <DropdownMenuTrigger>
                 <button
                   className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
@@ -173,36 +160,7 @@ const TorneosDashboard = () => {
               icon={Play}
               gradient="bg-gradient-to-r from-emerald-600 to-green-600"
             />
-            <DropdownMenu
-              items={[
-                {
-                  label: 'Ver lista completa',
-                  onSelect: () => {
-                    addActivity({
-                      id: generateId(),
-                      userId: 'admin',
-                      action: 'Tournament List Viewed',
-                      details: 'Viewed active tournaments list',
-                      date: new Date().toISOString(),
-                    });
-                    navigate('/admin/torneos/list?status=active');
-                  }
-                },
-                {
-                  label: 'Ir a resultados pendientes',
-                  onSelect: () => {
-                    addActivity({
-                      id: generateId(),
-                      userId: 'admin',
-                      action: 'Results Pending Viewed',
-                      details: 'Visited pending match results',
-                      date: new Date().toISOString(),
-                    });
-                    navigate('/admin/resultados-pendientes');
-                  }
-                }
-              ]}
-            >
+            <DropdownMenu>
               <DropdownMenuTrigger>
                 <button
                   className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
@@ -234,33 +192,7 @@ const TorneosDashboard = () => {
               icon={Award}
               gradient="bg-gradient-to-r from-blue-600 to-purple-600"
             />
-            <DropdownMenu
-              items={[
-                {
-                  label: 'Ver lista completa',
-                  onSelect: () => {
-                    addActivity({
-                      id: generateId(),
-                      userId: 'admin',
-                      action: 'Tournament List Viewed',
-                      details: 'Viewed completed tournaments list',
-                      date: new Date().toISOString(),
-                    });
-                    navigate('/admin/torneos/list?status=completed');
-                  }
-                },
-                {
-                  label: 'Duplicar último torneo',
-                  onSelect: handleDuplicate,
-                  hidden: !canModify
-                },
-                {
-                  label: 'Generar reporte PDF',
-                  onSelect: generateTournamentsReport,
-                  hidden: !canModify
-                }
-              ]}
-            >
+            <DropdownMenu>
               <DropdownMenuTrigger>
                 <button
                   className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"


### PR DESCRIPTION
## Summary
- fix admin tournaments dashboard by importing `DropdownMenuTrigger` and `DropdownMenuItem`
- remove unused `items` prop from dropdown menus

## Testing
- `npm test` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864aac3e2fc83338314d2d3edd445d8