### PR TITLE
Fix PublicProfile club link slug

### DIFF
--- a/src/pages/PublicProfile.tsx
+++ b/src/pages/PublicProfile.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { getUserByUsername } from '../utils/userService';
 import { User } from '../types/shared';
+import { slugify } from '../utils/helpers';
 
 const PublicProfile = () => {
   const { username } = useParams<{ username: string }>();
@@ -39,7 +40,10 @@ const PublicProfile = () => {
         {user.club && (
           <p>
             Director Técnico de{' '}
-            <Link to={`/liga-master/club/${user.clubId}`} className="text-primary hover:text-primary-light">
+            <Link
+              to={`/liga-master/club/${slugify(user.club)}`}
+              className="text-primary hover:text-primary-light"
+            >
               {user.club}
             </Link>
           </p>


### PR DESCRIPTION
## Summary
- link clubs using slug on public profiles

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68669e7efa288333969b97eb14bbcf66