### PR TITLE
Add FC Barcelona club and DT

### DIFF
--- a/src/data/seed.json
+++ b/src/data/seed.json
@@ -229,6 +229,27 @@
       "reputation": 80,
       "fanBase": 7500,
       "morale": 70
+    },
+    {
+      "id": "club13",
+      "slug": "fc-barcelona",
+      "name": "FC Barcelona",
+      "logo": "https://ui-avatars.com/api/?name=FCB&background=004d98&color=fff&size=128&bold=true",
+      "foundedYear": 1899,
+      "stadium": "Camp Nou",
+      "budget": 55000000,
+      "manager": "Xavi",
+      "playStyle": "Posesión",
+      "primaryColor": "#004d98",
+      "secondaryColor": "#A50044",
+      "description": "Club histórico reconocido por su estilo de posesión y cantera prolífica.",
+      "titles": [
+        { "id": "title9", "name": "Liga", "year": 2024, "type": "league" },
+        { "id": "title10", "name": "Champions", "year": 2024, "type": "cup" }
+      ],
+      "reputation": 94,
+      "fanBase": 19500,
+      "morale": 88
     }
   ],
   "players": [

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import { VZ_CLUBS_KEY, VZ_PLAYERS_KEY, VZ_FIXTURES_KEY } from './utils/storageKe
 
 // Update this value when modifying seed.json to force re-seeding
 const SEED_VERSION_KEY = 'vz_seed_version';
-const SEED_VERSION = '3';
+const SEED_VERSION = '4';
 
 Sentry.init({ dsn: import.meta.env.VITE_SENTRY_DSN });
 
@@ -34,5 +34,4 @@ createRoot(document.getElementById('root')!).render(
       <App />
     </BrowserRouter>
   </StrictMode>
-);
- 
+); 

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -267,6 +267,23 @@ const TEST_USERS = [
     achievements: ['first_win', 'first_transfer'],
     following: { users: [], clubs: ['Rayo Digital FC'], players: [] },
     password: TEST_PASSWORD
+  },
+  {
+    id: '15',
+    username: 'dtbarca',
+    email: 'dtbarca@test.com',
+    role: 'dt',
+    level: 5,
+    xp: 500,
+    club: 'FC Barcelona',
+    clubId: 'club13',
+    avatar: 'https://ui-avatars.com/api/?name=Coach&background=00b3ff&color=fff&size=128&bold=true',
+    bio: 'Entrenador cul\u00e9 con preferencia por la posesi\u00f3n y la cantera.',
+    joinDate: new Date().toISOString(),
+    status: 'active',
+    achievements: ['first_win', 'first_transfer'],
+    following: { users: [], clubs: ['Rayo Digital FC'], players: [] },
+    password: TEST_PASSWORD
   }
 ];
 


### PR DESCRIPTION
## Summary
- add FC Barcelona entry to seed data
- include DT user for FC Barcelona
- bump seed version to reseed local storage

## Testing
- `npm run test` *(fails: build error while parsing docs/legal/terms.md)*

------
https://chatgpt.com/codex/tasks/task_e_686ddceb0efc83338f45b4f6e350cc66