### PR TITLE
Switch auth checks to Supabase session

### DIFF
--- a/src/adminPanel/App.tsx
+++ b/src/adminPanel/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import useSession from '../hooks/useSession';
 import SidebarAdmin from './components/SidebarAdmin';
 
 const Dashboard = lazy(() => import('./pages/admin/Dashboard'));
@@ -17,11 +18,8 @@ const Estadisticas = lazy(() => import('./pages/admin/Estadisticas'));
 const Calendario = lazy(() => import('./pages/admin/Calendario'));
 
 const AdminLayout = () => {
-  const { user, isAuthenticated } = useAuth();
-
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
+  useSession();
+  const { user } = useAuth();
 
   if (user?.role !== 'admin') {
     return (

--- a/src/adminPanel/components/SidebarAdmin.tsx
+++ b/src/adminPanel/components/SidebarAdmin.tsx
@@ -1,22 +1,15 @@
 import  { useState, useEffect } from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { Menu, X, Home, Users, Globe, User, ShoppingBag, Award, FileText, MessageCircle, Activity, BarChart, Calendar } from 'lucide-react';
 import { useGlobalStore } from '../store/globalStore';
-import { useAuth } from '../contexts/AuthContext';
+import useSession from '../../hooks/useSession';
 
 const SidebarAdmin = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { transfers } = useGlobalStore();
-  const { isAuthenticated } = useAuth();
-  const navigate = useNavigate();
+  useSession();
 
   const pendingTransfers = transfers.filter(t => t.status === 'pending').length;
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate('/login', { replace: true });
-    }
-  }, [isAuthenticated, navigate]);
 
   const menuItems = [
     { name: 'Dashboard', href: '/admin', icon: Home },

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -1,20 +1,13 @@
 import  { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell } from 'recharts';
 import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target } from 'lucide-react'; 
-import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../../contexts/AuthContext';
+import useSession from '../../../hooks/useSession';
 import { useGlobalStore } from '../../store/globalStore';
 
 const Dashboard = () => {
   const { users, clubs, players, transfers, activities } = useGlobalStore();
-  const { isAuthenticated } = useAuth();
+  useSession();
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate('/login', { replace: true });
-    }
-  }, [isAuthenticated, navigate]);
 
   const kpiData = [
     { name: 'Ene', users: 4, revenue: 2400 },

--- a/src/pages/DtDashboard.tsx
+++ b/src/pages/DtDashboard.tsx
@@ -2,6 +2,7 @@ import  { useState, useMemo, useRef, Suspense, lazy, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import    { Users, Target, DollarSign, Calendar as CalendarIcon, ShoppingBag, List, Play, Bell } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
+import useSession from '../hooks/useSession';
 import useClubes from '../hooks/useClubes';
 import useTorneos from '../hooks/useTorneos';
 import useOfertas from '../hooks/useOfertas';
@@ -29,6 +30,7 @@ const    tabs = [
 ];   
 
 export default function DtDashboard() {
+  useSession();
   const { user } = useAuthStore();
   const { clubes: clubs, loading: loadingClubes } = useClubes();
   const { torneos: tournaments, loading: loadingTorneos } = useTorneos();

--- a/src/pages/UserPanel.tsx
+++ b/src/pages/UserPanel.tsx
@@ -1,5 +1,5 @@
 import   { useState, useEffect, useRef } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { 
   User, 
   Settings, 
@@ -13,11 +13,13 @@ import {
   
 } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
+import useSession from '../hooks/useSession';
 import { useDataStore } from '../store/dataStore';
 import { xpForNextLevel } from '../utils/helpers';
 
 const UserPanel = () => {
-  const { user, isAuthenticated, logout } = useAuthStore();
+  useSession();
+  const { user, logout } = useAuthStore();
   const { clubs } = useDataStore();
   const navigate = useNavigate();
   
@@ -52,10 +54,7 @@ const UserPanel = () => {
   // Initialize achievements array if it doesn't exist
   const achievements = user?.achievements || [];
 
-  // If not authenticated, redirect to login
-  if (!isAuthenticated || !user) {
-    return <Navigate to="/login" />;
-  }
+
   
   return (
     <div className="container mx-auto px-4 py-8 pt-24">


### PR DESCRIPTION
## Summary
- use `useSession` hook in pages that need login
- remove old local storage checks

## Testing
- `npm test` *(fails: localStorage not defined and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68686845d5f88333b8b7e87846761320