### PR TITLE
Handle fetching errors for user data

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -366,7 +366,13 @@ useAuthStore.subscribe(state => {
   useDataStore.getState().setClubFromUser(state.user);
 });
 
-getUsers().then(users => {
-  useDataStore.setState({ users });
-});
+getUsers()
+  .then(users => {
+    useDataStore.setState({ users });
+  })
+  .catch(err => {
+    console.error('Error fetching users:', err);
+    // Keep existing users or initialize with an empty array
+    useDataStore.setState(state => ({ users: state.users ?? [] }));
+  });
  


### PR DESCRIPTION
## Summary
- handle errors in the initial `getUsers` call so the app can still load

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d2872780c8333bd4a47209a0dfb21