### PR TITLE
Fix tournaments list filtering

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -25,17 +25,15 @@ const TournamentsAdminPanel = () => {
     console.warn('Se encontraron torneos sin fecha de inicio definida');
   }
 
-  const validTournaments = tournaments.filter(t => t.startDate != null);
-
-  const filteredTournaments = validTournaments.filter(tournament => {
+  const filteredTournaments = tournaments.filter(tournament => {
     const matchesSearch = tournament.name.toLowerCase().includes(search.toLowerCase());
     const matchesStatus = statusFilter === 'all' || tournament.status === statusFilter;
     return matchesSearch && matchesStatus;
   });
 
-  const activeTournaments = validTournaments.filter(t => t.status === 'active').length;
-  const totalPrizePool = validTournaments.reduce((sum, t) => sum + t.prizePool, 0);
-  const totalTeams = validTournaments.reduce((sum, t) => sum + t.currentTeams, 0);
+  const activeTournaments = tournaments.filter(t => t.status === 'active').length;
+  const totalPrizePool = tournaments.reduce((sum, t) => sum + (t.prizePool ?? 0), 0);
+  const totalTeams = tournaments.reduce((sum, t) => sum + (t.currentTeams ?? 0), 0);
 
   const getStatusColor = (status: string) => {
     switch (status) {


### PR DESCRIPTION
## Summary
- include tournaments without a start date in admin panel listing

## Testing
- `npm test` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68670e7be9548333a188ffc7e4969c3b