### PR TITLE
Use Supabase for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente
 
 ## Supabase Setup
 
-La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` dentro de tu proyecto de Supabase.
+La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures`, `ofertas` y `comments` dentro de tu proyecto de Supabase.
+
+Para mayor comodidad se incluye la migración SQL `supabase/migrations/add_comments_table.sql` que puedes ejecutar desde la consola de Supabase para crear la tabla `comments` con los campos necesarios.
 
 Asegúrate de definir `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env` con los valores proporcionados por Supabase. Si el proyecto incluye migraciones para estas tablas, ejecútalas con:
 

--- a/supabase/migrations/add_comments_table.sql
+++ b/supabase/migrations/add_comments_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS comments (
+  id text PRIMARY KEY,
+  post_id text NOT NULL,
+  author text NOT NULL,
+  content text NOT NULL,
+  date timestamptz NOT NULL DEFAULT now(),
+  reported boolean NOT NULL DEFAULT false,
+  hidden boolean NOT NULL DEFAULT false
+);


### PR DESCRIPTION
## Summary
- store comments in Supabase instead of localStorage
- add SQL migration for the new `comments` table
- document comments table in Supabase setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68686e880a448333a2ae7db7196a2dd1