### PR TITLE
Fix admin login selector in E2E test

### DIFF
--- a/tests/e2e/admin_user_flow.cy.ts
+++ b/tests/e2e/admin_user_flow.cy.ts
@@ -4,7 +4,7 @@ describe('Admin user management flow', () => {
   it('creates a new user from the admin panel', () => {
     cy.visit('/login');
 
-    cy.get('input[type="text"]').first().type('admin');
+    cy.get('input[type="email"]').type('admin@virtualzone.com');
     cy.get('input[type="password"]').type('password');
     cy.get('button[type="submit"]').click();
 


### PR DESCRIPTION
## Summary
- update admin login selector to use email input for admin

## Testing
- `npm install`
- `npm test` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68688d1dacac8333bf81c574d0b2957c