### PR TITLE
Fix offer filters in market components

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -22,7 +22,7 @@ export default function MercadoTab() {
     if (user.role === 'admin') return offers;
     if (user.role === 'dt' && user.club) {
       const userClub = clubs.find(c => c.name === user.club);
-      return userClub ? offers.filter(o => o.fromClub === userClub.name) : [];
+      return userClub ? offers.filter(o => o.toClub === userClub.name) : [];
     }
     return offers.filter(o => o.userId === user.id);
   }, [offers, user, clubs]);

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -22,7 +22,7 @@ const OffersPanel = () => {
     user.role === 'dt' && user.club ?
       offers.filter(o => {
         const userClub = clubs.find(c => c.name === user.club);
-        return userClub && o.fromClub === userClub.name;
+        return userClub && o.toClub === userClub.name;
       }) :
       offers.filter(o => o.userId === user.id) :
     [];
@@ -34,7 +34,7 @@ const OffersPanel = () => {
     user.role === 'dt' && user.club ?
       offers.filter(o => {
         const userClub = clubs.find(c => c.name === user.club);
-        return userClub && o.toClub === userClub.name;
+        return userClub && o.fromClub === userClub.name;
       }) :
       [] :
     [];

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -658,6 +658,17 @@ export const offers: TransferOffer[] = [
     date: '2025-01-08',
     status: 'pending',
     userId: 'user3'
+  },
+  {
+    id: 'offer5',
+    playerId: 'player10',
+    playerName: 'Miguel Delgado',
+    fromClub: 'Rayo Digital FC',
+    toClub: 'Glitchers 404',
+    amount: 5000000,
+    date: '2025-01-09',
+    status: 'pending',
+    userId: 'user2'
   }
 ];
 


### PR DESCRIPTION
## Summary
- correct sent/received offer filtering in `OffersPanel`
- update sent offer calculation for DTs in `MercadoTab`
- add sample received offer for **Glitchers 404**

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68667393e448833380c91a6a1550ebd8