### PR TITLE
Fix Admin panel details button

### DIFF
--- a/src/adminPanel/components/admin/TournamentDetailsModal.tsx
+++ b/src/adminPanel/components/admin/TournamentDetailsModal.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+import { Tournament } from '../../types';
+
+interface Props {
+  tournament: Tournament;
+  onClose: () => void;
+}
+
+const TournamentDetailsModal = ({ tournament, onClose }: Props) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    modalRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div
+        ref={modalRef}
+        className="bg-gray-800 p-6 rounded-lg max-w-md w-full mx-4"
+        tabIndex={-1}
+      >
+        <h3 className="text-lg font-semibold mb-4">Detalles del Torneo</h3>
+        <div className="space-y-2 text-sm">
+          <p>
+            <span className="text-gray-400">Nombre: </span>
+            <span className="text-white">{tournament.name}</span>
+          </p>
+          <p>
+            <span className="text-gray-400">Estado: </span>
+            <span className="text-white capitalize">{tournament.status}</span>
+          </p>
+          <p>
+            <span className="text-gray-400">Formato: </span>
+            <span className="text-white capitalize">
+              {tournament.format === 'league' ? 'Liga' : 'Eliminación'}
+            </span>
+          </p>
+          <p>
+            <span className="text-gray-400">Inicio: </span>
+            <span className="text-white">
+              {new Date(tournament.startDate).toLocaleDateString()}
+            </span>
+          </p>
+          <p>
+            <span className="text-gray-400">Fin: </span>
+            <span className="text-white">
+              {new Date(tournament.endDate).toLocaleDateString()}
+            </span>
+          </p>
+          <p>
+            <span className="text-gray-400">Equipos: </span>
+            <span className="text-white">
+              {tournament.currentTeams}/{tournament.maxTeams}
+            </span>
+          </p>
+          <p>
+            <span className="text-gray-400">Premio: </span>
+            <span className="text-white">
+              €{tournament.prizePool.toLocaleString()}
+            </span>
+          </p>
+          <p>
+            <span className="text-gray-400">Ubicación: </span>
+            <span className="text-white">{tournament.location}</span>
+          </p>
+        </div>
+        <div className="flex justify-end mt-6">
+          <button type="button" onClick={onClose} className="btn-primary">
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TournamentDetailsModal;

--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -1,10 +1,20 @@
 import  React, { useState } from 'react';
-import { Trophy, Calendar, Users, MapPin, Plus, Edit, Trash2, Eye, Search, Filter } from 'lucide-react';
+import {
+  Trophy,
+  Calendar,
+  Users,
+  MapPin,
+  Plus,
+  Edit,
+  Trash2,
+  Eye,
+} from 'lucide-react';
 import { Tournament } from '../../types';
 import SearchFilter from './SearchFilter';
 import StatsCard from './StatsCard';
 import NewTournamentModal from './NewTournamentModal';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
+import TournamentDetailsModal from './TournamentDetailsModal';
 
 const TournamentsAdminPanel = () => {
   const [tournaments, setTournaments] = useState<Tournament[]>([
@@ -39,6 +49,7 @@ const TournamentsAdminPanel = () => {
   const [showNewModal, setShowNewModal] = useState(false);
   const [editingTournament, setEditingTournament] = useState<Tournament | null>(null);
   const [deletingTournament, setDeletingTournament] = useState<Tournament | null>(null);
+  const [viewingTournament, setViewingTournament] = useState<Tournament | null>(null);
 
   const filteredTournaments = tournaments.filter(tournament => {
     const matchesSearch = tournament.name.toLowerCase().includes(search.toLowerCase());
@@ -219,7 +230,10 @@ const TournamentsAdminPanel = () => {
                   <span className="text-sm text-gray-400 capitalize">
                     Formato: {tournament.format === 'league' ? 'Liga' : 'Eliminación'}
                   </span>
-                  <button className="btn-outline text-sm flex items-center space-x-2">
+                  <button
+                    onClick={() => setViewingTournament(tournament)}
+                    className="btn-outline text-sm flex items-center space-x-2"
+                  >
                     <Eye size={16} />
                     <span>Ver Detalles</span>
                   </button>
@@ -276,6 +290,13 @@ const TournamentsAdminPanel = () => {
           }}
           title="Eliminar Torneo"
           message={`¿Estás seguro de que quieres eliminar "${deletingTournament.name}"? Esta acción no se puede deshacer.`}
+        />
+      )}
+
+      {viewingTournament && (
+        <TournamentDetailsModal
+          tournament={viewingTournament}
+          onClose={() => setViewingTournament(null)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add `TournamentDetailsModal` component for tournament info
- wire up 'Ver Detalles' button to open the modal

## Testing
- `npm test` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68672ea4136c8333b6c5ea771e4bead4