### PR TITLE
Configure CORS in Nest bootstrap

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -5,7 +5,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   Sentry.init({ dsn: process.env.SENTRY_DSN });
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { cors: false });
   app.enableCors({
     origin: ['https://la-virtual-zone.app', 'http://localhost:5173'],
     credentials: true,


### PR DESCRIPTION
## Summary
- disable automatic CORS on Nest app creation
- re-enable CORS with custom options

## Testing
- `npx jest --rootDir . --testRegex '.*\.e2e-spec\.ts$' --runInBand --verbose` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_6872bd10eca48333a3d1db29d1c1f794