### PR TITLE
Fix admin panel subscriptions and tests

### DIFF
--- a/src/adminPanel/__tests__/mercado.test.tsx
+++ b/src/adminPanel/__tests__/mercado.test.tsx
@@ -1,10 +1,11 @@
 import  { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { useGlobalStore } from '../store/globalStore';
-import Mercado from '../pages/admin/Mercado';
 
 vi.mock('../store/globalStore');
+
+import { useGlobalStore } from '../store/globalStore';
+import Mercado from '../pages/admin/Mercado';
 
 const mockStore = {
   transfers: [
@@ -35,7 +36,7 @@ describe('Mercado Component', () => {
 
   it('should approve transfer', () => {
     render(<Mercado />);
-    const approveButton = screen.getByTitle('Aprobar');
+    const approveButton = screen.getByTitle('Aprobar transferencia');
     
     fireEvent.click(approveButton);
     

--- a/src/adminPanel/__tests__/usuarios.test.tsx
+++ b/src/adminPanel/__tests__/usuarios.test.tsx
@@ -1,10 +1,11 @@
 import  { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { useGlobalStore } from '../store/globalStore';
-import Usuarios from '../pages/admin/Usuarios';
 
 vi.mock('../store/globalStore');
+
+import { useGlobalStore } from '../store/globalStore';
+import Usuarios from '../pages/admin/Usuarios';
 
 const mockStore = {
   users: [
@@ -36,20 +37,20 @@ describe('Usuarios Component', () => {
 
   it('should filter users by search term', async () => {
     render(<Usuarios />);
-    const searchInput = screen.getByPlaceholderText('Buscar usuarios...');
-    
+    const searchInput = screen.getByPlaceholderText('Buscar por usuario o email...');
+
     fireEvent.change(searchInput, { target: { value: 'test' } });
-    
+
     expect(screen.getByText('testuser')).toBeInTheDocument();
   });
 
   it('should open new user modal', () => {
     render(<Usuarios />);
     const newUserButton = screen.getByText('Nuevo Usuario');
-    
+
     fireEvent.click(newUserButton);
-    
-    expect(screen.getByText('Nuevo Usuario')).toBeInTheDocument();
+
+    expect(screen.getAllByText('Nuevo Usuario').length).toBeGreaterThan(1);
   });
 });
  

--- a/src/adminPanel/components/admin/CommentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/CommentsAdminPanel.tsx
@@ -20,7 +20,9 @@ const CommentsAdminPanel = () => {
       state => state.comments.filter(c => c.status === 'pending').length,
       setPendingCount
     );
-    return () => unsub();
+    return () => {
+      if (typeof unsub === 'function') unsub();
+    };
   }, []);
 
   const filteredComments = comments.filter(comment => {

--- a/src/adminPanel/hooks/useTournamentFilters.ts
+++ b/src/adminPanel/hooks/useTournamentFilters.ts
@@ -1,0 +1,11 @@
+import { useGlobalStore } from '../store/globalStore';
+import type { Tournament } from '../types';
+
+export const useUpcomingTournaments = (): Tournament[] =>
+  useGlobalStore(state => state.tournaments.filter(t => t.status === 'upcoming'));
+
+export const useActiveTournaments = (): Tournament[] =>
+  useGlobalStore(state => state.tournaments.filter(t => t.status === 'active'));
+
+export const useFinishedTournaments = (): Tournament[] =>
+  useGlobalStore(state => state.tournaments.filter(t => t.status === 'completed'));

--- a/src/adminPanel/pages/admin/Mercado.tsx
+++ b/src/adminPanel/pages/admin/Mercado.tsx
@@ -21,7 +21,9 @@ const Mercado = () => {
       state => state.transfers.filter(t => t.status === 'pending').length,
       setPendingCount
     );
-    return () => unsub();
+    return () => {
+      if (typeof unsub === 'function') unsub();
+    };
   }, []);
 
   const filteredTransfers = transfers.filter(transfer => {

--- a/tests/useTournamentFilters.test.ts
+++ b/tests/useTournamentFilters.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { useGlobalStore } from '../src/adminPanel/store/globalStore';
 import {
   useUpcomingTournaments,
@@ -20,20 +21,20 @@ beforeEach(() => {
 
 describe('useTournamentFilters', () => {
   it('returns only upcoming tournaments', () => {
-    const upcoming = useUpcomingTournaments();
-    expect(upcoming).toHaveLength(2);
-    expect(upcoming.every(t => t.status === 'upcoming')).toBe(true);
+    const { result } = renderHook(() => useUpcomingTournaments());
+    expect(result.current).toHaveLength(2);
+    expect(result.current.every(t => t.status === 'upcoming')).toBe(true);
   });
 
   it('returns only active tournaments', () => {
-    const active = useActiveTournaments();
-    expect(active).toHaveLength(1);
-    expect(active[0].status).toBe('active');
+    const { result } = renderHook(() => useActiveTournaments());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].status).toBe('active');
   });
 
   it('returns only finished tournaments', () => {
-    const finished = useFinishedTournaments();
-    expect(finished).toHaveLength(1);
-    expect(finished[0].status).toBe('completed');
+    const { result } = renderHook(() => useFinishedTournaments());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].status).toBe('completed');
   });
 });


### PR DESCRIPTION
## Summary
- avoid errors if subscribe mocks don't return a function
- mock globalStore before importing it in admin tests
- update admin test queries for placeholders and titles
- add missing tournament filter hooks and update tests

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68696bcd840c8333816c87ca1caba4ca