### PR TITLE
Implement offer actions for received offers

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -45,7 +45,8 @@ export default function MercadoTab() {
 
   const receivedOffers = useMemo(() => {
     if (!user || user.role !== 'dt') return [];
-    return userClub ? offers.filter(o => o.toClub === userClub.name) : [];
+    // Offers for players from my club
+    return userClub ? offers.filter(o => o.fromClub === userClub.name) : [];
   }, [offers, userClub, user]);
 
   console.log('MercadoTab receivedOffers:', receivedOffers);

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -53,7 +53,8 @@ const OffersPanel = ({
       : user.role === 'dt' && user.club
         ? offers.filter(o => {
             const userClub = clubs.find(c => c.name === user.club);
-            return userClub && o.toClub === userClub.name;
+            // Offers where my club is selling
+            return userClub && o.fromClub === userClub.name;
           })
         : []
     : [];
@@ -283,19 +284,19 @@ const OffersPanel = ({
                 <div className="flex space-x-3">
                   <button
                     onClick={() => handleRenegotiate(offer)}
-                    className="btn-secondary text-sm flex-1"
+                    className="text-sm flex-1 rounded-lg bg-orange-500 hover:bg-orange-600 text-white py-2"
                   >
                     Renegociar
                   </button>
                   <button
                     onClick={() => setConfirmAction({ offer, action: 'accept' })}
-                    className="btn-primary text-sm flex-1"
+                    className="text-sm flex-1 rounded-lg bg-green-600 hover:bg-green-700 text-white py-2"
                   >
                     Aceptar
                   </button>
                   <button
                     onClick={() => setConfirmAction({ offer, action: 'reject' })}
-                    className="btn-secondary text-sm flex-1"
+                    className="text-sm flex-1 rounded-lg bg-red-600 hover:bg-red-700 text-white py-2"
                   >
                     Rechazar
                   </button>


### PR DESCRIPTION
## Summary
- fix list of received offers to use `fromClub`
- filter received offers in OffersPanel by seller club
- style accept/renegotiate/reject buttons and show when pending

## Testing
- `npm run lint` *(fails: ESLint module issues)*
- `npm run test:unit` *(fails: localStorage and module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866cfec697c8333af5b2437d235ac8a