### PR TITLE
Allow viewing Liga Master page in public mode

### DIFF
--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -1,7 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Suspense, lazy } from 'react';
-import Spinner from '../components/Spinner';
-const DtDashboard = lazy(() => import('./DtDashboard'));
+
 import { useAuthStore } from '../store/authStore';
 import { 
   Trophy, 
@@ -28,23 +26,9 @@ const LigaMaster = () => {
   const { torneos: tournaments, loading: loadingTorneos, error: torneosError } = useTorneos();
   const { players, standings, marketStatus } = useDataStore();
 
-  if (isAuthenticated && user?.role === 'dt') {
-    if (user.clubId) {
-      const assignedClub = clubes.find(c => c.id === user.clubId);
-      if (assignedClub) {
-        return (
-          <Suspense fallback={<Spinner />}>
-            <DtDashboard />
-          </Suspense>
-        );
-      }
-    }
-    return (
-      <div className="p-8 text-center">
-        <p>No tienes un club asignado. Contacta a un administrador.</p>
-      </div>
-    );
-  }
+  const assignedClub = isAuthenticated && user?.clubId
+    ? clubes.find(c => c.id === user.clubId)
+    : undefined;
   
   // Get active tournament (Liga Master)
   const ligaMaster = tournaments.find(t => t.id === 'tournament1');
@@ -100,6 +84,14 @@ const topScorers = [...players]
           </nav>
         )}
       />
+
+      {assignedClub && (
+        <div className="container mx-auto px-4 mb-4 text-right">
+          <Link to="/dt-dashboard" className="btn-primary inline-block">
+            Mi Club
+          </Link>
+        </div>
+      )}
       
       <div className="container mx-auto px-4 py-8">
         {/* Stats cards */}


### PR DESCRIPTION
## Summary
- simplify `LigaMaster` logic so all users see the public page
- show a **Mi Club** button linking to `/dt-dashboard` when the user has an assigned club

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aeb6aa9a083338396334577f26391