### PR TITLE
Fix received offers filter

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -30,9 +30,7 @@ export default function MercadoTab() {
   const receivedOffers = useMemo(() => {
     if (!user || user.role !== 'dt' || !user.club) return [];
     const userClub = clubs.find(c => c.name === user.club);
-    return userClub
-      ? offers.filter(o => o.fromClub === userClub.name)
-      : [];
+    return userClub ? offers.filter(o => o.toClub === userClub.name) : [];
   }, [offers, user, clubs]);
 
 

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -47,13 +47,7 @@ const OffersPanel = ({ initialView = 'sent' }: OffersPanelProps) => {
       : user.role === 'dt' && user.club
         ? offers.filter(o => {
             const userClub = clubs.find(c => c.name === user.club);
-            const player = players.find(p => p.id === o.playerId);
-            return (
-              userClub &&
-              player &&
-              player.clubId === userClub.id &&
-              o.fromClub === userClub.name
-            );
+            return userClub && o.toClub === userClub.name;
           })
         : []
     : [];

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -49,7 +49,7 @@ export default function DtDashboard() {
   useEffect(() => {
     if (!club) return;
     const incoming = offers.filter(
-      (o) => o.fromClub === club.name && o.status === 'pending'
+      (o) => o.toClub === club.name && o.status === 'pending'
     );
     const newOnes = incoming.filter((o) => !prevOffersRef.current.has(o.id));
     if (newOnes.length > 0) {


### PR DESCRIPTION
## Summary
- fix received offers filter in MercadoTab
- update OffersPanel to show offers where the current club is the recipient
- trigger notifications only for offers directed to the user's club

## Testing
- `npm run test` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866c2fad2a88333b3114c3cfdbf83c2