### PR TITLE
Remove unused GA and SMTP env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-VITE_GA_ID=YOUR_GA_ID
-VITE_SMTP_API_KEY=demo-key
 SUPABASE_SERVICE_ROLE_KEY=service-role-key
 SUPABASE_JWT_SECRET=jwt-secret
 SUPABASE_URL=https://your-project.supabase.co

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -11,8 +11,6 @@ declare module '*.md' {
 }
 
 interface ImportMetaEnv {
-  readonly VITE_GA_ID?: string;
-  readonly VITE_SMTP_API_KEY?: string;
   readonly VITE_SENTRY_DSN?: string;
 }
 


### PR DESCRIPTION
## Summary
- remove `VITE_GA_ID` and `VITE_SMTP_API_KEY` from `.env.example`
- clean up interface `ImportMetaEnv` accordingly

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68689b3b0a708333aeadf04aa73d4496