### PR TITLE
Improve adminStorage typing

### DIFF
--- a/src/adminPanel/utils/adminStorage.ts
+++ b/src/adminPanel/utils/adminStorage.ts
@@ -21,7 +21,9 @@ export interface AdminData {
 const PREFIX = 'vz_';
 
 // Keys previously used by older admin panel versions
-const OLD_KEYS = {
+type AdminDataKey = keyof AdminData;
+
+const OLD_KEYS: Record<AdminDataKey, string> = {
   users: `${PREFIX}users_admin`,
   clubs: `${PREFIX}clubs_admin`,
   players: `${PREFIX}players_admin`,
@@ -35,7 +37,7 @@ const OLD_KEYS = {
 } as const;
 
 // Updated keys aligned with the main application
-const keys = {
+const keys: Record<AdminDataKey, string> = {
   users: VZ_USERS_KEY,
   clubs: VZ_CLUBS_KEY,
   players: VZ_PLAYERS_KEY,
@@ -48,9 +50,10 @@ const keys = {
   comments: OLD_KEYS.comments
 } as const;
 
-const migrateOldKeys = () => {
-  Object.entries(OLD_KEYS).forEach(([prop, oldKey]) => {
-    const newKey = (keys as any)[prop];
+const migrateOldKeys = (): void => {
+  (Object.keys(OLD_KEYS) as AdminDataKey[]).forEach((prop) => {
+    const oldKey = OLD_KEYS[prop];
+    const newKey = keys[prop];
     if (oldKey !== newKey) {
       const oldVal = localStorage.getItem(oldKey);
       if (oldVal && !localStorage.getItem(newKey)) {
@@ -69,11 +72,12 @@ export const loadAdminData = (defaults: AdminData): AdminData => {
   }
   const data: AdminData = { ...defaults };
   migrateOldKeys();
-  Object.entries(keys).forEach(([prop, key]) => {
+  (Object.keys(keys) as AdminDataKey[]).forEach((prop) => {
+    const key = keys[prop];
     const json = localStorage.getItem(key);
     if (json) {
       try {
-        (data as any)[prop] = JSON.parse(json);
+        data[prop] = JSON.parse(json) as AdminData[typeof prop];
       } catch {
         // ignore parse errors and keep defaults
       }
@@ -86,8 +90,9 @@ export const saveAdminData = (data: AdminData): void => {
   if (typeof localStorage === 'undefined') {
     return;
   }
-  Object.entries(keys).forEach(([prop, key]) => {
-    const value = (data as any)[prop];
+  (Object.keys(keys) as AdminDataKey[]).forEach((prop) => {
+    const key = keys[prop];
+    const value = data[prop] as AdminData[typeof prop];
     try {
       localStorage.setItem(key, JSON.stringify(value));
     } catch {


### PR DESCRIPTION
## Summary
- remove `any` casts in `adminStorage`
- type storage keys and data access for AdminData

## Testing
- `npm run test:unit` *(fails: localStorage not defined & missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_686daa91f9208333868e3688b078352d