### PR TITLE
Update auth service to merge DB data

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -35,7 +35,12 @@ export const getUsers = async (): Promise<User[]> => {
 export const getCurrentUser = async (): Promise<User | null> => {
   const { data } = await supabase.auth.getSession();
   const authUser = data.session?.user;
-  return authUser ? mapAuthUser(authUser) : null;
+  if (!authUser) return null;
+
+  const base = await getUserById(authUser.id);
+  const mapped = mapAuthUser(authUser);
+
+  return base ? { ...base, ...mapped } : mapped;
 };
 
 // Save current user to localStorage

--- a/tests/getCurrentUser.test.ts
+++ b/tests/getCurrentUser.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const getSessionMock = vi.fn();
+const singleMock = vi.fn();
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({ eq: vi.fn(() => ({ single: singleMock })) }))
+    }))
+  }
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getCurrentUser', () => {
+  it('returns user with clubId when record exists', async () => {
+    getSessionMock.mockResolvedValueOnce({
+      data: {
+        session: {
+          user: {
+            id: '1',
+            email: 'a@b.com',
+            user_metadata: { username: 'a', role: 'user' }
+          }
+        }
+      }
+    });
+    singleMock.mockResolvedValueOnce({
+      data: {
+        id: '1',
+        username: 'a',
+        email: 'a@b.com',
+        role: 'user',
+        clubId: 'club1',
+        status: 'active'
+      },
+      error: null
+    });
+
+    const { getCurrentUser } = await import('../src/utils/authService');
+    const user = await getCurrentUser();
+
+    expect(user?.clubId).toBe('club1');
+    expect(user?.id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- merge user row data when getting current user
- add a unit test for fetching current user

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6869e62fc89083338b8198fd1aa3cda1