### PR TITLE
sync tournaments between admin and site

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -1,38 +1,19 @@
-import  React, { useState } from 'react';
+import React, { useState } from 'react';
 import { Trophy, Calendar, Users, MapPin, Plus, Edit, Trash2, Eye, Search, Filter } from 'lucide-react';
 import { Tournament } from '../../types';
+import { useDataStore } from '../../../store/dataStore';
 import SearchFilter from './SearchFilter';
 import StatsCard from './StatsCard';
 import NewTournamentModal from './NewTournamentModal';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
 
 const TournamentsAdminPanel = () => {
-  const [tournaments, setTournaments] = useState<Tournament[]>([
-    {
-      id: '1',
-      name: 'Liga Master 2024',
-      format: 'league',
-      status: 'active',
-      startDate: '2024-01-15',
-      endDate: '2024-06-30',
-      maxTeams: 20,
-      currentTeams: 18,
-      prizePool: 500000,
-      location: 'España'
-    },
-    {
-      id: '2',
-      name: 'Copa Elite',
-      format: 'knockout',
-      status: 'upcoming',
-      startDate: '2024-07-01',
-      endDate: '2024-07-31',
-      maxTeams: 32,
-      currentTeams: 24,
-      prizePool: 250000,
-      location: 'Internacional'
-    }
-  ]);
+  const {
+    tournaments,
+    addTournament,
+    updateTournamentEntry,
+    removeTournament
+  } = useDataStore();
 
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -247,7 +228,7 @@ const TournamentsAdminPanel = () => {
               currentTeams: 0,
               ...data
             } as Tournament;
-            setTournaments([...tournaments, newTournament]);
+            addTournament(newTournament);
             setShowNewModal(false);
           }}
         />
@@ -258,9 +239,7 @@ const TournamentsAdminPanel = () => {
           tournament={editingTournament}
           onClose={() => setEditingTournament(null)}
           onSave={(data) => {
-            setTournaments(tournaments.map(t => 
-              t.id === editingTournament.id ? { ...t, ...data } : t
-            ));
+            updateTournamentEntry({ ...editingTournament, ...data });
             setEditingTournament(null);
           }}
         />
@@ -271,7 +250,7 @@ const TournamentsAdminPanel = () => {
           isOpen={true}
           onClose={() => setDeletingTournament(null)}
           onConfirm={() => {
-            setTournaments(tournaments.filter(t => t.id !== deletingTournament.id));
+            removeTournament(deletingTournament.id);
             setDeletingTournament(null);
           }}
           title="Eliminar Torneo"

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -56,6 +56,9 @@ interface GlobalStore {
   removeMatch: (id: string) => void;
 
   // Tournaments
+  addTournament: (t: Tournament) => void;
+  updateTournament: (t: Tournament) => void;
+  removeTournament: (id: string) => void;
   updateTournamentStatus: (id: string, status: Tournament['status']) => void;
   
   // Transfers
@@ -403,6 +406,26 @@ export const useGlobalStore = create<GlobalStore>()(
 
     removeMatch: id => {
       set(state => ({ matches: state.matches.filter(m => m.id !== id) }));
+      persist();
+    },
+
+    addTournament: t => {
+      set(state => ({ tournaments: [...state.tournaments, t] }));
+      useDataStore.getState().addTournament(t);
+      persist();
+    },
+
+    updateTournament: t => {
+      set(state => ({
+        tournaments: state.tournaments.map(tt => (tt.id === t.id ? t : tt))
+      }));
+      useDataStore.getState().updateTournamentEntry(t);
+      persist();
+    },
+
+    removeTournament: id => {
+      set(state => ({ tournaments: state.tournaments.filter(t => t.id !== id) }));
+      useDataStore.getState().removeTournament(id);
       persist();
     },
 

--- a/src/utils/tournamentService.ts
+++ b/src/utils/tournamentService.ts
@@ -1,0 +1,27 @@
+import { Tournament } from '../types';
+import { tournaments as defaultTournaments } from '../data/mockData';
+
+const VZ_TOURNAMENTS_KEY = 'vz_tournaments';
+
+export const getTournaments = (): Tournament[] => {
+  if (typeof localStorage === 'undefined') {
+    return defaultTournaments as Tournament[];
+  }
+  const json = localStorage.getItem(VZ_TOURNAMENTS_KEY);
+  if (json) {
+    try {
+      return JSON.parse(json) as Tournament[];
+    } catch {
+      // ignore parse errors
+    }
+  }
+  localStorage.setItem(VZ_TOURNAMENTS_KEY, JSON.stringify(defaultTournaments));
+  return defaultTournaments as Tournament[];
+};
+
+export const saveTournaments = (data: Tournament[]): void => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(VZ_TOURNAMENTS_KEY, JSON.stringify(data));
+};
+
+export { VZ_TOURNAMENTS_KEY };


### PR DESCRIPTION
## Summary
- centralize tournaments data in `useDataStore`
- persist tournaments with a new service
- update admin store to modify global tournaments
- load tournaments from the shared store in the admin panel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686702f60c008333b4fc1470a44abf01