### PR TITLE
Add Supabase users table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente
 
 ## Supabase Setup
 
-La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` dentro de tu proyecto de Supabase. El panel de administración también persiste su estado en la base de datos. Ejecuta el script `supabase/admin_tables.sql` para crear las tablas `admin_users`, `admin_clubs`, `admin_players`, `admin_matches`, `admin_tournaments`, `admin_news`, `admin_transfers`, `admin_standings`, `admin_activities` y `admin_comments`.
+La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` dentro de tu proyecto de Supabase. El panel de administración también persiste su estado en la base de datos. Ejecuta el script `supabase/admin_tables.sql` para crear las tablas `admin_users`, `admin_clubs`, `admin_players`, `admin_matches`, `admin_tournaments`, `admin_news`, `admin_transfers`, `admin_standings`, `admin_activities` y `admin_comments`. Además, aplica la migración `supabase/migrations/create_users_table.sql` para definir la tabla `users` utilizada en la función `addUser`.
 
 Asegúrate de definir `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env` con los valores proporcionados por Supabase. Si el proyecto incluye migraciones para estas tablas, ejecútalas con:
 

--- a/supabase/migrations/create_users_table.sql
+++ b/supabase/migrations/create_users_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS users (
+  id text PRIMARY KEY,
+  username text NOT NULL,
+  email text NOT NULL,
+  role text NOT NULL,
+  clubId text,
+  avatar text,
+  xp integer NOT NULL DEFAULT 0,
+  createdAt timestamptz NOT NULL DEFAULT now(),
+  status text NOT NULL DEFAULT 'active',
+  notifications boolean NOT NULL DEFAULT true,
+  lastLogin timestamptz,
+  followers integer NOT NULL DEFAULT 0,
+  following integer NOT NULL DEFAULT 0,
+  password text NOT NULL
+);


### PR DESCRIPTION
## Summary
- create SQL migration to define `users` table
- document running the migration in README

## Testing
- `npm test` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6868874f08788333aa4bc3806888ba48