### PR TITLE
Synchronize admin club changes with public view

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -317,6 +317,7 @@ export const useGlobalStore = create<GlobalStore>()(
           ]
         };
       });
+      useDataStore.getState().addClub(club);
       persist();
     },
 
@@ -341,6 +342,7 @@ export const useGlobalStore = create<GlobalStore>()(
           clubs: updatedClubs
         };
       });
+      useDataStore.getState().updateClubEntry(club);
       persist();
     },
 
@@ -355,6 +357,7 @@ export const useGlobalStore = create<GlobalStore>()(
         const updatedClubs = state.clubs.filter(c => c.id !== id);
         return { users: updatedUsers, clubs: updatedClubs };
       });
+      useDataStore.getState().removeClub(id);
       persist();
     },
 


### PR DESCRIPTION
## Summary
- propagate admin panel club operations to the main data store so edits show on the public interface

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f2bd738408333b149dfb4db157a6b