### PR TITLE
Fix matches filter when date missing

### DIFF
--- a/src/adminPanel/components/admin/CalendarScheduler.tsx
+++ b/src/adminPanel/components/admin/CalendarScheduler.tsx
@@ -98,6 +98,7 @@ const CalendarScheduler = ({ matches, weekStart, onEdit }: SchedulerProps) => {
     const conflict = matches.some(m => {
       if (m.id === match.id) return false;
       if (m.homeTeam === match.homeTeam || m.homeTeam === match.awayTeam || m.awayTeam === match.homeTeam || m.awayTeam === match.awayTeam) {
+        if (!m.date) return false;
         const diff = Math.abs(new Date(m.date).getTime() - overDate.getTime());
         return diff < 2 * 60 * 60 * 1000; // 2 hours overlap
       }
@@ -119,7 +120,7 @@ const CalendarScheduler = ({ matches, weekStart, onEdit }: SchedulerProps) => {
       <div className="grid grid-cols-1 md:grid-cols-7 gap-2">
         {days.map(day => (
           <DroppableDay key={dayId(day)} date={day}>
-            {matches.filter(m => isSameDay(new Date(m.date), day)).map(m => (
+            {matches.filter(m => m.date && isSameDay(new Date(m.date), day)).map(m => (
               <DraggableMatch key={m.id} match={m} onEdit={onEdit} />
             ))}
           </DroppableDay>

--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -48,8 +48,9 @@ const TorneosDashboard = () => {
   const finished = useFinishedTournaments();
 
   const hoyInscritos = players.filter(p => p.createdAt && isToday(p.createdAt)).length;
-  const partidosManana = matches.filter(m => isTomorrow(m.date)).length;
+  const partidosManana = matches.filter(m => m.date && isTomorrow(m.date)).length;
   const matchesLast7Days = matches.filter(m => {
+    if (!m.date) return false;
     const d = new Date(m.date);
     const now = new Date();
     const diff = now.getTime() - d.getTime();

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -482,6 +482,7 @@ export const useGlobalStore = create<GlobalStore>()(
       const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
       const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 2);
       return get().matches.filter(m => {
+        if (!m.date) return false;
         const d = new Date(m.date);
         return d >= start && d < end;
       });
@@ -491,6 +492,7 @@ export const useGlobalStore = create<GlobalStore>()(
       const now = Date.now();
       const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
       const recent = get().matches.filter(m => {
+        if (!m.date) return false;
         const d = new Date(m.date).getTime();
         return d >= weekAgo && d <= now &&
           typeof m.homeScore === 'number' && typeof m.awayScore === 'number';


### PR DESCRIPTION
## Summary
- handle missing date fields when filtering or creating `Date` objects

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68654265e6a88333bdda1de738ccf458