### PR TITLE
Implement bcrypt password hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fullcalendar/react": "^6.1.17",
         "@sentry/react": "^7.92.0",
         "@supabase/supabase-js": "^2.50.3",
+        "bcryptjs": "^2.4.3",
         "date-fns": "^3.6.0",
         "framer-motion": "^12.19.1",
         "lucide-react": "^0.244.0",
@@ -3527,6 +3528,12 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fullcalendar/react": "^6.1.17",
     "@sentry/react": "^7.92.0",
     "@supabase/supabase-js": "^2.50.3",
+    "bcryptjs": "^2.4.3",
     "date-fns": "^3.6.0",
     "framer-motion": "^12.19.1",
     "lucide-react": "^0.244.0",

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -2,6 +2,7 @@ import { User } from '../types/shared';
 import { VZ_CURRENT_USER_KEY } from './storageKeys';
 import { supabase } from '../supabaseClient';
 import { User as SupabaseUser } from '@supabase/supabase-js';
+import bcrypt from 'bcryptjs';
 
 interface UserMetadata {
   username?: string;
@@ -20,10 +21,8 @@ const mapAuthUser = (authUser: SupabaseUser): User => {
 };
 
 export const hashPassword = (pwd: string): string => {
-  if (typeof btoa !== 'undefined') {
-    return btoa(pwd);
-  }
-  return Buffer.from(pwd).toString('base64');
+  const salt = bcrypt.genSaltSync(10);
+  return bcrypt.hashSync(pwd, salt);
 };
 
 export const getUsers = async (): Promise<User[]> => {

--- a/tests/hashPassword.test.ts
+++ b/tests/hashPassword.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { hashPassword } from '../src/utils/authService';
+import bcrypt from 'bcryptjs';
+
+describe('hashPassword', () => {
+  it('generates a bcrypt hash', () => {
+    const pwd = 'secret';
+    const hash = hashPassword(pwd);
+    expect(hash).not.toBe(pwd);
+    expect(bcrypt.compareSync(pwd, hash)).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,17 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    exclude: ['server/**'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      'server/**'
+    ],
+    env: {
+      VITE_SUPABASE_URL: 'http://localhost',
+      VITE_SUPABASE_ANON_KEY: 'anon'
+    },
     coverage: {
       reporter: ['text', 'json']
     }


### PR DESCRIPTION
## Summary
- use bcryptjs to hash passwords securely
- add a new unit test for hashPassword
- update vitest config to ignore node_modules and set env vars

## Testing
- `npm run test` *(fails: supabase fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68689b3990448333ab090107f2e97d6c