### PR TITLE
Update Supabase channels to refresh hooks

### DIFF
--- a/src/hooks/useClubes.ts
+++ b/src/hooks/useClubes.ts
@@ -21,7 +21,17 @@ export default function useClubes() {
       .channel('public:clubes')
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'clubes' },
+        { event: 'INSERT', schema: 'public', table: 'clubes' },
+        () => fetchClubes()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'clubes' },
+        () => fetchClubes()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'clubes' },
         () => fetchClubes()
       )
       .subscribe();

--- a/src/hooks/useFixtures.ts
+++ b/src/hooks/useFixtures.ts
@@ -21,7 +21,17 @@ export default function useFixtures() {
       .channel('public:fixtures')
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'fixtures' },
+        { event: 'INSERT', schema: 'public', table: 'fixtures' },
+        () => fetchFixtures()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'fixtures' },
+        () => fetchFixtures()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'fixtures' },
         () => fetchFixtures()
       )
       .subscribe();

--- a/src/hooks/useJugadores.ts
+++ b/src/hooks/useJugadores.ts
@@ -21,7 +21,17 @@ export default function useJugadores() {
       .channel('public:jugadores')
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'jugadores' },
+        { event: 'INSERT', schema: 'public', table: 'jugadores' },
+        () => fetchJugadores()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'jugadores' },
+        () => fetchJugadores()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'jugadores' },
         () => fetchJugadores()
       )
       .subscribe();

--- a/src/hooks/useOfertas.ts
+++ b/src/hooks/useOfertas.ts
@@ -21,7 +21,17 @@ export default function useOfertas() {
       .channel('public:ofertas')
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'ofertas' },
+        { event: 'INSERT', schema: 'public', table: 'ofertas' },
+        () => fetchOfertas()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'ofertas' },
+        () => fetchOfertas()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'ofertas' },
         () => fetchOfertas()
       )
       .subscribe();

--- a/src/hooks/useTorneos.ts
+++ b/src/hooks/useTorneos.ts
@@ -21,7 +21,17 @@ export default function useTorneos() {
       .channel('public:torneos')
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'torneos' },
+        { event: 'INSERT', schema: 'public', table: 'torneos' },
+        () => fetchTorneos()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'torneos' },
+        () => fetchTorneos()
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'torneos' },
         () => fetchTorneos()
       )
       .subscribe();


### PR DESCRIPTION
## Summary
- listen to table-specific events in data fetching hooks

## Testing
- `npm test` *(fails: Cannot find package '@nestjs/testing' & reference errors)*

------
https://chatgpt.com/codex/tasks/task_e_68686847155883338463437e4da2b978