### PR TITLE
Fix tournament admin login test

### DIFF
--- a/tests/e2e/tournament_admin_flow.cy.ts
+++ b/tests/e2e/tournament_admin_flow.cy.ts
@@ -3,7 +3,7 @@
 describe('Admin tournament management', () => {
   it('creates, starts and deletes a tournament', () => {
     cy.visit('/login');
-    cy.get('input[type="text"]').first().type('admin');
+    cy.get('input[type="email"]').type('admin@virtualzone.com');
     cy.get('input[type="password"]').type('password');
     cy.get('button[type="submit"]').click();
     cy.url().should('include', '/usuario');


### PR DESCRIPTION
## Summary
- use email field in tournament admin flow test

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68689f82e2548333bd471dd3107fe073