### PR TITLE
Implement realtime data hooks

### DIFF
--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -1,16 +1,24 @@
 import { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Search, Star } from 'lucide-react';
-import { useDataStore } from '../../store/dataStore';
 import { useAuthStore } from '../../store/authStore';
+import { useDataStore } from '../../store/dataStore';
 import { Player } from '../../types/shared';
+import useJugadores from '../../hooks/useJugadores';
+import useOfertas from '../../hooks/useOfertas';
+import useClubes from '../../hooks/useClubes';
 import toast from 'react-hot-toast';
 import OffersPanel from '../market/OffersPanel';
 import OfferModal from '../market/OfferModal';
+import Spinner from '../Spinner';
 
 export default function MercadoTab() {
   const { user } = useAuthStore();
-  const { players, club, clubs, offers, marketStatus } = useDataStore();
+  const { club, marketStatus } = useDataStore();
+  const { jugadores: players, loading: loadingPlayers } = useJugadores();
+  const { ofertas: offers, loading: loadingOfertas } = useOfertas();
+  const { clubes: clubs, loading: loadingClubes } = useClubes();
+  const loading = loadingPlayers || loadingOfertas || loadingClubes;
   const [search, setSearch] = useState('');
   const [positionFilter, setPositionFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'value' | 'overall' | 'age'>('value');
@@ -85,8 +93,13 @@ export default function MercadoTab() {
     setSelectedPlayer(player);
   };
 
-  const formatCurrency = (amount: number) => 
-    new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(amount);
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('es-ES', {
+      style: 'currency',
+      currency: 'EUR'
+    }).format(amount);
+
+  if (loading) return <Spinner />;
 
   return (
     <div className="space-y-6">

--- a/src/hooks/useJugadores.ts
+++ b/src/hooks/useJugadores.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../supabaseClient';
+import { Player } from '../types/shared';
+
+export default function useJugadores() {
+  const [jugadores, setJugadores] = useState<Player[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const fetchJugadores = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase.from('jugadores').select('*').order('id');
+    if (!error && data) {
+      setJugadores(data as Player[]);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchJugadores();
+    const channel = supabase
+      .channel('public:jugadores')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'jugadores' },
+        () => fetchJugadores()
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [fetchJugadores]);
+
+  return { jugadores, loading, refresh: fetchJugadores };
+}

--- a/src/hooks/useOfertas.ts
+++ b/src/hooks/useOfertas.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../supabaseClient';
+import { TransferOffer } from '../types';
+
+export default function useOfertas() {
+  const [ofertas, setOfertas] = useState<TransferOffer[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const fetchOfertas = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase.from('ofertas').select('*').order('id');
+    if (!error && data) {
+      setOfertas(data as TransferOffer[]);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchOfertas();
+    const channel = supabase
+      .channel('public:ofertas')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'ofertas' },
+        () => fetchOfertas()
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [fetchOfertas]);
+
+  return { ofertas, loading, refresh: fetchOfertas };
+}

--- a/src/hooks/useTorneos.ts
+++ b/src/hooks/useTorneos.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../supabaseClient';
+import { Tournament } from '../types';
+
+export default function useTorneos() {
+  const [torneos, setTorneos] = useState<Tournament[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const fetchTorneos = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase.from('torneos').select('*').order('id');
+    if (!error && data) {
+      setTorneos(data as Tournament[]);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchTorneos();
+    const channel = supabase
+      .channel('public:torneos')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'torneos' },
+        () => fetchTorneos()
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [fetchTorneos]);
+
+  return { torneos, loading, refresh: fetchTorneos };
+}

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -1,9 +1,12 @@
 import  { useState, useMemo, useRef, Suspense, lazy, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import    { Users, Target, DollarSign, Calendar as CalendarIcon, ShoppingBag, List, Play, TrendingUp, Award, Settings, Bell } from 'lucide-react';   
+import    { Users, Target, DollarSign, Calendar as CalendarIcon, ShoppingBag, List, Play, TrendingUp, Award, Settings, Bell } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
-import { useDataStore } from '../store/dataStore';
+import useClubes from '../hooks/useClubes';
+import useTorneos from '../hooks/useTorneos';
+import useOfertas from '../hooks/useOfertas';
 import toast, { Toaster } from 'react-hot-toast';
+import Spinner from '../components/Spinner';
 
 const   PlantillaTab = lazy(() => import('../components/dt-dashboard/PlantillaTab'));
 const TacticasTab = lazy(() => import('../components/dt-dashboard/TacticasTab'));
@@ -27,7 +30,10 @@ const    tabs = [
 
 export default function DtDashboard() {
   const { user } = useAuthStore();
-  const { clubs, tournaments, offers } = useDataStore();
+  const { clubes: clubs, loading: loadingClubes } = useClubes();
+  const { torneos: tournaments, loading: loadingTorneos } = useTorneos();
+  const { ofertas: offers, loading: loadingOfertas } = useOfertas();
+  const loading = loadingClubes || loadingTorneos || loadingOfertas;
   const club = useMemo(
     () => clubs.find(c => c.id === user?.clubId),
     [clubs, user?.clubId]
@@ -74,6 +80,14 @@ export default function DtDashboard() {
     setActiveTab(tab);
     toast.dismiss();
   };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (!user) {
     return (

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -1,19 +1,27 @@
 import { Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, Calendar, Users, ChevronRight, Filter } from 'lucide-react';
-import { useDataStore } from '../store/dataStore';
+import useTorneos from '../hooks/useTorneos';
+import Spinner from '../components/Spinner';
 import usePersistentState from '../hooks/usePersistentState';
 
 const Tournaments = () => {
-  const [filter, setFilter] = usePersistentState<'all' | 'ongoing' | 'open' | 'finished'>('tournaments_filter', 'all');
+  const [filter, setFilter] =
+    usePersistentState<'all' | 'ongoing' | 'open' | 'finished'>(
+      'tournaments_filter',
+      'all'
+    );
 
-  const { tournaments } = useDataStore();
+  const { torneos: tournaments, loading } = useTorneos();
   
   // Filter tournaments
-  const filteredTournaments = filter === 'all' 
-    ? tournaments 
-    : tournaments.filter(tournament => tournament.status === filter);
-  
+  const filteredTournaments =
+    filter === 'all'
+      ? tournaments
+      : tournaments.filter(tournament => tournament.status === filter);
+
+  if (loading) return <Spinner />;
+
   return (
     <div>
       <PageHeader 


### PR DESCRIPTION
## Summary
- add `useJugadores`, `useTorneos` and `useOfertas` hooks with realtime updates
- switch `Tournaments` page to new hook and show spinner
- update market and dashboard pages to use the new hooks

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68684b4cc2bc83339179c475a43621b8