### PR TITLE
Enable offer modal in DT market

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -1,46 +1,35 @@
-import  { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Search, Filter, Star, TrendingUp, TrendingDown, Clock, CheckCircle, AlertCircle } from 'lucide-react';
+import { Search, Star } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { useAuthStore } from '../../store/authStore';
 import { Player } from '../../types/shared';
 import toast from 'react-hot-toast';
-
-interface MarketOffer {
-  id: string;
-  player: Player;
-  club: string;
-  amount: number;
-  status: 'pending' | 'accepted' | 'rejected';
-  date: string;
-}
+import OffersPanel from '../market/OffersPanel';
+import OfferModal from '../market/OfferModal';
 
 export default function MercadoTab() {
   const { user } = useAuthStore();
-  const { players, club, clubs } = useDataStore();
+  const { players, club, clubs, offers, marketStatus } = useDataStore();
   const [search, setSearch] = useState('');
   const [positionFilter, setPositionFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'value' | 'overall' | 'age'>('value');
   const [showOffers, setShowOffers] = useState(false);
+  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
-  const [mockOffers] = useState<MarketOffer[]>([
-    {
-      id: '1',
-      player: players[0],
-      club: 'Barcelona',
-      amount: 30000000,
-      status: 'pending',
-      date: '2024-02-10'
-    },
-    {
-      id: '2', 
-      player: players[2],
-      club: 'Manchester City',
-      amount: 120000000,
-      status: 'accepted',
-      date: '2024-02-08'
+  const myOffers = useMemo(() => {
+    if (!user) return [];
+    if (user.role === 'admin') return offers;
+    if (user.role === 'dt' && user.club) {
+      const userClub = clubs.find(c => c.name === user.club);
+      return userClub
+        ? offers.filter(
+            o => o.fromClub === userClub.name || o.toClub === userClub.name
+          )
+        : [];
     }
-  ]);
+    return offers.filter(o => o.userId === user.id);
+  }, [offers, user, clubs]);
 
   const availablePlayers = useMemo(() => {
     return players
@@ -63,20 +52,15 @@ export default function MercadoTab() {
   };
 
   const handleMakeOffer = (player: Player) => {
-    toast.success(`Oferta enviada por ${player.name}`);
+    if (!marketStatus) {
+      toast.error('El mercado está cerrado');
+      return;
+    }
+    setSelectedPlayer(player);
   };
 
   const formatCurrency = (amount: number) => 
     new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(amount);
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'pending': return <Clock size={16} className="text-yellow-500" />;
-      case 'accepted': return <CheckCircle size={16} className="text-green-500" />;
-      case 'rejected': return <AlertCircle size={16} className="text-red-500" />;
-      default: return null;
-    }
-  };
 
   return (
     <div className="space-y-6">
@@ -146,7 +130,7 @@ export default function MercadoTab() {
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
-            Mis Ofertas ({mockOffers.length})
+            Mis Ofertas ({myOffers.length})
           </motion.button>
         </div>
       </motion.div>
@@ -217,37 +201,18 @@ export default function MercadoTab() {
             exit={{ opacity: 0 }}
             className="space-y-4"
           >
-            {mockOffers.map((offer, index) => (
-              <motion.div
-                key={offer.id}
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: index * 0.1 }}
-                className="bg-black/20 backdrop-blur-xl rounded-2xl p-6 border border-white/10"
-              >
-                <div className="flex items-center gap-4">
-                  <img 
-                    src={offer.player.image} 
-                    alt={offer.player.name}
-                    className="w-16 h-16 rounded-xl object-cover"
-                  />
-                  <div className="flex-1">
-                    <h3 className="font-bold text-lg">{offer.player.name}</h3>
-                    <p className="text-gray-400">{offer.club}</p>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-bold text-primary">{formatCurrency(offer.amount)}</p>
-                    <div className="flex items-center gap-2 mt-1">
-                      {getStatusIcon(offer.status)}
-                      <span className="text-sm capitalize">{offer.status}</span>
-                    </div>
-                  </div>
-                </div>
-              </motion.div>
-            ))}
+            <OffersPanel />
           </motion.div>
         )}
       </AnimatePresence>
+
+      {selectedPlayer && (
+        <OfferModal
+          player={selectedPlayer}
+          onClose={() => setSelectedPlayer(null)}
+          onOfferSent={() => setShowOffers(true)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -5,14 +5,16 @@ import { useDataStore } from '../../store/dataStore';
 import { Player } from '../../types/shared';
 import { makeOffer, getMinOfferAmount, getMaxOfferAmount } from '../../utils/transferService';
 import { formatCurrency } from '../../utils/helpers';
+import toast from 'react-hot-toast';
 import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface OfferModalProps {
   player: Player;
   onClose: () => void;
+  onOfferSent?: () => void;
 }
 
-const OfferModal = ({ player, onClose }: OfferModalProps) => {
+const OfferModal = ({ player, onClose, onOfferSent }: OfferModalProps) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
   const [offerAmount, setOfferAmount] = useState<number>(0);
@@ -92,6 +94,8 @@ const OfferModal = ({ player, onClose }: OfferModalProps) => {
       setError(result);
     } else {
       setSuccess(true);
+      toast.success('Oferta enviada');
+      if (onOfferSent) onOfferSent();
       setTimeout(() => {
         onClose();
       }, 1500);

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -312,9 +312,10 @@ const Market = () => {
       
       {/* Offer modal */}
       {selectedPlayer && (
-        <OfferModal 
-          player={selectedPlayer} 
-          onClose={() => setSelectedPlayer(null)} 
+        <OfferModal
+          player={selectedPlayer}
+          onClose={() => setSelectedPlayer(null)}
+          onOfferSent={() => setActiveTab('offers')}
         />
       )}
     </div>

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -7,10 +7,8 @@ import {
   deleteUser as persistDeleteUser
 } from '../utils/authService';
 import {
-  players as seedPlayers,
   tournaments,
   transfers,
-  offers,
   marketStatus,
   leagueStandings,
   newsItems,
@@ -28,6 +26,7 @@ import {
 } from '../data/mockData';
 import { getClubs, saveClubs } from '../utils/clubService';
 import { getPlayers, savePlayers } from '../utils/playerService';
+import { getOffers, saveOffers } from '../utils/offerService';
 import {
   Tournament,
   Transfer,
@@ -50,6 +49,7 @@ import { Club, Player, User } from '../types/shared';
 
 const initialClubs = getClubs();
 const initialPlayers = getPlayers();
+const initialOffers = getOffers();
 const initialUser = useAuthStore.getState().user;
 const baseClub = initialClubs.find(c => c.id === initialUser?.clubId) || initialClubs[0];
 const initialClub: DtClub = {
@@ -118,6 +118,7 @@ interface DataState {
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
   toggleTask: (id: string) => void;
+  setClubFromUser: (user: User | null) => void;
 }
 
 export const useDataStore = create<DataState>((set) => ({
@@ -125,7 +126,7 @@ export const useDataStore = create<DataState>((set) => ({
   players: initialPlayers,
   tournaments,
   transfers,
-  offers,
+  offers: initialOffers,
   standings: leagueStandings,
   newsItems,
   mediaItems,
@@ -144,7 +145,19 @@ export const useDataStore = create<DataState>((set) => ({
   dtRankings,
   users: getUsers(),
   
-  updateClubs: (newClubs) => set({ clubs: newClubs }),
+  updateClubs: (newClubs) =>
+    set((state) => {
+      saveClubs(newClubs);
+      const current = useAuthStore.getState().user;
+      let club = state.club;
+      if (current?.clubId) {
+        const updated = newClubs.find(c => c.id === current.clubId);
+        if (updated) {
+          club = { ...club, budget: updated.budget };
+        }
+      }
+      return { clubs: newClubs, club };
+    }),
   
   updatePlayers: (newPlayers) => {
     savePlayers(newPlayers);
@@ -161,7 +174,10 @@ export const useDataStore = create<DataState>((set) => ({
   
   updateTransfers: (newTransfers) => set({ transfers: newTransfers }),
   
-  updateOffers: (newOffers) => set({ offers: newOffers }),
+  updateOffers: (newOffers) => {
+    saveOffers(newOffers);
+    set({ offers: newOffers });
+  },
   
   updateMarketStatus: (status) =>
     set(() => {
@@ -176,15 +192,21 @@ export const useDataStore = create<DataState>((set) => ({
       return { marketStatus: status };
     }),
   
-  addOffer: (offer) => set((state) => ({
-    offers: [...state.offers, offer]
-  })),
+  addOffer: (offer) =>
+    set((state) => {
+      const updated = [...state.offers, offer];
+      saveOffers(updated);
+      return { offers: updated };
+    }),
   
-  updateOfferStatus: (offerId, status) => set((state) => ({
-    offers: state.offers.map(offer =>
-      offer.id === offerId ? { ...offer, status } : offer
-    )
-  })),
+  updateOfferStatus: (offerId, status) =>
+    set((state) => {
+      const updated = state.offers.map((offer) =>
+        offer.id === offerId ? { ...offer, status } : offer
+      );
+      saveOffers(updated);
+      return { offers: updated };
+    }),
 
   addTransfer: (transfer) => set((state) => ({
     transfers: [transfer, ...state.transfers]
@@ -312,6 +334,29 @@ export const useDataStore = create<DataState>((set) => ({
     newsItems: state.newsItems.filter(n => n.id !== id)
   })),
 
+  setClubFromUser: (user) =>
+    set((state) => {
+      if (!user?.clubId) return state;
+      const baseClub = state.clubs.find(c => c.id === user.clubId);
+      if (!baseClub) return state;
+      const club: DtClub = {
+        id: baseClub.id,
+        name: baseClub.name,
+        slug: baseClub.slug,
+        logo: baseClub.logo,
+        formation: '4-3-3',
+        budget: baseClub.budget,
+        players: refreshClubPlayers(state.players, baseClub.id)
+      };
+      const fixtures = state.tournaments[0].matches
+        .filter(
+          m => m.homeTeam === baseClub.name || m.awayTeam === baseClub.name
+        )
+        .slice(0, 6)
+        .map(m => ({ ...m, played: m.status === 'finished' }));
+      return { club, fixtures };
+    }),
+
   updateStandings: (newStandings) => set({ standings: newStandings }),
 
   toggleTask: (id) =>
@@ -321,4 +366,9 @@ export const useDataStore = create<DataState>((set) => ({
       )
     }))
 }));
+
+// Update DT club when authenticated user changes
+useAuthStore.subscribe(state => {
+  useDataStore.getState().setClubFromUser(state.user);
+});
  

--- a/src/utils/offerService.ts
+++ b/src/utils/offerService.ts
@@ -1,0 +1,22 @@
+export const VZ_OFFERS_KEY = 'vz_offers';
+
+import { TransferOffer } from '../types';
+import { offers as defaultOffers } from '../data/mockData';
+
+export const getOffers = (): TransferOffer[] => {
+  if (typeof localStorage === 'undefined') return defaultOffers as TransferOffer[];
+  const json = localStorage.getItem(VZ_OFFERS_KEY);
+  if (json) {
+    try {
+      return JSON.parse(json) as TransferOffer[];
+    } catch {
+      // ignore and fallback to defaults
+    }
+  }
+  return defaultOffers as TransferOffer[];
+};
+
+export const saveOffers = (data: TransferOffer[]): void => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(VZ_OFFERS_KEY, JSON.stringify(data));
+};

--- a/src/utils/transferService.ts
+++ b/src/utils/transferService.ts
@@ -72,7 +72,7 @@ export function makeOffer(params: MakeOfferParams): string | null {
   
   // Create new offer
   const newOffer: TransferOffer = {
-    id: `offer${offers.length + 1}`,
+    id: `offer${Date.now()}`,
     playerId,
     playerName,
     fromClub,


### PR DESCRIPTION
## Summary
- connect dashboard offer modal to show 'Mis Ofertas' after sending
- notify successful offers with a toast
- allow passing callback from `OfferModal`
- generate unique offer IDs using timestamps
- sync DT club budget whenever clubs data updates

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6865da41a43c83338f9582e5ebd5ac2e