### PR TITLE
Fix Mercado padding

### DIFF
--- a/src/adminPanel/pages/admin/Mercado.tsx
+++ b/src/adminPanel/pages/admin/Mercado.tsx
@@ -52,7 +52,7 @@ const Mercado = () => {
   };
 
   return (
-    <>
+    <div className="p-6">
       <div className="space-y-6">
         <div className="flex justify-between items-center">
           <div>
@@ -276,7 +276,7 @@ const Mercado = () => {
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a padded container around Mercado admin panel to match other pages

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657034ab108333906c32273ea4814a