### PR TITLE
Fix tournament start date display

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -50,6 +50,13 @@ const TournamentsAdminPanel = () => {
     return format === 'league' ? Trophy : Users;
   };
 
+  const formatStartDate = (date: unknown): React.ReactNode => {
+    if (typeof date === 'string' && !isNaN(new Date(date).getTime())) {
+      return new Date(date).toLocaleString();
+    }
+    return <span className="text-red-400">Fecha no definida</span>;
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
@@ -157,13 +164,7 @@ const TournamentsAdminPanel = () => {
                       Fecha Inicio
                     </div>
                     <div className="text-white font-medium">
-                      {tournament.startDate ? (
-                        new Date(tournament.startDate).toLocaleString()
-                      ) : (
-                        <span className="bg-red-500/20 text-red-400 px-2 py-1 rounded">
-                          Fecha no definida
-                        </span>
-                      )}
+                      {formatStartDate(tournament.startDate)}
                     </div>
                   </div>
                   <div className="bg-gray-800/50 rounded-lg p-3">


### PR DESCRIPTION
## Summary
- add `formatStartDate` helper in TournamentsAdminPanel
- use the helper when rendering each tournament to avoid TypeError if the date is invalid

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867090a4c1c833398d8845c24cbd3c0