### PR TITLE
Add mini KPIs on tournaments dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-hot-toast": "^2.5.2",
         "react-router-dom": "^6.14.0",
         "recharts": "^3.0.0",
-        "zustand": "^4.3.8"
+        "zustand": "^4.3.8",
+        "date-fns": "^3.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-hot-toast": "^2.5.2",
     "react-router-dom": "^6.14.0",
     "recharts": "^3.0.0",
-    "zustand": "^4.3.8"
+    "zustand": "^4.3.8",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- compute dashboard KPI metrics with date-fns
- memoize KPI calculations
- render KPI chips below the Torneos title
- add date-fns dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686547b1de1883339fb12ed8e96205da