### PR TITLE
Fix selective delete in saveAdminData

### DIFF
--- a/tests/loadAdminDataSupabase.test.ts
+++ b/tests/loadAdminDataSupabase.test.ts
@@ -6,7 +6,8 @@ vi.mock('../src/supabaseClient', () => {
     supabase: {
       from: vi.fn(() => ({
         select: vi.fn(() => ({ data: [] }))
-      }))
+      })),
+      auth: { getSession: vi.fn(() => ({ data: { session: null } })) }
     }
   };
 });

--- a/tests/saveAdminDataSupabase.test.ts
+++ b/tests/saveAdminDataSupabase.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { saveAdminData, AdminData } from '../src/adminPanel/utils/adminStorage';
+
+const selectMock = vi.fn(() => ({ data: [{ id: '1' }, { id: '2' }] }));
+const deleteInMock = vi.fn();
+const upsertMock = vi.fn();
+var fromMock: any;
+
+vi.mock('../src/supabaseClient', () => {
+  fromMock = vi.fn(() => ({
+    select: selectMock,
+    delete: vi.fn(() => ({ in: deleteInMock })),
+    upsert: upsertMock
+  }));
+  return {
+    supabase: { from: fromMock, auth: { getSession: vi.fn(() => ({ data: { session: null } })) } }
+  };
+});
+
+describe('saveAdminData', () => {
+  it('deletes only missing ids and upserts new rows', async () => {
+    const data: AdminData = {
+      tournaments: [
+        {
+          id: '1',
+          name: 'T1',
+          status: 'upcoming',
+          currentRound: 0,
+          totalRounds: 1
+        } as any
+      ]
+    } as any;
+
+    await saveAdminData(data);
+
+    expect(fromMock).toHaveBeenCalledWith('admin_tournaments');
+    expect(deleteInMock).toHaveBeenCalledWith('id', ['2']);
+    expect(upsertMock).toHaveBeenCalledWith(data.tournaments);
+  });
+});


### PR DESCRIPTION
## Summary
- adjust `saveAdminData` to only delete rows absent from the payload
- mock Supabase in related unit tests
- add regression test for selective deletion logic

## Testing
- `npx vitest run tests/addTournament.test.ts tests/adminStorage.test.ts tests/loadAdminDataSupabase.test.ts tests/saveAdminDataSupabase.test.ts tests/useCan.test.ts tests/hashPassword.test.ts --run`

------
https://chatgpt.com/codex/tasks/task_e_686952c2f138833380203b7f60e5839d