### PR TITLE
Fix missing Filter icon import

### DIFF
--- a/src/adminPanel/pages/admin/Clubes.tsx
+++ b/src/adminPanel/pages/admin/Clubes.tsx
@@ -1,5 +1,5 @@
 import  { useState } from 'react';
-import { Plus, Search, Edit, Trash, Building, Trophy, Users, Eye } from 'lucide-react';
+import { Plus, Search, Edit, Trash, Building, Trophy, Users, Eye, Filter } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useGlobalStore } from '../../store/globalStore';
 import NewClubModal from '../../components/admin/NewClubModal';


### PR DESCRIPTION
## Summary
- import the Filter icon in Clubes.tsx

## Testing
- `npm test` *(fails during build: docs/legal/terms.md: Expression expected)*
- `npm run test:unit` *(fails: useGlobalStore.getState(...).addTournament is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_686db3bae0c883339b503ba6e74c6cd8