### PR TITLE
Fix auth merge order

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ values ('1', 'admin@virtualzone.com', 'admin', 'admin', 'password');
 await addUser('1', 'admin@virtualzone.com', 'admin', 'admin');
 ```
 
+Si se cambia el orden de fusión en `authService` para que los datos de la tabla
+`users` prevalezcan sobre `user_metadata`, asegúrate de que el campo `id` de
+esta fila coincida con el ID de usuario generado por Supabase Auth. De lo
+contrario, el rol de administrador no se aplicará correctamente.
+
 Para cargar datos de ejemplo puedes importar manualmente `src/data/seed.json` desde la consola o CLI de Supabase.
 
 ## Development

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -40,7 +40,8 @@ export const getCurrentUser = async (): Promise<User | null> => {
   const base = await getUserById(authUser.id);
   const mapped = mapAuthUser(authUser);
 
-  return base ? { ...base, ...mapped } : mapped;
+  // Data from the users table should override the auth metadata
+  return base ? { ...mapped, ...base } : mapped;
 };
 
 // Save current user to localStorage
@@ -119,7 +120,9 @@ export const login = async (email: string, password: string): Promise<User> => {
 
   const base = await getUserById(data.user.id);
   const authUser = mapAuthUser(data.user);
-  return base ? { ...base, ...authUser } : authUser;
+
+  // Allow values from the users table to override auth metadata
+  return base ? { ...authUser, ...base } : authUser;
 };
 
 // Logout function


### PR DESCRIPTION
## Summary
- override Supabase Auth metadata with `users` table fields
- mention ID requirement for admin row when merge order changes

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d596183f083339e30cb58055c1c91