### PR TITLE
Integrate supabase auth

### DIFF
--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Session } from '@supabase/supabase-js';
+import { supabase } from '../supabaseClient';
+
+export default function useSession() {
+  const navigate = useNavigate();
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (!data.session) {
+        navigate('/login');
+      }
+      setSession(data.session);
+    });
+
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange((_event, sess) => {
+      if (!sess) {
+        navigate('/login');
+      }
+      setSession(sess);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [navigate]);
+
+  return session;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,21 +1,20 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { LogIn, AlertCircle } from 'lucide-react';
-import { useAuthStore } from '../store/authStore';
+import { supabase } from '../supabaseClient';
 
 const Login = () => {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  
+
   const navigate = useNavigate();
-  const { login } = useAuthStore();
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!username || !password) {
+    if (!email || !password) {
       setError('Por favor, completa todos los campos');
       return;
     }
@@ -24,7 +23,14 @@ const Login = () => {
     setIsLoading(true);
     
     try {
-      await login(username, password);
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email,
+        password
+      });
+      if (signInError) {
+        setError(signInError.message);
+        return;
+      }
       navigate('/usuario');
     } catch (err) {
       if (err instanceof Error) {
@@ -59,13 +65,13 @@ const Login = () => {
             <form onSubmit={handleSubmit} className="space-y-6">
               <div>
                 <label className="block text-sm font-medium text-gray-300 mb-1">
-                  Nombre de usuario
+                  Correo electrónico
                 </label>
                 <input
-                  type="text"
+                  type="email"
                   className="input w-full"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
                 />
               </div>
               
@@ -114,9 +120,9 @@ const Login = () => {
             <div className="mt-8 pt-6 border-t border-gray-800">
               <div className="text-xs text-gray-500 text-center">
                 <p>Para pruebas, puedes usar:</p>
-                <p className="mt-1">Usuario: <span className="text-primary">usuario</span> / Contraseña: <span className="text-primary">password</span></p>
-                <p className="mt-1">DT: <span className="text-primary">entrenador</span> / Contraseña: <span className="text-primary">password</span></p>
-                <p className="mt-1">Admin: <span className="text-primary">admin</span> / Contraseña: <span className="text-primary">password</span></p>
+                <p className="mt-1">Email: <span className="text-primary">usuario@test.com</span> / Contraseña: <span className="text-primary">password</span></p>
+                <p className="mt-1">DT: <span className="text-primary">dt@test.com</span> / Contraseña: <span className="text-primary">password</span></p>
+                <p className="mt-1">Admin: <span className="text-primary">admin@virtualzone.com</span> / Contraseña: <span className="text-primary">password</span></p>
               </div>
             </div>
           </div>

--- a/src/pages/RecuperarContrasena.tsx
+++ b/src/pages/RecuperarContrasena.tsx
@@ -1,6 +1,7 @@
 import  { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Mail, ArrowLeft, Check, AlertCircle, Shield, Lock } from 'lucide-react';
+import { supabase } from '../supabaseClient';
 
 export default function RecuperarContrasena() {
   const [email, setEmail] = useState('');
@@ -24,11 +25,20 @@ export default function RecuperarContrasena() {
     }
 
     setIsLoading(true);
-    
-    setTimeout(() => {
-      setIsLoading(false);
+
+    try {
+      const { error: resetError } = await supabase.auth.resetPasswordForEmail(
+        email
+      );
+      if (resetError) {
+        setError(resetError.message);
+        setIsLoading(false);
+        return;
+      }
       setIsSubmitted(true);
-    }, 2000);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   if (isSubmitted) {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { User, AlertCircle } from 'lucide-react';
-import { useAuthStore } from '../store/authStore';
+import { supabase } from '../supabaseClient';
 
 const Register = () => {
   const [username, setUsername] = useState('');
@@ -12,7 +12,6 @@ const Register = () => {
   const [isLoading, setIsLoading] = useState(false);
   
   const navigate = useNavigate();
-  const { register } = useAuthStore();
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,7 +43,17 @@ const Register = () => {
     setIsLoading(true);
     
     try {
-      await register(email, username, password);
+      const { error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: { username }
+        }
+      });
+      if (signUpError) {
+        setError(signUpError.message);
+        return;
+      }
       navigate('/usuario');
     } catch (err) {
       if (err instanceof Error) {


### PR DESCRIPTION
## Summary
- update Login page to sign in with Supabase
- update Register page to sign up with Supabase
- use Supabase in password recovery pages
- add `useSession` hook to verify the current session

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68684b4c78e08333950242d60c0c5185