### PR TITLE
Fix API server instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ starting the E2E tests.
 To access the administrator interface:
 
 1. Start the development server with `npm run dev`.
-nTo start the API server run:
+To start the API server run:
 ```bash
 (cd server && npm install && npm run start:dev)
 ```


### PR DESCRIPTION
## Summary
- correct the admin panel instructions to start the API server

## Testing
- `npm run test:unit` *(fails: localStorage not defined, @nestjs/testing not found)*

------
https://chatgpt.com/codex/tasks/task_e_686daa9030708333bf23e34fa7ecc026