### PR TITLE
Add comment for CalendarAdminPanel effect

### DIFF
--- a/src/adminPanel/components/admin/CalendarAdminPanel.tsx
+++ b/src/adminPanel/components/admin/CalendarAdminPanel.tsx
@@ -94,6 +94,8 @@ const CalendarAdminPanel = () => {
 
   useEffect(() => {
     setEvents(mockEvents);
+    // mockEvents is recreated on each render but contains static data
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const filteredEvents = events.filter(event => {


### PR DESCRIPTION
## Summary
- clarify why `mockEvents` isn't in the dependency list

## Testing
- `npm test` *(fails: several pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686daa926640833385b321ccdd33f722