### PR TITLE
Use Supabase for admin storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente
 
 ## Supabase Setup
 
-La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` dentro de tu proyecto de Supabase.
+La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` dentro de tu proyecto de Supabase. El panel de administración también persiste su estado en la base de datos. Ejecuta el script `supabase/admin_tables.sql` para crear las tablas `admin_users`, `admin_clubs`, `admin_players`, `admin_matches`, `admin_tournaments`, `admin_news`, `admin_transfers`, `admin_standings`, `admin_activities` y `admin_comments`.
 
 Asegúrate de definir `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env` con los valores proporcionados por Supabase. Si el proyecto incluye migraciones para estas tablas, ejecútalas con:
 

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -220,10 +220,11 @@ const defaultData: AdminData = {
 
 export const useGlobalStore = create<GlobalStore>()(
   subscribeWithSelector<GlobalStore>((set, get) => {
-  const initial = loadAdminData(defaultData);
+  const initial = { ...defaultData };
+  loadAdminData(defaultData).then(data => set(data));
 
-  const persist = () => {
-      saveAdminData({
+  const persist = async () => {
+      await saveAdminData({
         users: get().users,
         clubs: get().clubs,
         players: get().players,

--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -1,9 +1,4 @@
-import {
-  VZ_USERS_KEY,
-  VZ_CLUBS_KEY,
-  VZ_PLAYERS_KEY,
-  VZ_FIXTURES_KEY
-} from '../../utils/storageKeys';
+import { supabase } from '../../supabaseClient';
 
 export interface AdminData {
   users: import('../types/shared').User[];
@@ -18,80 +13,43 @@ export interface AdminData {
   comments: import('../types').Comment[];
 }
 
-const PREFIX = 'vz_';
-
-// Keys previously used by older admin panel versions
-const OLD_KEYS = {
-  users: `${PREFIX}users_admin`,
-  clubs: `${PREFIX}clubs_admin`,
-  players: `${PREFIX}players_admin`,
-  tournaments: `${PREFIX}tournaments_admin`,
-  matches: `${PREFIX}fixtures_admin`,
-  newsItems: `${PREFIX}news_admin`,
-  transfers: `${PREFIX}transfers_admin`,
-  standings: `${PREFIX}standings_admin`,
-  activities: `${PREFIX}activities_admin`,
-  comments: `${PREFIX}comments_admin`
+const TABLES = {
+  users: 'admin_users',
+  clubs: 'admin_clubs',
+  players: 'admin_players',
+  matches: 'admin_matches',
+  tournaments: 'admin_tournaments',
+  newsItems: 'admin_news',
+  transfers: 'admin_transfers',
+  standings: 'admin_standings',
+  activities: 'admin_activities',
+  comments: 'admin_comments'
 } as const;
 
-// Updated keys aligned with the main application
-const keys = {
-  users: VZ_USERS_KEY,
-  clubs: VZ_CLUBS_KEY,
-  players: VZ_PLAYERS_KEY,
-  matches: VZ_FIXTURES_KEY,
-  tournaments: OLD_KEYS.tournaments,
-  newsItems: OLD_KEYS.newsItems,
-  transfers: OLD_KEYS.transfers,
-  standings: OLD_KEYS.standings,
-  activities: OLD_KEYS.activities,
-  comments: OLD_KEYS.comments
-} as const;
-
-const migrateOldKeys = () => {
-  Object.entries(OLD_KEYS).forEach(([prop, oldKey]) => {
-    const newKey = (keys as any)[prop];
-    if (oldKey !== newKey) {
-      const oldVal = localStorage.getItem(oldKey);
-      if (oldVal && !localStorage.getItem(newKey)) {
-        localStorage.setItem(newKey, oldVal);
-      }
-      if (oldVal) {
-        localStorage.removeItem(oldKey);
-      }
-    }
-  });
-};
-
-export const loadAdminData = (defaults: AdminData): AdminData => {
-  if (typeof localStorage === 'undefined') {
-    return defaults;
-  }
+export const loadAdminData = async (
+  defaults: AdminData
+): Promise<AdminData> => {
   const data: AdminData = { ...defaults };
-  migrateOldKeys();
-  Object.entries(keys).forEach(([prop, key]) => {
-    const json = localStorage.getItem(key);
-    if (json) {
-      try {
-        (data as any)[prop] = JSON.parse(json);
-      } catch {
-        // ignore parse errors and keep defaults
+  await Promise.all(
+    Object.entries(TABLES).map(async ([prop, table]) => {
+      const { data: rows } = await supabase.from(table).select('*');
+      if (rows) {
+        (data as any)[prop] = rows;
       }
-    }
-  });
+    })
+  );
   return data;
 };
 
-export const saveAdminData = (data: AdminData): void => {
-  if (typeof localStorage === 'undefined') {
-    return;
-  }
-  Object.entries(keys).forEach(([prop, key]) => {
-    const value = (data as any)[prop];
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // ignore write errors
-    }
-  });
+export const saveAdminData = async (data: AdminData): Promise<void> => {
+  await Promise.all(
+    Object.entries(TABLES).map(async ([prop, table]) => {
+      const rows = (data as any)[prop];
+      if (!Array.isArray(rows)) return;
+      await supabase.from(table).delete().neq('id', '');
+      if (rows.length > 0) {
+        await supabase.from(table).upsert(rows);
+      }
+    })
+  );
 };

--- a/supabase/admin_tables.sql
+++ b/supabase/admin_tables.sql
@@ -1,0 +1,94 @@
+-- SQL schema for admin panel entities
+-- Run these statements in your Supabase project's SQL editor or CLI
+
+create table if not exists admin_users (
+  id text primary key,
+  username text not null,
+  email text not null,
+  role text not null,
+  status text not null,
+  created_at timestamptz default now(),
+  club_id text
+);
+
+create table if not exists admin_clubs (
+  id text primary key,
+  name text not null,
+  manager text,
+  manager_id text,
+  budget numeric,
+  created_at timestamptz default now()
+);
+
+create table if not exists admin_players (
+  id text primary key,
+  name text not null,
+  position text,
+  club_id text,
+  overall integer,
+  price numeric
+);
+
+create table if not exists admin_matches (
+  id text primary key,
+  tournament_id text,
+  round integer,
+  date timestamptz,
+  home_team text,
+  away_team text,
+  home_score integer,
+  away_score integer,
+  status text
+);
+
+create table if not exists admin_tournaments (
+  id text primary key,
+  name text not null,
+  status text,
+  current_round integer,
+  total_rounds integer
+);
+
+create table if not exists admin_news (
+  id text primary key,
+  title text,
+  content text,
+  author text,
+  published_at timestamptz,
+  status text
+);
+
+create table if not exists admin_transfers (
+  id text primary key,
+  player_id text,
+  from_club_id text,
+  to_club_id text,
+  amount numeric,
+  status text,
+  created_at timestamptz
+);
+
+create table if not exists admin_standings (
+  id text primary key,
+  club_id text,
+  points integer,
+  wins integer,
+  draws integer,
+  losses integer
+);
+
+create table if not exists admin_activities (
+  id text primary key,
+  user_id text,
+  action text,
+  details text,
+  date timestamptz
+);
+
+create table if not exists admin_comments (
+  id text primary key,
+  user_id text,
+  content text,
+  status text,
+  created_at timestamptz
+);


### PR DESCRIPTION
## Summary
- add SQL migration file for admin tables
- persist admin data in Supabase instead of LocalStorage
- update global store to load and save via Supabase
- document new admin tables in README

## Testing
- `npm run test` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68686e890c5c8333a5312a084798af1a