### PR TITLE
Fix prize display crash in admin tournaments

### DIFF
--- a/src/adminPanel/components/admin/TournamentDetailsModal.tsx
+++ b/src/adminPanel/components/admin/TournamentDetailsModal.tsx
@@ -62,7 +62,7 @@ const TournamentDetailsModal = ({ tournament, onClose }: Props) => {
           <p>
             <span className="text-gray-400">Premio: </span>
             <span className="text-white">
-              €{tournament.prizePool.toLocaleString()}
+              €{(tournament.prizePool ?? 0).toLocaleString()}
             </span>
           </p>
           <p>

--- a/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/TournamentsAdminPanel.tsx
@@ -208,7 +208,7 @@ const TournamentsAdminPanel = () => {
                       Premio
                     </div>
                     <div className="text-white font-medium">
-                      €{tournament.prizePool.toLocaleString()}
+                      €{(tournament.prizePool ?? 0).toLocaleString()}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- handle missing prizePool fields when listing tournaments
- do the same in the tournament detail modal

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e7511b3648333948da7d9a4a885d6