### PR TITLE
Ensure registered users populate table

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Agrega la cuenta inicial del panel ejecutando el snippet SQL incluido en el
 repositorio o utilizando el helper `addUser` de `src/utils/authService.ts`:
 
 ```sql
-insert into users (email, username, role, password)
-values ('admin@virtualzone.com', 'admin', 'admin', 'password');
+insert into users (id, email, username, role, password)
+values ('1', 'admin@virtualzone.com', 'admin', 'admin', 'password');
 ```
 
 ```ts
-await addUser('admin@virtualzone.com', 'admin', 'admin');
+await addUser('1', 'admin@virtualzone.com', 'admin', 'admin');
 ```
 
 Para cargar datos de ejemplo puedes importar manualmente `src/data/seed.json` desde la consola o CLI de Supabase.

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -61,11 +61,15 @@ export const register = async (
   if (error || !data.user) {
     throw new Error(error?.message || 'Error al registrar la cuenta');
   }
+
+  await addUser(data.user.id, email, username, 'user', undefined, password);
+
   return mapAuthUser(data.user);
 };
 
 // Add new user (admin)
 export const addUser = async (
+  id: string,
   email: string,
   username: string,
   role: 'user' | 'dt' | 'admin',
@@ -75,6 +79,7 @@ export const addUser = async (
   const { data, error } = await supabase
     .from('users')
     .insert({
+      id,
       email,
       username,
       role,


### PR DESCRIPTION
## Summary
- insert newly registered users into the `users` table
- store a user id when calling `addUser`
- document updated `addUser` usage

## Testing
- `npm run test:unit` *(fails: fetch to supabase during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6868b3414bbc83338d9d1fea6214b320