### PR TITLE
Fix Sentry init on server

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -4,7 +4,9 @@ import * as Sentry from '@sentry/node';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  Sentry.init({ dsn: process.env.SENTRY_DSN });
+  if (process.env.SENTRY_DSN) {
+    Sentry.init({ dsn: process.env.SENTRY_DSN });
+  }
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
   await app.listen(3000);


### PR DESCRIPTION
## Summary
- only initialize Sentry on the server when `SENTRY_DSN` is set

## Testing
- `npm run test` *(fails: Xvfb missing for Cypress)*

------
https://chatgpt.com/codex/tasks/task_e_686d286e49c483339a4e5f5cf0872459