### PR TITLE
Update password reset e2e

### DIFF
--- a/tests/e2e/password_reset.cy.ts
+++ b/tests/e2e/password_reset.cy.ts
@@ -4,13 +4,18 @@ describe('Password recovery flow', () => {
   const email = 'usuario@test.com';
 
   it('resets password with valid token', () => {
+    let resetToken = '';
+    cy.intercept('POST', '**/recover', req => {
+      req.reply({ statusCode: 200, body: { oobCode: 'test-token' } });
+    }).as('recover');
+
     cy.visit('/recuperar-password');
     cy.get('input[type="email"]').type(email);
     cy.contains('button', 'Enviar enlace').click();
-    cy.window().then(win => {
-      const tokens = JSON.parse(win.localStorage.getItem('vz_reset_tokens') || '[]');
-      const token = tokens[0].token;
-      cy.visit(`/reset/${token}`);
+
+    cy.wait('@recover').then(interception => {
+      resetToken = interception.response?.body.oobCode;
+      cy.visit(`/reset/${resetToken}`);
       cy.get('input[type="password"]').first().type('nueva123');
       cy.get('input[type="password"]').eq(1).type('nueva123');
       cy.contains('button', 'Restablecer').click();


### PR DESCRIPTION
## Summary
- intercept Supabase password reset request in e2e test
- use the intercepted oobCode to navigate to reset page

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689f8f23108333964a60ddd86424ef