### PR TITLE
Fix club reset on logout

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -327,7 +327,10 @@ export const useDataStore = create<DataState>((set) => ({
 
   setClubFromUser: (user) =>
     set((state) => {
-      if (!user?.clubId) return state;
+      if (!user) {
+        return { club: initialClub, fixtures: initialFixtures };
+      }
+      if (!user.clubId) return state;
       const baseClub = state.clubs.find(c => c.id === user.clubId);
       if (!baseClub) return state;
       const club: DtClub = {


### PR DESCRIPTION
## Summary
- reset club and fixture state when no user is present

## Testing
- `npm run test:unit`
- `npm run test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686a66ce42a883338873409ea271439e