### PR TITLE
Make server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ El archivo `src/data/seed.json` contiene los valores iniciales que puedes import
 ## Health Checks
 
 Comprueba que la API está activa haciendo una solicitud a `/healthz`.
+De forma predeterminada la API escucha en el puerto `3000`, pero puedes
+cambiarlo definiendo la variable de entorno `PORT`.
 El servidor responde con un **HTTP 200** si el servicio se está ejecutando.
 
 ```bash

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -7,7 +7,8 @@ async function bootstrap() {
   Sentry.init({ dsn: process.env.SENTRY_DSN });
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
-  await app.listen(3000);
+  const port = parseInt(process.env.PORT ?? '3000', 10);
+  await app.listen(port);
 }
 
 bootstrap();


### PR DESCRIPTION
## Summary
- allow configuring Nest server port with `PORT` env var
- note new option in README

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d286cd64c83339da8b103bf02ce4a