### PR TITLE
Show received offers inside DT market

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -15,6 +15,7 @@ export default function MercadoTab() {
   const [positionFilter, setPositionFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'value' | 'overall' | 'age'>('value');
   const [showOffers, setShowOffers] = useState(false);
+  const [offersView, setOffersView] = useState<'sent' | 'received'>('sent');
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
   const sentOffers = useMemo(() => {
@@ -26,6 +27,17 @@ export default function MercadoTab() {
     }
     return offers.filter(o => o.userId === user.id);
   }, [offers, user, clubs]);
+
+  const receivedOffers = useMemo(() => {
+    if (!user) return [];
+    if (user.role === 'admin') return offers;
+    if (user.role === 'dt' && user.club) {
+      const userClub = clubs.find(c => c.name === user.club);
+      return userClub ? offers.filter(o => o.fromClub === userClub.name) : [];
+    }
+    return [];
+  }, [offers, user, clubs]);
+
 
   const availablePlayers = useMemo(() => {
     return players
@@ -114,8 +126,8 @@ export default function MercadoTab() {
             whileTap={{ scale: 0.98 }}
             onClick={() => setShowOffers(false)}
             className={`px-6 py-3 rounded-xl font-medium transition-all ${
-              !showOffers 
-                ? 'bg-primary text-black' 
+              !showOffers
+                ? 'bg-primary text-black'
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
@@ -124,14 +136,32 @@ export default function MercadoTab() {
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            onClick={() => setShowOffers(true)}
+            onClick={() => {
+              setOffersView('sent');
+              setShowOffers(true);
+            }}
             className={`px-6 py-3 rounded-xl font-medium transition-all ${
-              showOffers 
-                ? 'bg-primary text-black' 
+              showOffers && offersView === 'sent'
+                ? 'bg-primary text-black'
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
             Mis Ofertas ({sentOffers.length})
+          </motion.button>
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => {
+              setOffersView('received');
+              setShowOffers(true);
+            }}
+            className={`px-6 py-3 rounded-xl font-medium transition-all ${
+              showOffers && offersView === 'received'
+                ? 'bg-primary text-black'
+                : 'bg-white/5 text-white/70 hover:bg-white/10'
+            }`}
+          >
+            Ofertas Recibidas ({receivedOffers.length})
           </motion.button>
         </div>
       </motion.div>
@@ -202,7 +232,7 @@ export default function MercadoTab() {
             exit={{ opacity: 0 }}
             className="space-y-4"
           >
-            <OffersPanel />
+            <OffersPanel initialView={offersView} />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -7,10 +7,14 @@ import { TransferOffer } from '../../types';
 import { formatCurrency, formatDate, getStatusBadge } from '../../utils/helpers';
 import Card from '../common/Card';
 
-const OffersPanel = () => {
+interface OffersPanelProps {
+  initialView?: 'sent' | 'received';
+}
+
+const OffersPanel = ({ initialView = 'sent' }: OffersPanelProps) => {
   const [expandedOffers, setExpandedOffers] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
-  const [view, setView] = useState<'sent' | 'received'>('sent');
+  const [view, setView] = useState<'sent' | 'received'>(initialView);
   
   const { user } = useAuthStore();
   const { offers, clubs } = useDataStore();


### PR DESCRIPTION
## Summary
- allow OffersPanel to accept an initial view
- compute received offers in `MercadoTab` and provide buttons for sent and received offers
- pass the selected view to the OffersPanel

## Testing
- `npm test` *(fails: ESLint dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866a2a9c53c8333b415cc20877d48e6