### PR TITLE
Implement admin data sync

### DIFF
--- a/src/adminPanel/store/globalStore.ts
+++ b/src/adminPanel/store/globalStore.ts
@@ -18,6 +18,7 @@ import {
 import { createClub, updateClub as apiUpdateClub } from '../../utils/clubService';
 import { createPlayer as apiCreatePlayer, updatePlayer as apiUpdatePlayer } from '../../utils/playerService';
 import { useDataStore } from '../../store/dataStore';
+import { useCommentStore } from '../../store/commentStore';
 
 interface GlobalStore {
   users: User[];
@@ -428,6 +429,7 @@ export const useGlobalStore = create<GlobalStore>()(
           }
         ]
       }));
+      useDataStore.getState().updateTransferStatus(id, 'approved');
       persist();
     },
 
@@ -445,21 +447,27 @@ export const useGlobalStore = create<GlobalStore>()(
           }
         ]
       }));
+      useDataStore.getState().updateTransferStatus(id, 'rejected');
       persist();
     },
 
     addNewsItem: item => {
       set(state => ({ newsItems: [...state.newsItems, item] }));
+      useDataStore.getState().addNewsItem(item);
       persist();
     },
 
     updateNewsItem: item => {
       set(state => ({ newsItems: state.newsItems.map(n => (n.id === item.id ? item : n)) }));
+      if (useDataStore.getState().updateNewsItem) {
+        useDataStore.getState().updateNewsItem(item);
+      }
       persist();
     },
 
     removeNewsItem: id => {
       set(state => ({ newsItems: state.newsItems.filter(n => n.id !== id) }));
+      useDataStore.getState().removeNewsItem(id);
       persist();
     },
 
@@ -467,6 +475,7 @@ export const useGlobalStore = create<GlobalStore>()(
       set(state => ({
         comments: state.comments.map(c => (c.id === id ? { ...c, status: 'approved' as const } : c))
       }));
+      useCommentStore.getState().approveComment(id);
       persist();
     },
 
@@ -474,11 +483,13 @@ export const useGlobalStore = create<GlobalStore>()(
       set(state => ({
         comments: state.comments.map(c => (c.id === id ? { ...c, status: 'hidden' as const } : c))
       }));
+      useCommentStore.getState().hideComment(id);
       persist();
     },
 
     deleteComment: id => {
       set(state => ({ comments: state.comments.filter(c => c.id !== id) }));
+      useCommentStore.getState().deleteComment(id);
       persist();
     },
 

--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -100,6 +100,10 @@ interface DataState {
   updateOfferAmount: (offerId: string, amount: number) => void;
   addTransfer: (transfer: Transfer) => void;
   removeTransfer: (id: string) => void;
+  updateTransferStatus: (
+    id: string,
+    status: 'approved' | 'rejected'
+  ) => void;
   addUser: (user: User) => void;
   addClub: (club: Club) => void;
   addPlayer: (player: Player) => void;
@@ -111,6 +115,7 @@ interface DataState {
   removePlayer: (id: string) => void;
   addTournament: (tournament: Tournament) => void;
   addNewsItem: (item: NewsItem) => void;
+  updateNewsItem: (item: NewsItem) => void;
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
   toggleTask: (id: string) => void;
@@ -216,6 +221,13 @@ export const useDataStore = create<DataState>((set) => ({
   removeTransfer: (id) =>
     set((state) => ({
       transfers: state.transfers.filter(t => t.id !== id)
+    })),
+
+  updateTransferStatus: (id, status) =>
+    set(state => ({
+      transfers: state.transfers.map(t =>
+        t.id === id ? { ...t, status } : t
+      )
     })),
 
   addUser: (user) => set((state) => ({
@@ -324,6 +336,11 @@ export const useDataStore = create<DataState>((set) => ({
   addNewsItem: (item) => set((state) => ({
     newsItems: [item, ...state.newsItems]
   })),
+
+  updateNewsItem: (item) =>
+    set(state => ({
+      newsItems: state.newsItems.map(n => (n.id === item.id ? item : n))
+    })),
 
   removeNewsItem: (id) => set((state) => ({
     newsItems: state.newsItems.filter(n => n.id !== id)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,7 @@ export interface Transfer {
   toClub: string;
   fee: number;
   date: string;
+  status?: 'pending' | 'approved' | 'rejected';
 }
 
 export interface TransferOffer {


### PR DESCRIPTION
## Summary
- augment Transfer type to hold optional status
- add updateTransferStatus and updateNewsItem to data store
- call data store and comment store from admin panel to sync updates

## Testing
- `npm run test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fd38fa7d0833385d6a6d180c0fb43