### PR TITLE
Fix nested button issue

### DIFF
--- a/src/adminPanel/pages/TorneosDashboard.tsx
+++ b/src/adminPanel/pages/TorneosDashboard.tsx
@@ -133,14 +133,12 @@ const TorneosDashboard = () => {
               gradient="bg-gradient-to-r from-gray-600 to-gray-800"
             />
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <button
-                  className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
-                  onClick={e => e.stopPropagation()}
-                  aria-label="Más opciones"
-                >
-                  <MoreHorizontal size={16} />
-                </button>
+              <DropdownMenuTrigger
+                className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
+                onClick={e => e.stopPropagation()}
+                aria-label="Más opciones"
+              >
+                <MoreHorizontal size={16} />
               </DropdownMenuTrigger>
               <DropdownMenuItem
                 onSelect={() => navigate('/admin/torneos/list?status=upcoming')}
@@ -160,14 +158,12 @@ const TorneosDashboard = () => {
               gradient="bg-gradient-to-r from-emerald-600 to-green-600"
             />
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <button
-                  className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
-                  onClick={e => e.stopPropagation()}
-                  aria-label="Más opciones"
-                >
-                  <MoreHorizontal size={16} />
-                </button>
+              <DropdownMenuTrigger
+                className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
+                onClick={e => e.stopPropagation()}
+                aria-label="Más opciones"
+              >
+                <MoreHorizontal size={16} />
               </DropdownMenuTrigger>
               <DropdownMenuItem
                 onSelect={() => navigate('/admin/torneos/list?status=active')}
@@ -192,14 +188,12 @@ const TorneosDashboard = () => {
               gradient="bg-gradient-to-r from-blue-600 to-purple-600"
             />
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <button
-                  className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
-                  onClick={e => e.stopPropagation()}
-                  aria-label="Más opciones"
-                >
-                  <MoreHorizontal size={16} />
-                </button>
+              <DropdownMenuTrigger
+                className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-700"
+                onClick={e => e.stopPropagation()}
+                aria-label="Más opciones"
+              >
+                <MoreHorizontal size={16} />
               </DropdownMenuTrigger>
               <DropdownMenuItem
                 onSelect={() => navigate('/admin/torneos/list?status=completed')}

--- a/src/components/common/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu.tsx
@@ -47,24 +47,37 @@ export const DropdownMenu = ({ children }: DropdownMenuProps) => {
   );
 };
 
-interface DropdownMenuTriggerProps {
+interface DropdownMenuTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   className?: string;
 }
 
-export const DropdownMenuTrigger = ({ children, className }: DropdownMenuTriggerProps) => {
+export const DropdownMenuTrigger = ({
+  children,
+  className,
+  onClick,
+  ...props
+}: DropdownMenuTriggerProps) => {
   const context = useContext(DropdownMenuContext);
   if (!context) {
     throw new Error('DropdownMenuTrigger must be used within DropdownMenu');
   }
   const { open, setOpen } = context;
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    if (!e.defaultPrevented) {
+      setOpen(!open);
+    }
+  };
   return (
     <button
       type="button"
-      onClick={() => setOpen(!open)}
+      onClick={handleClick}
       className={className}
       aria-haspopup="true"
       aria-expanded={open}
+      {...props}
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary
- allow passing button attributes to `DropdownMenuTrigger`
- stop nesting `<button>` elements in TorneosDashboard

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686543a639748333924ccf138f936a1a