### PR TITLE
Fallback to mock data when Supabase unavailable

### DIFF
--- a/src/hooks/useClubes.ts
+++ b/src/hooks/useClubes.ts
@@ -6,11 +6,13 @@ import { getClubs } from '../utils/dataService';
 export default function useClubes() {
   const [clubes, setClubes] = useState<Club[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
 
   const fetchClubes = useCallback(async () => {
     setLoading(true);
-    const data = await getClubs();
+    const { data, error } = await getClubs();
     setClubes(data);
+    setError(error ?? null);
     setLoading(false);
   }, []);
 
@@ -39,5 +41,5 @@ export default function useClubes() {
     };
   }, [fetchClubes]);
 
-  return { clubes, loading, refresh: fetchClubes };
+  return { clubes, loading, error, refresh: fetchClubes };
 }

--- a/src/hooks/useFixtures.ts
+++ b/src/hooks/useFixtures.ts
@@ -9,7 +9,7 @@ export default function useFixtures() {
 
   const fetchFixtures = useCallback(async () => {
     setLoading(true);
-    const data = await getFixtures();
+    const { data } = await getFixtures();
     setFixtures(data);
     setLoading(false);
   }, []);

--- a/src/hooks/useJugadores.ts
+++ b/src/hooks/useJugadores.ts
@@ -9,7 +9,7 @@ export default function useJugadores() {
 
   const fetchJugadores = useCallback(async () => {
     setLoading(true);
-    const data = await getPlayers();
+    const { data } = await getPlayers();
     setJugadores(data);
     setLoading(false);
   }, []);

--- a/src/hooks/useOfertas.ts
+++ b/src/hooks/useOfertas.ts
@@ -9,7 +9,7 @@ export default function useOfertas() {
 
   const fetchOfertas = useCallback(async () => {
     setLoading(true);
-    const data = await getOffers();
+    const { data } = await getOffers();
     setOfertas(data);
     setLoading(false);
   }, []);

--- a/src/hooks/useTorneos.ts
+++ b/src/hooks/useTorneos.ts
@@ -6,11 +6,13 @@ import { getTournaments } from '../utils/dataService';
 export default function useTorneos() {
   const [torneos, setTorneos] = useState<Tournament[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
 
   const fetchTorneos = useCallback(async () => {
     setLoading(true);
-    const data = await getTournaments();
+    const { data, error } = await getTournaments();
     setTorneos(data);
+    setError(error ?? null);
     setLoading(false);
   }, []);
 
@@ -39,5 +41,5 @@ export default function useTorneos() {
     };
   }, [fetchTorneos]);
 
-  return { torneos, loading, refresh: fetchTorneos };
+  return { torneos, loading, error, refresh: fetchTorneos };
 }

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -22,8 +22,8 @@ import { formatDate, formatCurrency } from '../utils/helpers';
 
 const LigaMaster = () => {
   const { user } = useAuthStore();
-  const { clubes, loading: loadingClubes } = useClubes();
-  const { torneos: tournaments, loading: loadingTorneos } = useTorneos();
+  const { clubes, loading: loadingClubes, error: clubesError } = useClubes();
+  const { torneos: tournaments, loading: loadingTorneos, error: torneosError } = useTorneos();
   const { players, standings, marketStatus } = useDataStore();
 
   if (user?.role === 'dt') {
@@ -42,9 +42,18 @@ const LigaMaster = () => {
   
   // Get active tournament (Liga Master)
   const ligaMaster = tournaments.find(t => t.id === 'tournament1');
+  const hasError = Boolean(clubesError || torneosError);
 
-  if (loadingClubes || loadingTorneos || !ligaMaster) {
+  if (loadingClubes || loadingTorneos) {
     return <DashboardSkeleton />;
+  }
+
+  if (!ligaMaster) {
+    return (
+      <div className="p-8 text-center">
+        <p>No se encontró la información de la Liga Master.</p>
+      </div>
+    );
   }
   
   // Get upcoming matches
@@ -70,6 +79,11 @@ const topScorers = [...players]
   
   return (
     <div>
+      {hasError && (
+        <div className="bg-yellow-900 text-yellow-300 p-4 text-center">
+          Ocurrió un problema al conectar con la base de datos. Se muestran datos de ejemplo.
+        </div>
+      )}
       <PageHeader
         title={ligaMaster.name}
         subtitle={ligaMaster.description}

--- a/src/utils/dataService.ts
+++ b/src/utils/dataService.ts
@@ -1,33 +1,45 @@
 import { supabase } from '../supabaseClient';
 import type { Club, Player } from '../types/shared';
 import type { Tournament, Match, TransferOffer } from '../types';
+import { clubs as mockClubs, players as mockPlayers, tournaments as mockTournaments, offers as mockOffers } from '../data/mockData';
 
-export const getClubs = async (): Promise<Club[]> => {
+export const getClubs = async (): Promise<{ data: Club[]; error?: Error }> => {
   const { data, error } = await supabase.from('clubes').select('*').order('id');
-  if (error || !data) return [];
-  return data as Club[];
+  if (error || !data) {
+    return { data: mockClubs, error: error ?? new Error('Failed to fetch clubs') };
+  }
+  return { data: data as Club[] };
 };
 
-export const getPlayers = async (): Promise<Player[]> => {
+export const getPlayers = async (): Promise<{ data: Player[]; error?: Error }> => {
   const { data, error } = await supabase.from('jugadores').select('*').order('id');
-  if (error || !data) return [];
-  return data as Player[];
+  if (error || !data) {
+    return { data: mockPlayers, error: error ?? new Error('Failed to fetch players') };
+  }
+  return { data: data as Player[] };
 };
 
-export const getTournaments = async (): Promise<Tournament[]> => {
+export const getTournaments = async (): Promise<{ data: Tournament[]; error?: Error }> => {
   const { data, error } = await supabase.from('torneos').select('*').order('id');
-  if (error || !data) return [];
-  return data as Tournament[];
+  if (error || !data) {
+    return { data: mockTournaments, error: error ?? new Error('Failed to fetch tournaments') };
+  }
+  return { data: data as Tournament[] };
 };
 
-export const getFixtures = async (): Promise<Match[]> => {
+export const getFixtures = async (): Promise<{ data: Match[]; error?: Error }> => {
   const { data, error } = await supabase.from('fixtures').select('*').order('id');
-  if (error || !data) return [];
-  return data as Match[];
+  if (error || !data) {
+    const fallback = mockTournaments.flatMap(t => t.matches);
+    return { data: fallback, error: error ?? new Error('Failed to fetch fixtures') };
+  }
+  return { data: data as Match[] };
 };
 
-export const getOffers = async (): Promise<TransferOffer[]> => {
+export const getOffers = async (): Promise<{ data: TransferOffer[]; error?: Error }> => {
   const { data, error } = await supabase.from('ofertas').select('*').order('id');
-  if (error || !data) return [];
-  return data as TransferOffer[];
+  if (error || !data) {
+    return { data: mockOffers, error: error ?? new Error('Failed to fetch offers') };
+  }
+  return { data: data as TransferOffer[] };
 };

--- a/tests/hooksFallback.test.ts
+++ b/tests/hooksFallback.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { clubs, tournaments } from '../src/data/mockData.ts';
+
+const orderMock = vi.fn();
+const selectMock = vi.fn(() => ({ order: orderMock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+const channelMock = vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() }));
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    from: fromMock,
+    channel: channelMock,
+    removeChannel: vi.fn(),
+    auth: { getSession: vi.fn(() => ({ data: { session: null } })) }
+  }
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  orderMock.mockReset();
+  selectMock.mockReturnValue({ order: orderMock });
+  fromMock.mockReturnValue({ select: selectMock });
+});
+
+describe('hooks fallback data', () => {
+  it('useClubes returns mock clubs when supabase fails', async () => {
+    orderMock.mockResolvedValueOnce({ data: null, error: new Error('fail') });
+
+    const { default: useClubes } = await import('../src/hooks/useClubes');
+    const { result } = renderHook(() => useClubes());
+
+    await act(async () => {
+      await new Promise(setImmediate);
+    });
+    expect(result.current.clubes).toEqual(clubs);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it('useTorneos returns mock tournaments when supabase fails', async () => {
+    orderMock.mockResolvedValueOnce({ data: null, error: new Error('fail') });
+
+    const { default: useTorneos } = await import('../src/hooks/useTorneos');
+    const { result } = renderHook(() => useTorneos());
+
+    await act(async () => {
+      await new Promise(setImmediate);
+    });
+    expect(result.current.torneos.length).toBe(tournaments.length);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## Summary
- use mock data in `dataService` when Supabase queries fail
- surface errors from `useClubes` and `useTorneos`
- show an error banner in LigaMaster when data comes from mocks
- adjust hooks for new `dataService` API
- add unit tests verifying mock fallbacks

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_686a5df412a48333ab02ea650738056b