### PR TITLE
Lazy load DtDashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,14 @@ function App() {
             <Route path="usuarios" element={<Users />} />
             <Route path="usuarios/:username" element={<PublicProfile />} />
             <Route path="usuario" element={<UserPanel />} />
-            <Route path="dt-dashboard" element={<DtDashboard />} />
+            <Route
+              path="dt-dashboard"
+              element={(
+                <Suspense fallback={<Spinner />}>
+                  <DtDashboard />
+                </Suspense>
+              )}
+            />
             <Route path="admin/*" element={<Admin />} />
 
             <Route path="torneos">

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
-import DtDashboard from './DtDashboard';
+import { Suspense, lazy } from 'react';
+import Spinner from '../components/Spinner';
+const DtDashboard = lazy(() => import('./DtDashboard'));
 import { useAuthStore } from '../store/authStore';
 import { 
   Trophy, 
@@ -30,7 +32,11 @@ const LigaMaster = () => {
     if (user.clubId) {
       const assignedClub = clubes.find(c => c.id === user.clubId);
       if (assignedClub) {
-        return <DtDashboard />;
+        return (
+          <Suspense fallback={<Spinner />}>
+            <DtDashboard />
+          </Suspense>
+        );
       }
     }
     return (


### PR DESCRIPTION
## Summary
- lazy load DtDashboard in LigaMaster
- wrap DtDashboard in Suspense for individual route and LigaMaster page
- verify split bundle output and run unit tests

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm test` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a66cd422483339951c23bdd0c25dc