### PR TITLE
Fix admin tournaments panel

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Trophy, Calendar, Users, MapPin, Plus, Edit, Trash2, Eye, Search, Filter } from 'lucide-react';
 import { Tournament } from '../../types';
-import { useDataStore } from '../../../store/dataStore';
+import { useGlobalStore } from '../../store/globalStore';
 import SearchFilter from './SearchFilter';
 import StatsCard from './StatsCard';
 import NewTournamentModal from './NewTournamentModal';
@@ -11,9 +11,9 @@ const TournamentsAdminPanel = () => {
   const {
     tournaments,
     addTournament,
-    updateTournamentEntry,
+    updateTournament,
     removeTournament
-  } = useDataStore();
+  } = useGlobalStore();
 
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -255,7 +255,7 @@ const TournamentsAdminPanel = () => {
           tournament={editingTournament}
           onClose={() => setEditingTournament(null)}
           onSave={(data) => {
-            updateTournamentEntry({ ...editingTournament, ...data });
+            updateTournament({ ...editingTournament, ...data });
             setEditingTournament(null);
           }}
         />


### PR DESCRIPTION
## Summary
- connect `TournamentsAdminPanel` to `useGlobalStore` so tournament actions work

## Testing
- `npm run test` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68670cf088dc8333a9a741d9abf0dff3