### PR TITLE
Add missing transfer offer

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -647,6 +647,17 @@ export const offers: TransferOffer[] = [
     date: '2025-01-07',
     status: 'rejected',
     userId: 'user2'
+  },
+  {
+    id: 'offer4',
+    playerId: 'player52',
+    playerName: 'Martín Pérez',
+    fromClub: 'Real Madrid',
+    toClub: 'Defensores del Lag',
+    amount: 45000000,
+    date: '2025-01-08',
+    status: 'pending',
+    userId: 'user3'
   }
 ];
 


### PR DESCRIPTION
## Summary
- extend transfer offers with Real Madrid bid for Defensores del Lag

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865f02500c48333aac862be80f56f5a