### PR TITLE
Persist transfer offers in DT dashboard

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -7,10 +7,8 @@ import {
   deleteUser as persistDeleteUser
 } from '../utils/authService';
 import {
-  players as seedPlayers,
   tournaments,
   transfers,
-  offers,
   marketStatus,
   leagueStandings,
   newsItems,
@@ -28,6 +26,7 @@ import {
 } from '../data/mockData';
 import { getClubs, saveClubs } from '../utils/clubService';
 import { getPlayers, savePlayers } from '../utils/playerService';
+import { getOffers, saveOffers } from '../utils/offerService';
 import {
   Tournament,
   Transfer,
@@ -50,6 +49,7 @@ import { Club, Player, User } from '../types/shared';
 
 const initialClubs = getClubs();
 const initialPlayers = getPlayers();
+const initialOffers = getOffers();
 const initialUser = useAuthStore.getState().user;
 const baseClub = initialClubs.find(c => c.id === initialUser?.clubId) || initialClubs[0];
 const initialClub: DtClub = {
@@ -118,6 +118,7 @@ interface DataState {
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
   toggleTask: (id: string) => void;
+  setClubFromUser: (user: User | null) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -125,7 +126,7 @@ export const useDataStore = create<DataState>((set) => ({
   players: initialPlayers,
   tournaments,
   transfers,
-  offers,
+  offers: initialOffers,
   standings: leagueStandings,
   newsItems,
   mediaItems,
@@ -161,7 +162,10 @@ export const useDataStore = create<DataState>((set) => ({
   
   updateTransfers: (newTransfers) => set({ transfers: newTransfers }),
   
-  updateOffers: (newOffers) => set({ offers: newOffers }),
+  updateOffers: (newOffers) => {
+    saveOffers(newOffers);
+    set({ offers: newOffers });
+  },
   
   updateMarketStatus: (status) =>
     set(() => {
@@ -176,15 +180,21 @@ export const useDataStore = create<DataState>((set) => ({
       return { marketStatus: status };
     }),
   
-  addOffer: (offer) => set((state) => ({
-    offers: [...state.offers, offer]
-  })),
+  addOffer: (offer) =>
+    set((state) => {
+      const updated = [...state.offers, offer];
+      saveOffers(updated);
+      return { offers: updated };
+    }),
   
-  updateOfferStatus: (offerId, status) => set((state) => ({
-    offers: state.offers.map(offer =>
-      offer.id === offerId ? { ...offer, status } : offer
-    )
-  })),
+  updateOfferStatus: (offerId, status) =>
+    set((state) => {
+      const updated = state.offers.map((offer) =>
+        offer.id === offerId ? { ...offer, status } : offer
+      );
+      saveOffers(updated);
+      return { offers: updated };
+    }),
 
   addTransfer: (transfer) => set((state) => ({
     transfers: [transfer, ...state.transfers]
@@ -312,6 +322,29 @@ export const useDataStore = create<DataState>((set) => ({
     newsItems: state.newsItems.filter(n => n.id !== id)
   })),
 
+  setClubFromUser: (user) =>
+    set((state) => {
+      if (!user?.clubId) return state;
+      const baseClub = state.clubs.find(c => c.id === user.clubId);
+      if (!baseClub) return state;
+      const club: DtClub = {
+        id: baseClub.id,
+        name: baseClub.name,
+        slug: baseClub.slug,
+        logo: baseClub.logo,
+        formation: '4-3-3',
+        budget: baseClub.budget,
+        players: refreshClubPlayers(state.players, baseClub.id)
+      };
+      const fixtures = state.tournaments[0].matches
+        .filter(
+          m => m.homeTeam === baseClub.name || m.awayTeam === baseClub.name
+        )
+        .slice(0, 6)
+        .map(m => ({ ...m, played: m.status === 'finished' }));
+      return { club, fixtures };
+    }),
+
   updateStandings: (newStandings) => set({ standings: newStandings }),
 
   toggleTask: (id) =>
@@ -321,4 +354,9 @@ export const useDataStore = create<DataState>((set) => ({
       )
     }))
 }));
+
+// Update DT club when authenticated user changes
+useAuthStore.subscribe(state => {
+  useDataStore.getState().setClubFromUser(state.user);
+});
  

--- a/src/utils/offerService.ts
+++ b/src/utils/offerService.ts
@@ -1,0 +1,22 @@
+export const VZ_OFFERS_KEY = 'vz_offers';
+
+import { TransferOffer } from '../types';
+import { offers as defaultOffers } from '../data/mockData';
+
+export const getOffers = (): TransferOffer[] => {
+  if (typeof localStorage === 'undefined') return defaultOffers as TransferOffer[];
+  const json = localStorage.getItem(VZ_OFFERS_KEY);
+  if (json) {
+    try {
+      return JSON.parse(json) as TransferOffer[];
+    } catch {
+      // ignore and fallback to defaults
+    }
+  }
+  return defaultOffers as TransferOffer[];
+};
+
+export const saveOffers = (data: TransferOffer[]): void => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(VZ_OFFERS_KEY, JSON.stringify(data));
+};


### PR DESCRIPTION
## Summary
- persist transfer offers via new `offerService`
- load offers from localStorage in the data store
- save updates whenever offers are created or their status changes
- sync DT dashboard club data whenever the logged-in user changes

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6865da41a43c83338f9582e5ebd5ac2e