### PR TITLE
Fix adminStorage load logic

### DIFF
--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -33,7 +33,7 @@ export const loadAdminData = async (
   await Promise.all(
     Object.entries(TABLES).map(async ([prop, table]) => {
       const { data: rows } = await supabase.from(table).select('*');
-      if (rows) {
+      if (rows && rows.length > 0) {
         (data as any)[prop] = rows;
       }
     })

--- a/tests/loadAdminDataSupabase.test.ts
+++ b/tests/loadAdminDataSupabase.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadAdminData, AdminData } from '../src/adminPanel/utils/adminStorage';
+
+vi.mock('../src/supabaseClient', () => {
+  return {
+    supabase: {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ data: [] }))
+      }))
+    }
+  };
+});
+
+describe('loadAdminData', () => {
+  it('keeps default data when tables are empty', async () => {
+    const defaults: AdminData = {
+      users: [{ id: '1', username: 'admin' } as any],
+      clubs: [],
+      players: [],
+      matches: [],
+      tournaments: [],
+      newsItems: [],
+      transfers: [],
+      standings: [],
+      activities: [],
+      comments: []
+    };
+
+    const data = await loadAdminData(defaults);
+    expect(data.users).toEqual(defaults.users);
+  });
+});


### PR DESCRIPTION
## Summary
- keep default admin data when Supabase tables are empty
- add a regression test for loadAdminData with mocked Supabase

## Testing
- `npm test` *(fails: fetch failed in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6868b0c2afdc83339691947dcff5351c