### PR TITLE
Move received offers into DT market tab

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -15,6 +15,7 @@ export default function MercadoTab() {
   const [positionFilter, setPositionFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'value' | 'overall' | 'age'>('value');
   const [showOffers, setShowOffers] = useState(false);
+  const [offersView, setOffersView] = useState<'sent' | 'received'>('sent');
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
   const sentOffers = useMemo(() => {
@@ -25,6 +26,16 @@ export default function MercadoTab() {
       return userClub ? offers.filter(o => o.toClub === userClub.name) : [];
     }
     return offers.filter(o => o.userId === user.id);
+  }, [offers, user, clubs]);
+
+  const receivedOffers = useMemo(() => {
+    if (!user) return [];
+    if (user.role === 'admin') return offers;
+    if (user.role === 'dt' && user.club) {
+      const userClub = clubs.find(c => c.name === user.club);
+      return userClub ? offers.filter(o => o.fromClub === userClub.name) : [];
+    }
+    return [];
   }, [offers, user, clubs]);
 
   const availablePlayers = useMemo(() => {
@@ -114,8 +125,8 @@ export default function MercadoTab() {
             whileTap={{ scale: 0.98 }}
             onClick={() => setShowOffers(false)}
             className={`px-6 py-3 rounded-xl font-medium transition-all ${
-              !showOffers 
-                ? 'bg-primary text-black' 
+              !showOffers
+                ? 'bg-primary text-black'
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
@@ -124,14 +135,32 @@ export default function MercadoTab() {
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            onClick={() => setShowOffers(true)}
+            onClick={() => {
+              setShowOffers(true);
+              setOffersView('sent');
+            }}
             className={`px-6 py-3 rounded-xl font-medium transition-all ${
-              showOffers 
-                ? 'bg-primary text-black' 
+              showOffers && offersView === 'sent'
+                ? 'bg-primary text-black'
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
             Mis Ofertas ({sentOffers.length})
+          </motion.button>
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => {
+              setShowOffers(true);
+              setOffersView('received');
+            }}
+            className={`px-6 py-3 rounded-xl font-medium transition-all ${
+              showOffers && offersView === 'received'
+                ? 'bg-primary text-black'
+                : 'bg-white/5 text-white/70 hover:bg-white/10'
+            }`}
+          >
+            Ofertas Recibidas ({receivedOffers.length})
           </motion.button>
         </div>
       </motion.div>
@@ -202,7 +231,7 @@ export default function MercadoTab() {
             exit={{ opacity: 0 }}
             className="space-y-4"
           >
-            <OffersPanel />
+            <OffersPanel initialView={offersView} />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';
@@ -7,10 +7,19 @@ import { TransferOffer } from '../../types';
 import { formatCurrency, formatDate, getStatusBadge } from '../../utils/helpers';
 import Card from '../common/Card';
 
-const OffersPanel = () => {
+interface OffersPanelProps {
+  initialView?: 'sent' | 'received';
+}
+
+const OffersPanel = ({ initialView = 'sent' }: OffersPanelProps) => {
   const [expandedOffers, setExpandedOffers] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
-  const [view, setView] = useState<'sent' | 'received'>('sent');
+  const [view, setView] = useState<'sent' | 'received'>(initialView);
+
+  // Update view if parent changes the initial view
+  useEffect(() => {
+    setView(initialView);
+  }, [initialView]);
   
   const { user } = useAuthStore();
   const { offers, clubs } = useDataStore();


### PR DESCRIPTION
## Summary
- allow OffersPanel to receive an initialView
- show buttons for sent and received offers in DT Mercado tab
- display the selected offers view when opening the offers panel

## Testing
- `npm test` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866a2a9c53c8333b415cc20877d48e6