### PR TITLE
Modify newsItems initialization

### DIFF
--- a/src/store/dataStore.ts
+++ b/src/store/dataStore.ts
@@ -119,6 +119,7 @@ interface DataState {
   removeNewsItem: (id: string) => void;
   updateStandings: (newStandings: Standing[]) => void;
   toggleTask: (id: string) => void;
+  loadNewsItems: () => void;
   setClubFromUser: (user: User | null) => void;
 }
 
@@ -129,7 +130,7 @@ export const useDataStore = create<DataState>((set) => ({
   transfers,
   offers: initialOffers,
   standings: leagueStandings,
-  newsItems,
+  newsItems: [],
   mediaItems,
   faqs,
   storeItems,
@@ -376,8 +377,10 @@ export const useDataStore = create<DataState>((set) => ({
       tasks: state.tasks.map(t =>
         t.id === id ? { ...t, done: !t.done } : t
       )
-    }))
+    })),
+  loadNewsItems: () => set({ newsItems }),
 }));
+useDataStore.getState().loadNewsItems();
 
 // Update DT club when authenticated user changes
 useAuthStore.subscribe(state => {


### PR DESCRIPTION
## Summary
- initialize `newsItems` as empty array
- expose `loadNewsItems` helper and populate mock data after store creation

## Testing
- `npm run test:unit` *(fails: localStorage not defined, missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6872bd1018a08333912dd0bbd6fc7552