### PR TITLE
Implement useJugadores hook and update pages

### DIFF
--- a/src/components/dt-dashboard/FinanzasTab.tsx
+++ b/src/components/dt-dashboard/FinanzasTab.tsx
@@ -2,11 +2,13 @@ import  { motion } from 'framer-motion';
 import { DollarSign, TrendingUp, TrendingDown, Target, Users, Trophy } from 'lucide-react';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, BarChart, Bar } from 'recharts';
 import { useDataStore } from '../../store/dataStore';
+import useJugadores from '../../hooks/useJugadores';
 
 const formatCurrency= (amount: number) => `€${amount.toLocaleString()}`;
 
 export default function FinanzasTab() {
-  const { club, players } = useDataStore();
+  const { club } = useDataStore();
+  const { jugadores: players } = useJugadores();
 
   const clubPlayers = players.filter(p => p.clubId === club?.id);
   const totalSalaries = clubPlayers.reduce((sum, p) => sum + (p.contract?.salary || 0), 0);

--- a/src/components/dt-dashboard/PlantillaTab.tsx
+++ b/src/components/dt-dashboard/PlantillaTab.tsx
@@ -2,10 +2,12 @@ import  { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { Search, Filter, Star, TrendingUp, Clock, DollarSign } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
+import useJugadores from '../../hooks/useJugadores';
 import { Player } from '../../types/shared';
 
 export default function PlantillaTab() {
-  const { club, players } = useDataStore();
+  const { club } = useDataStore();
+  const { jugadores: players } = useJugadores();
   const [search, setSearch] = useState('');
   const [selectedPosition, setSelectedPosition] = useState('all');
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);

--- a/src/components/dt-dashboard/TacticasTab.tsx
+++ b/src/components/dt-dashboard/TacticasTab.tsx
@@ -2,6 +2,7 @@ import  { useState, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { RotateCcw, Save, Settings } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
+import useJugadores from '../../hooks/useJugadores';
 import { Player } from '../../types/shared';
 
 const formations = [
@@ -26,7 +27,8 @@ const formations = [
 ];
 
 export default function TacticasTab() {
-  const { club, players } = useDataStore();
+  const { club } = useDataStore();
+  const { jugadores: players } = useJugadores();
   const [selectedFormation, setSelectedFormation] = useState(formations[0]);
   const [playerPositions, setPlayerPositions] = useState(selectedFormation.positions);
   const [selectedPlayers, setSelectedPlayers] = useState<Player[]>([]);

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useDataStore } from '../../store/dataStore';
+import useJugadores from '../../hooks/useJugadores';
 import { processTransfer } from '../../utils/transferService';
 import { TransferOffer } from '../../types';
 import { formatCurrency, formatDate, getStatusBadge } from '../../utils/helpers';
@@ -32,7 +33,8 @@ const OffersPanel = ({
   const MIN_SQUAD_SIZE = 18;
   
   const { user } = useAuthStore();
-  const { offers, clubs, players } = useDataStore();
+  const { offers, clubs } = useDataStore();
+  const { jugadores: players } = useJugadores();
   
   // Offers sent by the current user/club
   const storeSentOffers = user ?
@@ -86,8 +88,8 @@ const OffersPanel = ({
   const handleOfferAction = (offerId: string, action: 'accept' | 'reject') => {
     setError(null);
 
-    const { offers: allOffers, clubs: allClubs, players: allPlayers } =
-      useDataStore.getState();
+    const { offers: allOffers, clubs: allClubs } = useDataStore.getState();
+    const allPlayers = players;
     const offer = allOffers.find(o => o.id === offerId);
     if (!offer) return;
 

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -12,13 +12,15 @@ import {
 import PageHeader from '../components/common/PageHeader';
 import StatsCard from '../components/common/StatsCard';
 import { useDataStore } from '../store/dataStore';
+import useJugadores from '../hooks/useJugadores';
 import { formatDate, formatCurrency, getMatchResult } from '../utils/helpers';
 
 const ClubProfile = () => {
   const { clubName } = useParams<{ clubName: string }>();
   const [activeTab, setActiveTab] = useState('overview');
   
-  const { clubs, players, tournaments } = useDataStore();
+  const { clubs, tournaments } = useDataStore();
+  const { jugadores: players } = useJugadores();
   
   // Find club by slug
   const club = clubs.find(c => c.slug === clubName);

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from 'react-router-dom';
 import { Shield, ChevronLeft, Users, Database, ArrowDown, ArrowUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
+import useJugadores from '../hooks/useJugadores';
 import { formatCurrency, getOverallColor } from '../utils/helpers';
 import { useState } from 'react';
 
@@ -10,7 +11,8 @@ const ClubSquad = () => {
   const [sortBy, setSortBy] = useState('overall');
   const [sortOrder, setSortOrder] = useState('desc');
 
-  const { clubs, players } = useDataStore();
+  const { clubs } = useDataStore();
+  const { jugadores: players } = useJugadores();
   
   // Find club by slug
   const club = clubId

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -17,12 +17,14 @@ import ClubListItem from '../components/common/ClubListItem';
 import DashboardSkeleton from '../components/common/DashboardSkeleton';
 import { useDataStore } from '../store/dataStore';
 import useClubes from '../hooks/useClubes';
+import useJugadores from '../hooks/useJugadores';
 import { formatDate, formatCurrency } from '../utils/helpers';
 
 const LigaMaster = () => {
   const { user } = useAuthStore();
   const { clubes, loading } = useClubes();
-  const { tournaments, players, standings, marketStatus } = useDataStore();
+  const { tournaments, standings, marketStatus } = useDataStore();
+  const { jugadores: players } = useJugadores();
 
   if (user?.role === 'dt') {
     if (user.clubId) {

--- a/src/pages/Plantilla.tsx
+++ b/src/pages/Plantilla.tsx
@@ -4,6 +4,7 @@ import ResumenClub from '../components/plantilla/ResumenClub';
 import PlayerTable from '../components/plantilla/PlayerTable';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
+import useJugadores from '../hooks/useJugadores';
 import { Player as FullPlayer } from '../types/shared';
 
 const PlayerDrawer = lazy(() => import('../components/plantilla/PlayerDrawer'));
@@ -22,7 +23,8 @@ interface TablePlayer {
 
 const Plantilla = () => {
   const { user } = useAuthStore();
-  const { clubs, players: allPlayers, updatePlayerEntry } = useDataStore();
+  const { clubs, updatePlayerEntry } = useDataStore();
+  const { jugadores: allPlayers } = useJugadores();
   const club = clubs.find(c => c.id === user?.clubId);
   const currentYear = new Date().getFullYear();
   const players: TablePlayer[] = allPlayers

--- a/src/pages/Rankings.tsx
+++ b/src/pages/Rankings.tsx
@@ -3,12 +3,14 @@ import { Link } from 'react-router-dom';
 import { ChevronLeft } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
+import useJugadores from '../hooks/useJugadores';
 
 const Rankings = () => {
   const [activeTab, setActiveTab] = useState('clubs');
   const [season, setSeason] = useState('2025');
   
-  const { clubs, players, standings } = useDataStore();
+  const { clubs, standings } = useDataStore();
+  const { jugadores: players } = useJugadores();
   
   // Get top scorers
   const topScorers = [...players]


### PR DESCRIPTION
## Summary
- add realtime `useJugadores` hook to get players from Supabase
- use new hook across pages and dashboard components

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868684372108333820fd429a74ae88f