### PR TITLE
Fix JWT secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Before starting the development server, run the `supabase/migrations/create_user
 1. Copia `.env.example` a `.env` en la raíz del proyecto.
 2. En tu panel de Supabase ve a **Settings → API** y copia la `Project URL` y la clave anónima.
 3. Asigna la URL a `SUPABASE_URL` (backend) y `VITE_SUPABASE_URL` (frontend); la clave anónima a `VITE_SUPABASE_ANON_KEY` en el archivo `.env`. Estas variables definen la conexión principal a la base de datos y reemplazan la configuración previa basada en `DATABASE_URL`.
-4. Ejecuta la migración `supabase/migrations/create_users_table.sql` en tu proyecto de Supabase antes de iniciar la aplicación.
+4. Define `SUPABASE_JWT_SECRET` con el valor proporcionado por Supabase. Esta variable es obligatoria para que el servidor valide los JWT.
+5. Ejecuta la migración `supabase/migrations/create_users_table.sql` en tu proyecto de Supabase antes de iniciar la aplicación.
 
 
 El archivo `src/supabaseClient.ts` utiliza estas variables para crear el cliente de Supabase que se consume en la aplicación.

--- a/server/src/auth/strategies/jwt.strategy.ts
+++ b/server/src/auth/strategies/jwt.strategy.ts
@@ -5,9 +5,13 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor() {
+    const secret = process.env.SUPABASE_JWT_SECRET;
+    if (!secret) {
+      throw new Error('SUPABASE_JWT_SECRET environment variable is not defined');
+    }
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.SUPABASE_JWT_SECRET || 'secret',
+      secretOrKey: secret,
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure SUPABASE_JWT_SECRET is defined for the JWT strategy
- document SUPABASE_JWT_SECRET in the setup instructions

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c94487aec83338fd4363297b08ac7