### PR TITLE
Fix transfer offer orientation and add renegotiation

### DIFF
--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -57,6 +57,18 @@ const OffersPanel = () => {
       useDataStore.getState().updateOfferStatus(offerId, 'rejected');
     }
   };
+
+  // Handle renegotiate offer
+  const handleRenegotiate = (offer: TransferOffer) => {
+    const input = window.prompt('Nueva cantidad para la oferta', String(offer.amount));
+    if (!input) return;
+    const amount = Number(input);
+    if (isNaN(amount) || amount <= 0) {
+      setError('Cantidad inválida');
+      return;
+    }
+    useDataStore.getState().updateOfferAmount(offer.id, amount);
+  };
   
   // Check if user can respond to offer
   const canRespondToOffer = (offer: TransferOffer) => {
@@ -167,7 +179,13 @@ const OffersPanel = () => {
               
               {canRespondToOffer(offer) && (
                 <div className="flex space-x-3">
-                  <button 
+                  <button
+                    onClick={() => handleRenegotiate(offer)}
+                    className="btn-secondary text-sm flex-1"
+                  >
+                    Renegociar
+                  </button>
+                  <button
                     onClick={() => handleOfferAction(offer.id, 'accept')}
                     className="btn-primary text-sm flex-1"
                   >

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -647,6 +647,17 @@ export const offers: TransferOffer[] = [
     date: '2025-01-07',
     status: 'rejected',
     userId: 'user2'
+  },
+  {
+    id: 'offer4',
+    playerId: 'player52',
+    playerName: 'Martín Pérez',
+    fromClub: 'Defensores del Lag',
+    toClub: 'Real Madrid',
+    amount: 45000000,
+    date: '2025-01-08',
+    status: 'pending',
+    userId: 'user3'
   }
 ];
 

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -102,6 +102,7 @@ interface DataState {
   updateMarketStatus: (status: boolean) => void;
   addOffer: (offer: TransferOffer) => void;
   updateOfferStatus: (offerId: string, status: 'pending' | 'accepted' | 'rejected') => void;
+  updateOfferAmount: (offerId: string, amount: number) => void;
   addTransfer: (transfer: Transfer) => void;
   removeTransfer: (id: string) => void;
   addUser: (user: User) => void;
@@ -203,6 +204,15 @@ export const useDataStore = create<DataState>((set) => ({
     set((state) => {
       const updated = state.offers.map((offer) =>
         offer.id === offerId ? { ...offer, status } : offer
+      );
+      saveOffers(updated);
+      return { offers: updated };
+    }),
+
+  updateOfferAmount: (offerId, amount) =>
+    set((state) => {
+      const updated = state.offers.map((offer) =>
+        offer.id === offerId ? { ...offer, amount } : offer
       );
       saveOffers(updated);
       return { offers: updated };


### PR DESCRIPTION
## Summary
- correct Real Madrid offer direction so Defensores del Lag is selling club
- allow editing offer amount through new `updateOfferAmount`
- add "Renegociar" option in offers panel

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865f02500c48333aac862be80f56f5a