### PR TITLE
Persist tournaments in admin store

### DIFF
--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -10,6 +10,7 @@ import {
   Eye,
 } from 'lucide-react';
 import { Tournament } from '../../types';
+import { useGlobalStore } from '../../store/globalStore';
 import SearchFilter from './SearchFilter';
 import StatsCard from './StatsCard';
 import NewTournamentModal from './NewTournamentModal';
@@ -17,32 +18,10 @@ import ConfirmDeleteModal from './ConfirmDeleteModal';
 import TournamentDetailsModal from './TournamentDetailsModal';
 
 const TournamentsAdminPanel = () => {
-  const [tournaments, setTournaments] = useState<Tournament[]>([
-    {
-      id: '1',
-      name: 'Liga Master 2024',
-      format: 'league',
-      status: 'active',
-      startDate: '2024-01-15',
-      endDate: '2024-06-30',
-      maxTeams: 20,
-      currentTeams: 18,
-      prizePool: 500000,
-      location: 'España'
-    },
-    {
-      id: '2',
-      name: 'Copa Elite',
-      format: 'knockout',
-      status: 'upcoming',
-      startDate: '2024-07-01',
-      endDate: '2024-07-31',
-      maxTeams: 32,
-      currentTeams: 24,
-      prizePool: 250000,
-      location: 'Internacional'
-    }
-  ]);
+  const tournaments = useGlobalStore(state => state.tournaments);
+  const addTournament = useGlobalStore(state => state.addTournament);
+  const updateTournament = useGlobalStore(state => state.updateTournament);
+  const removeTournament = useGlobalStore(state => state.removeTournament);
 
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -263,7 +242,7 @@ const TournamentsAdminPanel = () => {
               currentTeams: 0,
               ...data
             } as Tournament;
-            setTournaments([...tournaments, newTournament]);
+            addTournament(newTournament);
             setShowNewModal(false);
           }}
         />
@@ -274,9 +253,10 @@ const TournamentsAdminPanel = () => {
           tournament={editingTournament}
           onClose={() => setEditingTournament(null)}
           onSave={(data) => {
-            setTournaments(tournaments.map(t => 
-              t.id === editingTournament.id ? { ...t, ...data } : t
-            ));
+            updateTournament({
+              ...editingTournament!,
+              ...data
+            } as Tournament);
             setEditingTournament(null);
           }}
         />
@@ -287,7 +267,7 @@ const TournamentsAdminPanel = () => {
           isOpen={true}
           onClose={() => setDeletingTournament(null)}
           onConfirm={() => {
-            setTournaments(tournaments.filter(t => t.id !== deletingTournament.id));
+            removeTournament(deletingTournament.id);
             setDeletingTournament(null);
           }}
           title="Eliminar Torneo"

--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -54,6 +54,9 @@ interface GlobalStore {
   removeMatch: (id: string) => void;
 
   // Tournaments
+  addTournament: (tournament: Tournament) => void;
+  updateTournament: (tournament: Tournament) => void;
+  removeTournament: (id: string) => void;
   updateTournamentStatus: (id: string, status: Tournament['status']) => void;
   
   // Transfers
@@ -395,6 +398,26 @@ export const useGlobalStore = create<GlobalStore>()(
 
     removeMatch: id => {
       set(state => ({ matches: state.matches.filter(m => m.id !== id) }));
+      persist();
+    },
+
+    addTournament: tournament => {
+      set(state => ({ tournaments: [...state.tournaments, tournament] }));
+      useDataStore.getState().addTournament(tournament);
+      persist();
+    },
+
+    updateTournament: tournament => {
+      set(state => ({
+        tournaments: state.tournaments.map(t =>
+          t.id === tournament.id ? tournament : t
+        )
+      }));
+      persist();
+    },
+
+    removeTournament: id => {
+      set(state => ({ tournaments: state.tournaments.filter(t => t.id !== id) }));
       persist();
     },
 


### PR DESCRIPTION
## Summary
- add tournament management actions to `globalStore`
- expose new actions via `useGlobalStore` and use them in `TournamentsAdminPanel`
- sync new tournaments with the public `dataStore`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`
- `npm run test:unit` *(fails: fetch errors with Supabase)*

------
https://chatgpt.com/codex/tasks/task_e_686940b6a7c88333a6876d2856503f4c