### PR TITLE
Show received offers inside DT market

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -15,6 +15,7 @@ export default function MercadoTab() {
   const [positionFilter, setPositionFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'value' | 'overall' | 'age'>('value');
   const [showOffers, setShowOffers] = useState(false);
+  const [offersView, setOffersView] = useState<'sent' | 'received'>('sent');
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
   const sentOffers = useMemo(() => {
@@ -26,6 +27,17 @@ export default function MercadoTab() {
     }
     return offers.filter(o => o.userId === user.id);
   }, [offers, user, clubs]);
+
+  const receivedOffers = useMemo(() => {
+    if (!user) return [];
+    if (user.role === 'admin') return offers;
+    if (user.role === 'dt' && user.club) {
+      const userClub = clubs.find(c => c.name === user.club);
+      return userClub ? offers.filter(o => o.fromClub === userClub.name) : [];
+    }
+    return [];
+  }, [offers, user, clubs]);
+
 
   const availablePlayers = useMemo(() => {
     return players
@@ -114,8 +126,8 @@ export default function MercadoTab() {
             whileTap={{ scale: 0.98 }}
             onClick={() => setShowOffers(false)}
             className={`px-6 py-3 rounded-xl font-medium transition-all ${
-              !showOffers 
-                ? 'bg-primary text-black' 
+              !showOffers
+                ? 'bg-primary text-black'
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
@@ -124,14 +136,32 @@ export default function MercadoTab() {
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            onClick={() => setShowOffers(true)}
+            onClick={() => {
+              setOffersView('sent');
+              setShowOffers(true);
+            }}
             className={`px-6 py-3 rounded-xl font-medium transition-all ${
-              showOffers 
-                ? 'bg-primary text-black' 
+              showOffers && offersView === 'sent'
+                ? 'bg-primary text-black'
                 : 'bg-white/5 text-white/70 hover:bg-white/10'
             }`}
           >
             Mis Ofertas ({sentOffers.length})
+          </motion.button>
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => {
+              setOffersView('received');
+              setShowOffers(true);
+            }}
+            className={`px-6 py-3 rounded-xl font-medium transition-all ${
+              showOffers && offersView === 'received'
+                ? 'bg-primary text-black'
+                : 'bg-white/5 text-white/70 hover:bg-white/10'
+            }`}
+          >
+            Ofertas Recibidas ({receivedOffers.length})
           </motion.button>
         </div>
       </motion.div>
@@ -202,7 +232,7 @@ export default function MercadoTab() {
             exit={{ opacity: 0 }}
             className="space-y-4"
           >
-            <OffersPanel />
+            <OffersPanel initialView={offersView} />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -6,11 +6,17 @@ import { processTransfer } from '../../utils/transferService';
 import { TransferOffer } from '../../types';
 import { formatCurrency, formatDate, getStatusBadge } from '../../utils/helpers';
 import Card from '../common/Card';
+import RenegotiateModal from './RenegotiateModal';
 
-const OffersPanel = () => {
+interface OffersPanelProps {
+  initialView?: 'sent' | 'received';
+}
+
+const OffersPanel = ({ initialView = 'sent' }: OffersPanelProps) => {
   const [expandedOffers, setExpandedOffers] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
-  const [view, setView] = useState<'sent' | 'received'>('sent');
+  const [view, setView] = useState<'sent' | 'received'>(initialView);
+  const [renegotiateOffer, setRenegotiateOffer] = useState<TransferOffer | null>(null);
   
   const { user } = useAuthStore();
   const { offers, clubs } = useDataStore();
@@ -72,14 +78,7 @@ const OffersPanel = () => {
 
   // Handle renegotiate offer
   const handleRenegotiate = (offer: TransferOffer) => {
-    const input = window.prompt('Nueva cantidad para la oferta', String(offer.amount));
-    if (!input) return;
-    const amount = Number(input);
-    if (isNaN(amount) || amount <= 0) {
-      setError('Cantidad inválida');
-      return;
-    }
-    useDataStore.getState().updateOfferAmount(offer.id, amount);
+    setRenegotiateOffer(offer);
   };
   
   // Check if user can respond to offer
@@ -239,6 +238,12 @@ const OffersPanel = () => {
           )}
         </Card>
       ))}
+      {renegotiateOffer && (
+        <RenegotiateModal
+          offer={renegotiateOffer}
+          onClose={() => setRenegotiateOffer(null)}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/market/RenegotiateModal.tsx
+++ b/src/components/market/RenegotiateModal.tsx
@@ -1,0 +1,69 @@
+import { useState, useRef } from 'react';
+import { X } from 'lucide-react';
+import { useDataStore } from '../../store/dataStore';
+import { TransferOffer } from '../../types';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import { formatCurrency } from '../../utils/helpers';
+
+interface Props {
+  offer: TransferOffer;
+  onClose: () => void;
+}
+
+const RenegotiateModal = ({ offer, onClose }: Props) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
+  const [amount, setAmount] = useState<number>(offer.amount);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    useDataStore.getState().updateOfferAmount(offer.id, amount);
+    setSent(true);
+    setTimeout(onClose, 1500);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div
+        className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="renegotiate-title"
+        ref={dialogRef}
+      >
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        {sent ? (
+          <div className="text-center">
+            <p className="font-semibold mb-2">Oferta actualizada</p>
+            <p className="text-sm text-gray-400">El club comprador revisará la nueva propuesta.</p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <h3 id="renegotiate-title" className="text-xl font-bold">Renegociar Oferta</h3>
+            <p className="text-sm text-gray-400">
+              Oferta de {offer.toClub} por <span className="text-primary">{offer.playerName}</span>
+            </p>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Nueva cantidad</label>
+              <input
+                type="number"
+                className="input w-full"
+                value={amount}
+                min={1}
+                onChange={(e) => setAmount(Number(e.target.value))}
+              />
+              <p className="text-xs text-gray-500 mt-1">Actual: {formatCurrency(offer.amount)}</p>
+            </div>
+            <button type="submit" className="btn-primary w-full">Enviar</button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RenegotiateModal;


### PR DESCRIPTION
## Summary
- allow OffersPanel to accept an initial view
- compute received offers in `MercadoTab` and provide buttons for sent and received offers
- pass the selected view to the OffersPanel
- introduce a RenegotiateModal so DTs can counter offers directly in the UI

## Testing
- `npm test` *(fails: ESLint dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866a2a9c53c8333b415cc20877d48e6