### PR TITLE
Update LigaMaster auth check

### DIFF
--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -21,12 +21,12 @@ import useTorneos from '../hooks/useTorneos';
 import { formatDate, formatCurrency } from '../utils/helpers';
 
 const LigaMaster = () => {
-  const { user } = useAuthStore();
+  const { user, isAuthenticated } = useAuthStore();
   const { clubes, loading: loadingClubes, error: clubesError } = useClubes();
   const { torneos: tournaments, loading: loadingTorneos, error: torneosError } = useTorneos();
   const { players, standings, marketStatus } = useDataStore();
 
-  if (user?.role === 'dt') {
+  if (isAuthenticated && user?.role === 'dt') {
     if (user.clubId) {
       const assignedClub = clubes.find(c => c.id === user.clubId);
       if (assignedClub) {


### PR DESCRIPTION
## Summary
- retrieve `isAuthenticated` in LigaMaster
- show DT dashboard only when authenticated and user is a DT

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_686a66cc44008333a70f0e0e684bb3bc