### PR TITLE
Fix AuthContext export issue

### DIFF
--- a/src/adminPanel/contexts/AuthContext.tsx
+++ b/src/adminPanel/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode } from 'react';
+import { createContext, useContext, ReactNode } from 'react';
 import { useAuthStore } from '../../store/authStore';
 import { User } from '../../types/shared';
 
@@ -12,6 +12,7 @@ export interface AuthContextType {
   addXP: (amount: number) => void;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 function AuthProvider({ children }: { children: ReactNode }) {
@@ -31,4 +32,6 @@ export const useAuth = () => {
     throw new Error('useAuth must be used within an AuthProvider');
   }
   return context;
-}; 
+};
+
+export default AuthProvider;


### PR DESCRIPTION
## Summary
- export `AuthProvider` as default and add missing `useContext` import
- silence `react-refresh/only-export-components` warnings with eslint comments

## Testing
- `npm test` *(fails: docs/legal/terms.md Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_686db262e5f08333a974c178dc84a60c