### PR TITLE
Fix offer merge logic

### DIFF
--- a/src/utils/offerService.ts
+++ b/src/utils/offerService.ts
@@ -3,6 +3,13 @@ export const VZ_OFFERS_KEY = 'vz_offers';
 import { TransferOffer } from '../types';
 import { offers as defaultOffers } from '../data/mockData';
 
+/**
+ * Load transfer offers from localStorage.
+ *
+ * Default offers act as the source of truth: any stored offer with the
+ * same `id` is updated with default data, while new default offers are
+ * appended. The resulting list is persisted back to localStorage.
+ */
 export const getOffers = (): TransferOffer[] => {
   if (typeof localStorage === 'undefined') {
     return defaultOffers as TransferOffer[];
@@ -10,23 +17,30 @@ export const getOffers = (): TransferOffer[] => {
 
   const json = localStorage.getItem(VZ_OFFERS_KEY);
   if (!json) {
+    saveOffers(defaultOffers as TransferOffer[]);
     return defaultOffers as TransferOffer[];
   }
 
   try {
     const stored = JSON.parse(json) as TransferOffer[];
 
-    // Merge with new default offers that may not exist in storage
+    // Default offers take precedence. Existing entries with the same id
+    // are updated to ensure new fields are not lost and new offers are added.
     const merged = [...stored];
     for (const offer of defaultOffers) {
-      if (!merged.find(o => o.id === offer.id)) {
+      const index = merged.findIndex(o => o.id === offer.id);
+      if (index !== -1) {
+        merged[index] = { ...merged[index], ...offer };
+      } else {
         merged.push(offer);
       }
     }
 
+    saveOffers(merged);
     return merged;
   } catch {
-    // ignore and fallback to defaults
+    // ignore errors and fallback to defaults
+    saveOffers(defaultOffers as TransferOffer[]);
     return defaultOffers as TransferOffer[];
   }
 };


### PR DESCRIPTION
## Summary
- ensure default offers overwrite stored entries with the same id
- persist merged offers list
- clarify merging behavior in comments

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686668639eb88333941a79b99a00f945