### PR TITLE
Update env example and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ VITE_GA_ID=YOUR_GA_ID
 VITE_SMTP_API_KEY=demo-key
 SUPABASE_SERVICE_ROLE_KEY=service-role-key
 SUPABASE_JWT_SECRET=jwt-secret
+SUPABASE_URL=https://your-project.supabase.co
 VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=public-anon-key

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After the packages are installed you can start the development server.
 
 1. Copia `.env.example` a `.env` en la raíz del proyecto.
 2. En tu panel de Supabase ve a **Settings → API** y copia la `Project URL` y la clave anónima.
-3. Asigna esos valores a `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env`. Estas variables definen la conexión principal a la base de datos y reemplazan la configuración previa basada en `DATABASE_URL`.
+3. Asigna la URL a `SUPABASE_URL` (backend) y `VITE_SUPABASE_URL` (frontend); la clave anónima a `VITE_SUPABASE_ANON_KEY` en el archivo `.env`. Estas variables definen la conexión principal a la base de datos y reemplazan la configuración previa basada en `DATABASE_URL`.
 
 
 El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente de Supabase que se consume en la aplicación.


### PR DESCRIPTION
## Summary
- add `SUPABASE_URL` sample entry
- explain using `SUPABASE_URL` for the backend

## Testing
- `npm run test` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68688757285883338c13047ddbfc3cc4