### PR TITLE
Lazy load bcryptjs for hashPassword

### DIFF
--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -2,7 +2,6 @@ import { User } from '../types/shared';
 import { VZ_CURRENT_USER_KEY } from './storageKeys';
 import { supabase } from '../supabaseClient';
 import { User as SupabaseUser } from '@supabase/supabase-js';
-import bcrypt from 'bcryptjs';
 
 interface UserMetadata {
   username?: string;
@@ -20,7 +19,8 @@ const mapAuthUser = (authUser: SupabaseUser): User => {
   };
 };
 
-export const hashPassword = (pwd: string): string => {
+export const hashPassword = async (pwd: string): Promise<string> => {
+  const bcrypt = await import('bcryptjs/dist/bcrypt.js');
   const salt = bcrypt.genSaltSync(10);
   return bcrypt.hashSync(pwd, salt);
 };
@@ -99,7 +99,7 @@ export const addUser = async (
       lastLogin: new Date().toISOString(),
       followers: 0,
       following: 0,
-      password: hashPassword(password)
+      password: await hashPassword(password)
     })
     .select()
     .single();

--- a/tests/hashPassword.test.ts
+++ b/tests/hashPassword.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { hashPassword } from '../src/utils/authService';
-import bcrypt from 'bcryptjs';
+import bcrypt from 'bcryptjs/dist/bcrypt.js';
 
 describe('hashPassword', () => {
-  it('generates a bcrypt hash', () => {
+  it('generates a bcrypt hash', async () => {
     const pwd = 'secret';
-    const hash = hashPassword(pwd);
+    const hash = await hashPassword(pwd);
     expect(hash).not.toBe(pwd);
     expect(bcrypt.compareSync(pwd, hash)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- lazy load `bcryptjs` in `hashPassword`
- update `addUser` to await `hashPassword`
- tweak hashPassword test for async function

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_686a5df419288333b02a0fd7aa02eff7