### PR TITLE
Return user record on login

### DIFF
--- a/src/adminPanel/__tests__/mercado.test.tsx
+++ b/src/adminPanel/__tests__/mercado.test.tsx
@@ -3,6 +3,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 vi.mock('../store/globalStore');
+vi.mock('../../supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(() => ({ select: vi.fn(() => ({ data: [] })) })),
+    auth: { getSession: vi.fn(() => ({ data: { session: null } })) }
+  }
+}));
 
 import { useGlobalStore } from '../store/globalStore';
 import Mercado from '../pages/admin/Mercado';

--- a/src/adminPanel/__tests__/usuarios.test.tsx
+++ b/src/adminPanel/__tests__/usuarios.test.tsx
@@ -3,6 +3,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 vi.mock('../store/globalStore');
+vi.mock('../../supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(() => ({ select: vi.fn(() => ({ data: [] })) })),
+    auth: { getSession: vi.fn(() => ({ data: { session: null } })) }
+  }
+}));
 
 import { useGlobalStore } from '../store/globalStore';
 import Usuarios from '../pages/admin/Usuarios';

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -111,7 +111,10 @@ export const login = async (email: string, password: string): Promise<User> => {
   if (error || !data.user) {
     throw new Error(error?.message || 'Error al iniciar sesión');
   }
-  return mapAuthUser(data.user);
+
+  const base = await getUserById(data.user.id);
+  const authUser = mapAuthUser(data.user);
+  return base ? { ...base, ...authUser } : authUser;
 };
 
 // Logout function

--- a/tests/login.test.ts
+++ b/tests/login.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const signInMock = vi.fn();
+const singleMock = vi.fn();
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: signInMock,
+      getSession: vi.fn(() => ({ data: { session: null } }))
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({ eq: vi.fn(() => ({ single: singleMock })) }))
+    }))
+  }
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('login', () => {
+  it('returns user with clubId when record exists', async () => {
+    signInMock.mockResolvedValueOnce({
+      data: { user: { id: '1', email: 'a@b.com', user_metadata: { username: 'a', role: 'user' } } },
+      error: null
+    });
+    singleMock.mockResolvedValueOnce({ data: { id: '1', username: 'a', email: 'a@b.com', role: 'user', clubId: 'club1', status: 'active' }, error: null });
+
+    const { login } = await import('../src/utils/authService');
+    const user = await login('a@b.com', 'pass');
+
+    expect(user.clubId).toBe('club1');
+    expect(user.id).toBe('1');
+  });
+});

--- a/tests/useTournamentFilters.test.ts
+++ b/tests/useTournamentFilters.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useGlobalStore } from '../src/adminPanel/store/globalStore';
 import {
@@ -7,6 +7,13 @@ import {
   useFinishedTournaments
 } from '../src/adminPanel/hooks/useTournamentFilters';
 import type { Tournament } from '../src/adminPanel/types';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(() => ({ select: vi.fn(() => ({ data: [] })) })),
+    auth: { getSession: vi.fn(() => ({ data: { session: null } })) }
+  }
+}));
 
 const sampleTournaments: Tournament[] = [
   { id: '1', name: 'Upcoming 1', status: 'upcoming', currentRound: 0, totalRounds: 3 },


### PR DESCRIPTION
## Summary
- merge database user information when signing in
- mock supabase client in component and hook tests
- verify login resolves with clubId when a DB record exists

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6869e18404fc83339d06ac9d5dee59d7