### PR TITLE
Fix password route imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,8 @@ const Register = lazy(() => import("./pages/Register"));
 const UserPanel = lazy(() => import("./pages/UserPanel"));
 const Users = lazy(() => import("./pages/Users"));
 const PublicProfile = lazy(() => import("./pages/PublicProfile"));
-const RecoverPassword = lazy(() => import("./pages/RecoverPassword"));
-const ResetPassword = lazy(() => import("./pages/ResetPassword"));
+const RecuperarContrasena = lazy(() => import("./pages/RecuperarContrasena"));
+const DefinirContrasena = lazy(() => import("./pages/DefinirContrasena"));
 const Terms = lazy(() => import("./pages/Terms"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 
@@ -55,8 +55,8 @@ function App() {
 
             <Route path="login" element={<Login />} />
             <Route path="registro" element={<Register />} />
-            <Route path="recuperar-password" element={<RecoverPassword />} />
-            <Route path="reset/:token" element={<ResetPassword />} />
+            <Route path="recuperar-password" element={<RecuperarContrasena />} />
+            <Route path="reset/:token" element={<DefinirContrasena />} />
             <Route path="terminos" element={<Terms />} />
             <Route path="privacidad" element={<Privacy />} />
             <Route path="usuarios" element={<Users />} />

--- a/src/pages/DefinirContrasena.tsx
+++ b/src/pages/DefinirContrasena.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AlertCircle, Lock } from 'lucide-react';
+import { resetPassword } from '../utils/authService';
+import { z } from 'zod';
+
+const schema = z
+  .object({
+    password: z.string().min(6, 'La contraseña debe tener al menos 6 caracteres'),
+    confirm: z.string()
+  })
+  .refine(data => data.password === data.confirm, {
+    message: 'Las contraseñas no coinciden',
+    path: ['confirm']
+  });
+
+const DefinirContrasena = () => {
+  const { token } = useParams();
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState({ password: '', confirm: '' });
+  const [errors, setErrors] = useState<{ password?: string; confirm?: string }>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = schema.safeParse(form);
+    if (!result.success) {
+      const fieldErrors: { password?: string; confirm?: string } = {};
+      result.error.issues.forEach(issue => {
+        const key = issue.path[0] as 'password' | 'confirm';
+        fieldErrors[key] = issue.message;
+      });
+      setErrors(fieldErrors);
+      return;
+    }
+    if (!token) {
+      setError('Token inválido');
+      return;
+    }
+    const ok = resetPassword(token, form.password);
+    if (ok) {
+      navigate('/login');
+    } else {
+      setError('Token inválido o expirado');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4 py-20">
+      <div className="w-full max-w-md">
+        <div className="card border border-gray-800">
+          <div className="p-6 md:p-8">
+            <div className="text-center mb-8">
+              <h2 className="text-2xl font-bold">Restablecer Contraseña</h2>
+              <p className="text-gray-400 mt-1">Ingresa tu nueva contraseña</p>
+            </div>
+            {error && (
+              <div className="mb-6 p-3 bg-red-500/20 text-red-400 rounded-lg flex items-start">
+                <AlertCircle size={18} className="mr-2 mt-0.5 flex-shrink-0" />
+                <p>{error}</p>
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1">Nueva contraseña</label>
+                <input
+                  type="password"
+                  className="input w-full"
+                  value={form.password}
+                  onChange={e => setForm({ ...form, password: e.target.value })}
+                />
+                {errors.password && <p className="text-red-400 text-sm mt-1">{errors.password}</p>}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1">Confirmar contraseña</label>
+                <input
+                  type="password"
+                  className="input w-full"
+                  value={form.confirm}
+                  onChange={e => setForm({ ...form, confirm: e.target.value })}
+                />
+                {errors.confirm && <p className="text-red-400 text-sm mt-1">{errors.confirm}</p>}
+              </div>
+              <div>
+                <button type="submit" className="btn-primary w-full flex justify-center items-center">
+                  <Lock size={18} className="mr-2" />Restablecer
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DefinirContrasena;


### PR DESCRIPTION
## Summary
- rename RecoverPassword lazy import to RecuperarContrasena
- rename ResetPassword lazy import to DefinirContrasena
- add missing DefinirContrasena page

## Testing
- `npm run test` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867259fdbe083339f0a609dc24439d0