### PR TITLE
Add Supabase image uploads

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id            Int            @id @default(autoincrement())
   email         String         @unique
   username      String         @unique
+  avatar        String?
   password      String
   role          Role           @default(USER)
   clubs         Club[]
@@ -21,6 +22,7 @@ model User {
 model Club {
   id        Int      @id @default(autoincrement())
   name      String
+  logo      String?
   manager   User?    @relation(fields: [managerId], references: [id])
   managerId Int?
   players   Player[]

--- a/src/adminPanel/components/admin/EditClubModal.tsx
+++ b/src/adminPanel/components/admin/EditClubModal.tsx
@@ -23,6 +23,7 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
     secondaryColor: club.secondaryColor,
     description: club.description
   });
+  const [logoFile, setLogoFile] = useState<File | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const users = useGlobalStore(state => state.users);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -50,11 +51,21 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      const logo = formData.logo ||
-        `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=111827&color=fff&size=128&bold=true`;
+      let logo = formData.logo;
+      if (logoFile) {
+        try {
+          const { uploadImage } = await import('../../../lib/uploadImage');
+          logo = await uploadImage(logoFile, 'logos');
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      if (!logo) {
+        logo = `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=111827&color=fff&size=128&bold=true`;
+      }
       onSave({ ...club, ...formData, logo, slug: slugify(formData.name) });
     }
   };
@@ -134,6 +145,13 @@ const EditClubModal = ({ club, onClose, onSave }: Props) => {
               placeholder="Descripción"
               value={formData.description}
               onChange={e => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Logo</label>
+            <input
+              type="file"
+              onChange={e => setLogoFile(e.target.files ? e.target.files[0] : null)}
             />
           </div>
           <div className="flex space-x-2">

--- a/src/adminPanel/components/admin/EditUserModal.tsx
+++ b/src/adminPanel/components/admin/EditUserModal.tsx
@@ -14,6 +14,7 @@ const EditUserModal = ({ user, onClose, onSave }: Props) => {
     role: user.role,
     status: user.status
   });
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -35,10 +36,19 @@ const EditUserModal = ({ user, onClose, onSave }: Props) => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave({ ...user, ...formData });
+      let avatar = user.avatar;
+      if (avatarFile) {
+        try {
+          const { uploadImage } = await import('../../../lib/uploadImage');
+          avatar = await uploadImage(avatarFile, 'avatars');
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      onSave({ ...user, ...formData, avatar });
     }
   };
 
@@ -87,6 +97,13 @@ const EditUserModal = ({ user, onClose, onSave }: Props) => {
             <option value="active">Activo</option>
             <option value="inactive">Inactivo</option>
           </select>
+          <div>
+            <label className="block text-sm font-medium mb-1">Avatar</label>
+            <input
+              type="file"
+              onChange={e => setAvatarFile(e.target.files ? e.target.files[0] : null)}
+            />
+          </div>
           <div className="flex space-x-3 justify-end mt-6">
             <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>
             <button type="submit" className="btn-primary">Guardar</button>

--- a/src/adminPanel/components/admin/NewClubModal.tsx
+++ b/src/adminPanel/components/admin/NewClubModal.tsx
@@ -22,6 +22,7 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
     secondaryColor: '#000000',
     description: ''
   });
+  const [logoFile, setLogoFile] = useState<File | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const users = useGlobalStore(state => state.users);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -49,11 +50,21 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      const logo = formData.logo ||
-        `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=111827&color=fff&size=128&bold=true`;
+      let logo = formData.logo;
+      if (logoFile) {
+        try {
+          const { uploadImage } = await import('../../../lib/uploadImage');
+          logo = await uploadImage(logoFile, 'logos');
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      if (!logo) {
+        logo = `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.name)}&background=111827&color=fff&size=128&bold=true`;
+      }
       onSave({ ...formData, logo, slug: slugify(formData.name) });
     }
   };
@@ -133,6 +144,13 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
               placeholder="Descripción"
               value={formData.description}
               onChange={e => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Logo</label>
+            <input
+              type="file"
+              onChange={e => setLogoFile(e.target.files ? e.target.files[0] : null)}
             />
           </div>
           <div className="flex space-x-2">

--- a/src/adminPanel/components/admin/NewUserModal.tsx
+++ b/src/adminPanel/components/admin/NewUserModal.tsx
@@ -12,6 +12,7 @@ const NewUserModal = ({ onClose, onSave }: Props) => {
     email: '',
     role: 'user' as User['role']
   });
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -33,10 +34,19 @@ const NewUserModal = ({ onClose, onSave }: Props) => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (validate()) {
-      onSave(formData);
+      let avatar: string | undefined;
+      if (avatarFile) {
+        try {
+          const { uploadImage } = await import('../../../lib/uploadImage');
+          avatar = await uploadImage(avatarFile, 'avatars');
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      onSave({ ...formData, avatar });
     }
   };
 
@@ -77,6 +87,13 @@ const NewUserModal = ({ onClose, onSave }: Props) => {
             <option value="dt">DT</option>
             <option value="admin">Admin</option>
           </select>
+          <div>
+            <label className="block text-sm font-medium mb-1">Avatar</label>
+            <input
+              type="file"
+              onChange={e => setAvatarFile(e.target.files ? e.target.files[0] : null)}
+            />
+          </div>
           <div className="flex space-x-3 justify-end mt-6">
             <button type="button" onClick={onClose} className="btn-outline">Cancelar</button>
             <button type="submit" className="btn-primary">Crear</button>

--- a/src/adminPanel/pages/admin/Usuarios.tsx
+++ b/src/adminPanel/pages/admin/Usuarios.tsx
@@ -39,6 +39,9 @@ const Usuarios = () => {
       username: userData.username || '',
       email: userData.email || '',
       role: userData.role || 'user',
+      avatar:
+        userData.avatar ||
+        `https://ui-avatars.com/api/?name=${encodeURIComponent(userData.username || '')}&background=111827&color=fff&size=128&bold=true`,
       status: 'active',
       createdAt: new Date().toISOString()
     };

--- a/src/lib/uploadImage.ts
+++ b/src/lib/uploadImage.ts
@@ -1,0 +1,25 @@
+import { supabase } from '../supabaseClient';
+
+/**
+ * Upload a file to Supabase Storage and return the public URL.
+ * @param file File object to upload
+ * @param bucket Name of the storage bucket
+ * @returns public URL of the uploaded file
+ */
+export const uploadImage = async (
+  file: File | Blob,
+  bucket: string
+): Promise<string> => {
+  const ext = file instanceof File && file.name.includes('.')
+    ? file.name.split('.').pop()!
+    : 'png';
+  const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+  const { error } = await supabase.storage
+    .from(bucket)
+    .upload(fileName, file, { upsert: false });
+  if (error) {
+    throw error;
+  }
+  const { data } = supabase.storage.from(bucket).getPublicUrl(fileName);
+  return data.publicUrl;
+};


### PR DESCRIPTION
## Summary
- add `uploadImage` helper for Supabase Storage
- allow uploading club logos and user avatars in admin modals
- save uploaded URLs when creating users/clubs
- extend Prisma schema with `avatar` and `logo` fields

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68686847884c8333bd14205fc93d5199