### PR TITLE
refactor: move useAuth hook

### DIFF
--- a/src/adminPanel/App.tsx
+++ b/src/adminPanel/App.tsx
@@ -1,7 +1,8 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 import { Toaster } from 'react-hot-toast';
-import { AuthProvider, useAuth } from './contexts/AuthContext';
+import AuthProvider from './contexts/AuthContext';
+import useAuth from './hooks/useAuth';
 import SidebarAdmin from './components/SidebarAdmin';
 
 const Dashboard = lazy(() => import('./pages/admin/Dashboard'));

--- a/src/adminPanel/components/SidebarAdmin.tsx
+++ b/src/adminPanel/components/SidebarAdmin.tsx
@@ -2,7 +2,7 @@ import  { useState, useEffect } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { Menu, X, Home, Users, Globe, User, ShoppingBag, Award, FileText, MessageCircle, Activity, BarChart, Calendar } from 'lucide-react';
 import { useGlobalStore } from '../store/globalStore';
-import { useAuth } from '../contexts/AuthContext';
+import useAuth from '../hooks/useAuth';
 
 const SidebarAdmin = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/adminPanel/contexts/AuthContext.tsx
+++ b/src/adminPanel/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, ReactNode } from 'react';
 import { useAuthStore } from '../../store/authStore';
 import { User } from '../../types/shared';
 
@@ -12,9 +12,9 @@ export interface AuthContextType {
   addXP: (amount: number) => void;
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-export const AuthProvider = ({ children }: { children: ReactNode }) => {
+function AuthProvider({ children }: { children: ReactNode }) {
   const store = useAuthStore();
 
   return (
@@ -22,13 +22,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       {children}
     </AuthContext.Provider>
   );
-};
+}
 
-export const useAuth = () => {
-  const context = useContext(AuthContext);
-  if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
-  return context;
-};
- 
+export default AuthProvider; 

--- a/src/adminPanel/hooks/useAuth.ts
+++ b/src/adminPanel/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+
+export default function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -2,7 +2,7 @@ import  { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContain
 import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target } from 'lucide-react'; 
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../../contexts/AuthContext';
+import useAuth from '../../hooks/useAuth';
 import { useGlobalStore } from '../../store/globalStore';
 
 const Dashboard = () => {


### PR DESCRIPTION
## Summary
- move `useAuth` logic to `src/adminPanel/hooks/useAuth.ts`
- export `AuthProvider` as default and expose `AuthContext`
- update components to import the new `useAuth`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686daa938c0483339cc9b126842a81c5