### PR TITLE
Fix transfer offer user IDs

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -624,7 +624,7 @@ export const offers: TransferOffer[] = [
     amount: 9800000,
     date: '2025-01-05',
     status: 'pending',
-    userId: 'user2'
+    userId: '2'
   },
   {
     id: 'offer2',
@@ -635,7 +635,7 @@ export const offers: TransferOffer[] = [
     amount: 11500000,
     date: '2025-01-06',
     status: 'accepted',
-    userId: 'user2'
+    userId: '2'
   },
   {
     id: 'offer3',
@@ -646,7 +646,7 @@ export const offers: TransferOffer[] = [
     amount: 7800000,
     date: '2025-01-07',
     status: 'rejected',
-    userId: 'user2'
+    userId: '2'
   },
   {
     id: 'offer4',
@@ -657,7 +657,7 @@ export const offers: TransferOffer[] = [
     amount: 45000000,
     date: '2025-01-08',
     status: 'pending',
-    userId: 'user3'
+    userId: '3'
   },
   {
     id: 'offer5',
@@ -668,7 +668,7 @@ export const offers: TransferOffer[] = [
     amount: 5000000,
     date: '2025-01-09',
     status: 'pending',
-    userId: 'user2'
+    userId: '2'
   }
 ];
 


### PR DESCRIPTION
## Summary
- standardize `TransferOffer.userId` values

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm test` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6866849439508333b87d6ab28c137850