### PR TITLE
Improve password hashing with bcrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente
 ## Supabase Setup
 
 La aplicación utiliza Supabase para sincronizar en tiempo real los datos de algunos recursos. Crea las tablas `clubes`, `jugadores`, `torneos`, `fixtures` y `ofertas` dentro de tu proyecto de Supabase. El panel de administración también persiste su estado en la base de datos. Ejecuta el script `supabase/admin_tables.sql` para crear las tablas `admin_users`, `admin_clubs`, `admin_players`, `admin_matches`, `admin_tournaments`, `admin_news`, `admin_transfers`, `admin_standings`, `admin_activities` y `admin_comments`. Además, aplica la migración `supabase/migrations/create_users_table.sql` para definir la tabla `users` utilizada en la función `addUser`.
+Las contraseñas de esta tabla se almacenan con hashing seguro mediante **bcrypt**.
 
 Asegúrate de definir `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en el archivo `.env` con los valores proporcionados por Supabase. Si el proyecto incluye migraciones para estas tablas, ejecútalas con el CLI de Supabase, por ejemplo:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fullcalendar/react": "^6.1.17",
         "@sentry/react": "^7.92.0",
         "@supabase/supabase-js": "^2.50.3",
+        "bcrypt": "^6.0.0",
         "date-fns": "^3.6.0",
         "framer-motion": "^12.19.1",
         "lucide-react": "^0.244.0",
@@ -3516,6 +3517,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/bcrypt-pbkdf": {
@@ -8504,6 +8519,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
+      "integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -8523,6 +8547,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fullcalendar/react": "^6.1.17",
     "@sentry/react": "^7.92.0",
     "@supabase/supabase-js": "^2.50.3",
+    "bcrypt": "^6.0.0",
     "date-fns": "^3.6.0",
     "framer-motion": "^12.19.1",
     "lucide-react": "^0.244.0",

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -2,6 +2,7 @@ import { User } from '../types/shared';
 import { VZ_CURRENT_USER_KEY } from './storageKeys';
 import { supabase } from '../supabaseClient';
 import { User as SupabaseUser } from '@supabase/supabase-js';
+import bcrypt from 'bcrypt';
 
 interface UserMetadata {
   username?: string;
@@ -19,11 +20,8 @@ const mapAuthUser = (authUser: SupabaseUser): User => {
   };
 };
 
-export const hashPassword = (pwd: string): string => {
-  if (typeof btoa !== 'undefined') {
-    return btoa(pwd);
-  }
-  return Buffer.from(pwd).toString('base64');
+export const hashPassword = async (pwd: string): Promise<string> => {
+  return bcrypt.hash(pwd, 10);
 };
 
 export const getUsers = async (): Promise<User[]> => {
@@ -90,7 +88,7 @@ export const addUser = async (
       lastLogin: new Date().toISOString(),
       followers: 0,
       following: 0,
-      password: hashPassword(password)
+      password: await hashPassword(password)
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary
- add `bcrypt` dependency
- hash passwords using bcrypt in auth service
- update admin user creation to await hash
- document secure password hashing in README

## Testing
- `npm run test` *(fails: Snapshots 2 failed, Test Files 72 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68689f9676e883338031a3017c89d6f3