### PR TITLE
Use Supabase hooks for tournaments/offers

### DIFF
--- a/src/components/Home/FeaturedTournaments.tsx
+++ b/src/components/Home/FeaturedTournaments.tsx
@@ -1,11 +1,11 @@
 import { Link } from 'react-router-dom';
 import { Trophy, Calendar, Award, Users } from 'lucide-react';
-import { useDataStore } from '../../store/dataStore';
+import useTorneos from '../../hooks/useTorneos';
 import { formatDate } from '../../utils/helpers';
 import Card from '../common/Card';
 
 const FeaturedTournaments = () => {
-  const { tournaments } = useDataStore();
+  const { torneos: tournaments } = useTorneos();
   
   // Status indicators
   const getStatusBadge = (status: string) => {

--- a/src/components/Home/UpcomingMatches.tsx
+++ b/src/components/Home/UpcomingMatches.tsx
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
-import { useDataStore } from '../../store/dataStore';
+import useClubes from '../../hooks/useClubes';
+import useTorneos from '../../hooks/useTorneos';
 import { formatDate, formatTime } from '../../utils/helpers';
 
 const UpcomingMatches = () => {
-  const { tournaments, clubs } = useDataStore();
+  const { clubes: clubs } = useClubes();
+  const { torneos: tournaments } = useTorneos();
   
   // Find active tournament
   const activeTournament = tournaments.find(t => t.status === 'active');

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -12,13 +12,22 @@ import {
 import PageHeader from '../components/common/PageHeader';
 import StatsCard from '../components/common/StatsCard';
 import { useDataStore } from '../store/dataStore';
+import useClubes from '../hooks/useClubes';
+import useTorneos from '../hooks/useTorneos';
+import Spinner from '../components/Spinner';
 import { formatDate, formatCurrency, getMatchResult } from '../utils/helpers';
 
 const ClubProfile = () => {
   const { clubName } = useParams<{ clubName: string }>();
   const [activeTab, setActiveTab] = useState('overview');
   
-  const { clubs, players, tournaments } = useDataStore();
+  const { clubes: clubs, loading: loadingClubes } = useClubes();
+  const { torneos: tournaments, loading: loadingTorneos } = useTorneos();
+  const { players } = useDataStore();
+
+  if (loadingClubes || loadingTorneos) {
+    return <Spinner />;
+  }
   
   // Find club by slug
   const club = clubs.find(c => c.slug === clubName);

--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -3,7 +3,9 @@ import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronLeft, ChevronUp } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
 import Card from '../components/common/Card';
-import { useDataStore } from '../store/dataStore';
+import Spinner from '../components/Spinner';
+import useClubes from '../hooks/useClubes';
+import useTorneos from '../hooks/useTorneos';
 import { formatDate } from '../utils/helpers';
 import usePersistentState from '../hooks/usePersistentState';
 
@@ -11,8 +13,13 @@ const Fixtures = () => {
   const [selectedRound, setSelectedRound] = usePersistentState<number | null>('fixtures_round', null);
   const [expandedMatches, setExpandedMatches] = useState<Record<string, boolean>>({});
   
-  const { tournaments, clubs } = useDataStore();
-  
+  const { clubes: clubs, loading: loadingClubes } = useClubes();
+  const { torneos: tournaments, loading: loadingTorneos } = useTorneos();
+
+  if (loadingClubes || loadingTorneos) {
+    return <Spinner />;
+  }
+
   // Get Liga Master tournament
   const ligaMaster = tournaments.find(t => t.id === 'tournament1');
   

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -17,12 +17,14 @@ import ClubListItem from '../components/common/ClubListItem';
 import DashboardSkeleton from '../components/common/DashboardSkeleton';
 import { useDataStore } from '../store/dataStore';
 import useClubes from '../hooks/useClubes';
+import useTorneos from '../hooks/useTorneos';
 import { formatDate, formatCurrency } from '../utils/helpers';
 
 const LigaMaster = () => {
   const { user } = useAuthStore();
-  const { clubes, loading } = useClubes();
-  const { tournaments, players, standings, marketStatus } = useDataStore();
+  const { clubes, loading: loadingClubes } = useClubes();
+  const { torneos: tournaments, loading: loadingTorneos } = useTorneos();
+  const { players, standings, marketStatus } = useDataStore();
 
   if (user?.role === 'dt') {
     if (user.clubId) {
@@ -41,7 +43,7 @@ const LigaMaster = () => {
   // Get active tournament (Liga Master)
   const ligaMaster = tournaments.find(t => t.id === 'tournament1');
 
-  if (loading || !ligaMaster) {
+  if (loadingClubes || loadingTorneos || !ligaMaster) {
     return <DashboardSkeleton />;
   }
   

--- a/src/pages/TournamentDetail.tsx
+++ b/src/pages/TournamentDetail.tsx
@@ -2,7 +2,9 @@ import { useState, lazy, Suspense } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import PageHeader from '../components/common/PageHeader';
 import { Trophy, ChevronLeft, Image, ArrowRight, Star } from 'lucide-react';
-import { useDataStore } from '../store/dataStore';
+import useClubes from '../hooks/useClubes';
+import useTorneos from '../hooks/useTorneos';
+import Spinner from '../components/Spinner';
 import { Match } from '../types';
 import { formatDate, slugify } from '../utils/helpers';
 import ClubListItem from '../components/common/ClubListItem';
@@ -16,7 +18,12 @@ const TournamentDetail = () => {
   const { tournamentName } = useParams<{ tournamentName: string }>();
   const [activeTab, setActiveTab] = useState('overview');
 
-  const { tournaments, clubs } = useDataStore();
+  const { clubes: clubs, loading: loadingClubes } = useClubes();
+  const { torneos: tournaments, loading: loadingTorneos } = useTorneos();
+
+  if (loadingClubes || loadingTorneos) {
+    return <Spinner />;
+  }
   
   // Find tournament by slug
   const tournament = tournaments.find(t => t.slug === tournamentName);


### PR DESCRIPTION
## Summary
- implement Supabase hooks for tournaments and transfer offers
- swap mock data in tournament and offer pages to the new hooks
- update home widgets to load tournaments with the hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868684382888333ac74a2d379e3e8c7