### PR TITLE
Update README for Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 VITE_GA_ID=YOUR_GA_ID
 VITE_SMTP_API_KEY=demo-key
 JWT_SECRET=supersecret
+# Solo requerido si mantienes el servidor NestJS
 DATABASE_URL=postgresql://user:password@localhost:5432/lvz
 VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 VITE_SUPABASE_URL=https://your-project.supabase.co

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After the packages are installed you can start the development server.
 
 1. Copia `.env.example` a `.env` en la raíz del proyecto.
 2. En tu panel de Supabase ve a **Settings → API** y copia la `Project URL` y la clave anónima.
-3. Asigna esos valores a `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env`.
+3. Asigna esos valores a `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env`. Estas variables definen la conexión principal a la base de datos y reemplazan la configuración previa basada en `DATABASE_URL`.
 
 
 El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente de Supabase que se consume en la aplicación.
@@ -41,8 +41,10 @@ Run the development server with hot reload:
 
 ```bash
 npm run dev
+```
 
-To start the API server run:
+If you still require the legacy NestJS API you can start it from the `server/` directory:
+
 ```bash
 (cd server && npm install && npm run start:dev)
 ```
@@ -93,13 +95,13 @@ starting the E2E tests.
 To access the administrator interface:
 
 1. Start the development server with `npm run dev`.
-nTo start the API server run:
-```bash
-(cd server && npm install && npm run start:dev)
-```
+2. (Opcional) Inicia la API heredada ejecutando:
+   ```bash
+   (cd server && npm install && npm run start:dev)
+   ```
 
-2. Open the app in your browser and log in using the demo admin account (`admin` / `password`).
-3. Click on your avatar in the navigation bar and choose **Panel Admin** or navigate directly to `/admin`.
+3. Open the app in your browser and log in using the demo admin account (`admin` / `password`).
+4. Click on your avatar in the navigation bar and choose **Panel Admin** or navigate directly to `/admin`.
 
 Within the admin panel you will find management sections for:
 
@@ -132,7 +134,13 @@ The application seeds fictional manager users for the demo clubs. All DT account
 
 ## Data Persistence
 
-The platform now stores all data in a PostgreSQL database managed by Prisma. Run `npm run start:dev` inside `server/` to start the API.
+La base de datos vive ahora en Supabase. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` desde la consola de Supabase o con el CLI. Luego importa `src/data/seed.json` para poblarlas con datos de ejemplo.
+
+Si decides mantener la API antigua puedes seguir iniciándola en `server/`, pero no es necesario para usar Supabase.
+
+## Legacy Server
+
+El directorio `server/` contiene una API construida con NestJS y Prisma. Puedes eliminarlo por completo si quieres depender exclusivamente de Supabase. En caso de integrarlo, asegúrate de que `DATABASE_URL` esté configurada y que la API utilice las mismas tablas que tu instancia de Supabase.
 
 ## Recuperar contraseña
 
@@ -152,7 +160,7 @@ Si intentas acceder a una URL inexistente verás una página 404 con un botón q
 
 El back end expone `GET /healthz` para comprobar que el servicio está en línea.
 
-El archivo `src/data/seed.json` contiene los valores iniciales que se importan en la base de datos al ejecutar `npx prisma db seed` desde el directorio `server`.
+El archivo `src/data/seed.json` contiene los valores iniciales que puedes importar directamente en Supabase usando la opción **Table Editor** o el CLI `supabase db import`.
 
 ## Health Checks
 


### PR DESCRIPTION
## Summary
- document VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY as the main database config
- explain optional legacy server usage
- replace Prisma section with Supabase steps
- clarify seed data import
- note DATABASE_URL is only needed for the old server

## Testing
- `npm run test` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68686e89e820833393d391f584a03999