### PR TITLE
Update LatestNews loading behavior

### DIFF
--- a/src/components/Home/LatestNews.tsx
+++ b/src/components/Home/LatestNews.tsx
@@ -2,12 +2,17 @@ import { Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { formatDate, formatNewsType, getNewsTypeColor } from '../../utils/helpers';
-import SkeletonNewsFeed from './SkeletonNewsFeed';
 
 const LatestNews = () => {
   const { newsItems } = useDataStore();
 
-  if (!newsItems?.length) return <SkeletonNewsFeed />;
+  if (!newsItems?.length) {
+    return (
+      <div className="p-6 text-sm text-gray-400">
+        Cargando noticias…
+      </div>
+    );
+  }
 
   // Get latest 4 news
   const latestNews = newsItems.slice(0, 4);

--- a/tests/LatestNews.test.tsx
+++ b/tests/LatestNews.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import LatestNews from '../src/components/Home/LatestNews';
 import { useDataStore } from '../src/store/dataStore';
 
-test('LatestNews renders without news items', () => {
+test('LatestNews renders loading message when no news items', () => {
   useDataStore.setState({ newsItems: [] as any });
-  expect(() => render(<LatestNews />)).not.toThrow();
+  render(<LatestNews />);
+  expect(screen.getByText('Cargando noticias…')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- show loading message in `LatestNews` component
- remove unused `SkeletonNewsFeed` import
- test loading message behaviour

## Testing
- `npm run test:unit` *(fails: `useGlobalStore.addTournament` is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6872bd0fa58c83338ccce744ca45b499