### PR TITLE
Switch auth to Supabase

### DIFF
--- a/src/pages/DefinirContrasena.tsx
+++ b/src/pages/DefinirContrasena.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertCircle, Lock } from 'lucide-react';
-import { supabase } from '../supabaseClient';
+import { resetPassword } from '../utils/authService';
 import { z } from 'zod';
 
 const schema = z
@@ -34,13 +34,7 @@ const DefinirContrasena = () => {
       return;
     }
     try {
-      const { error: updateError } = await supabase.auth.updateUser({
-        password: form.password
-      });
-      if (updateError) {
-        setError(updateError.message);
-        return;
-      }
+      await resetPassword(form.password);
       navigate('/login');
     } catch (err) {
       if (err instanceof Error) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { LogIn, AlertCircle } from 'lucide-react';
-import { supabase } from '../supabaseClient';
+import { useAuthStore } from '../store/authStore';
 
 const Login = () => {
   const [email, setEmail] = useState('');
@@ -10,6 +10,7 @@ const Login = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   const navigate = useNavigate();
+  const { login } = useAuthStore();
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -23,14 +24,7 @@ const Login = () => {
     setIsLoading(true);
     
     try {
-      const { error: signInError } = await supabase.auth.signInWithPassword({
-        email,
-        password
-      });
-      if (signInError) {
-        setError(signInError.message);
-        return;
-      }
+      await login(email, password);
       navigate('/usuario');
     } catch (err) {
       if (err instanceof Error) {

--- a/src/pages/RecuperarContrasena.tsx
+++ b/src/pages/RecuperarContrasena.tsx
@@ -1,7 +1,7 @@
 import  { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Mail, ArrowLeft, Check, AlertCircle, Shield, Lock } from 'lucide-react';
-import { supabase } from '../supabaseClient';
+import { requestPasswordReset } from '../utils/authService';
 
 export default function RecuperarContrasena() {
   const [email, setEmail] = useState('');
@@ -27,14 +27,7 @@ export default function RecuperarContrasena() {
     setIsLoading(true);
 
     try {
-      const { error: resetError } = await supabase.auth.resetPasswordForEmail(
-        email
-      );
-      if (resetError) {
-        setError(resetError.message);
-        setIsLoading(false);
-        return;
-      }
+      await requestPasswordReset(email);
       setIsSubmitted(true);
     } finally {
       setIsLoading(false);

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { User, AlertCircle } from 'lucide-react';
-import { supabase } from '../supabaseClient';
+import { useAuthStore } from '../store/authStore';
 
 const Register = () => {
   const [username, setUsername] = useState('');
@@ -12,6 +12,7 @@ const Register = () => {
   const [isLoading, setIsLoading] = useState(false);
   
   const navigate = useNavigate();
+  const { register } = useAuthStore();
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,17 +44,7 @@ const Register = () => {
     setIsLoading(true);
     
     try {
-      const { error: signUpError } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: { username }
-        }
-      });
-      if (signUpError) {
-        setError(signUpError.message);
-        return;
-      }
+      await register(email, username, password);
       navigate('/usuario');
     } catch (err) {
       if (err instanceof Error) {


### PR DESCRIPTION
## Summary
- use Supabase auth API in `authService`
- delegate authentication in `authStore` to Supabase
- update login and registration pages to call the store
- use Supabase helpers for password reset pages

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68686844d4e08333bbd150eea2057cfd