### PR TITLE
Fix offers panel data flow

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -48,6 +48,8 @@ export default function MercadoTab() {
     return userClub ? offers.filter(o => o.toClub === userClub.name) : [];
   }, [offers, userClub, user]);
 
+  console.log('MercadoTab receivedOffers:', receivedOffers);
+
 
   const availablePlayers = useMemo(() => {
     return players
@@ -231,7 +233,11 @@ export default function MercadoTab() {
             exit={{ opacity: 0 }}
             className="space-y-4"
           >
-            <OffersPanel initialView="sent" />
+            <OffersPanel
+              initialView="sent"
+              sentOffers={sentOffers}
+              receivedOffers={receivedOffers}
+            />
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- pass sent and received offers to `OffersPanel`
- ensure correct offer filtering in panel
- add logging for received offers
- display 'No hay ofertas' messages depending on view

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866caeafe9c8333885f90cf15afe484