### PR TITLE
Fix duplicate handler call

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -11,7 +11,6 @@ import CreateTournamentWizard from '../wizards/CreateTournament';
 import { Tournament } from '../types';
 import useCan from '../../hooks/useCan';
 import { useGlobalStore } from '../store/globalStore';
-import { generateId } from '../../utils/id';
 import {
   useUpcomingTournaments,
   useActiveTournaments,
@@ -24,7 +23,6 @@ const TorneosDashboard = () => {
   const {
     duplicateLastTournament,
     generateTournamentsReport,
-    addActivity,
   } = useGlobalStore();
   const canModify = useCan(['super', 'gestor']);
 
@@ -208,7 +206,7 @@ const TorneosDashboard = () => {
                 Ver lista completa
               </DropdownMenuItem>
               {canModify && (
-                <DropdownMenuItem onSelect={duplicateLastTournament}>
+                <DropdownMenuItem onSelect={handleDuplicate}>
                   Duplicar último torneo
                 </DropdownMenuItem>
               )}


### PR DESCRIPTION
## Summary
- use `handleDuplicate` when duplicating tournaments
- clean up unused props in the dashboard

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686542650f6c8333aa97cfbbcc86ea52