### PR TITLE
Fix tournament prize display with optional data

### DIFF
--- a/src/adminPanel/components/admin/TournamentDetailsModal.tsx
+++ b/src/adminPanel/components/admin/TournamentDetailsModal.tsx
@@ -62,7 +62,9 @@ const TournamentDetailsModal = ({ tournament, onClose }: Props) => {
           <p>
             <span className="text-gray-400">Premio: </span>
             <span className="text-white">
-              €{tournament.prizePool.toLocaleString()}
+              {typeof tournament.prizePool === 'number'
+                ? `€${tournament.prizePool.toLocaleString()}`
+                : 'N/A'}
             </span>
           </p>
           <p>

--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -58,7 +58,7 @@ const TournamentsAdminPanel = () => {
   });
 
   const activeTournaments = tournaments.filter(t => t.status === 'active').length;
-  const totalPrizePool = tournaments.reduce((sum, t) => sum + t.prizePool, 0);
+  const totalPrizePool = tournaments.reduce((sum, t) => sum + (t.prizePool ?? 0), 0);
   const totalTeams = tournaments.reduce((sum, t) => sum + t.currentTeams, 0);
 
   const getStatusColor = (status: string) => {
@@ -208,7 +208,9 @@ const TournamentsAdminPanel = () => {
                       Premio
                     </div>
                     <div className="text-white font-medium">
-                      €{tournament.prizePool.toLocaleString()}
+                      {typeof tournament.prizePool === 'number'
+                        ? `€${tournament.prizePool.toLocaleString()}`
+                        : 'N/A'}
                     </div>
                   </div>
                 </div>

--- a/src/adminPanel/types.ts
+++ b/src/adminPanel/types.ts
@@ -21,6 +21,14 @@ export interface Tournament {
   status: 'active' | 'completed' | 'upcoming';
   currentRound: number;
   totalRounds: number;
+  /** Optional metadata used in some admin views */
+  format?: 'league' | 'knockout';
+  startDate?: string;
+  endDate?: string;
+  maxTeams?: number;
+  currentTeams: number;
+  prizePool?: number;
+  location?: string;
 }
 
 export interface NewsItem {


### PR DESCRIPTION
## Summary
- include optional fields like `prizePool` in `Tournament` admin type
- avoid crashes when `prizePool` is undefined in admin panel views

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68693b9639a08333a966bca144d7fb5e