### PR TITLE
Add Liga Master public view e2e test

### DIFF
--- a/tests/e2e/liga_master_public.cy.ts
+++ b/tests/e2e/liga_master_public.cy.ts
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+describe('Liga Master public access', () => {
+  it('shows public information when visiting without login', () => {
+    cy.visit('/liga-master');
+
+    cy.contains('h2', 'Clasificación').should('be.visible');
+    cy.contains('h2', 'Accesos Rápidos').should('be.visible');
+  });
+
+  it('does not render DT dashboard elements', () => {
+    cy.visit('/liga-master');
+
+    cy.contains('DT:').should('not.exist');
+    cy.contains('button', 'Plantilla').should('not.exist');
+    cy.contains('button', 'Mercado').should('not.exist');
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress test covering public access to Liga Master

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a6e5f244c833381daf37e27599471