### PR TITLE
Lazy-load Recharts graphs

### DIFF
--- a/src/adminPanel/components/admin/StatisticsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/StatisticsAdminPanel.tsx
@@ -1,7 +1,8 @@
-import  React, { useState } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell, AreaChart, Area } from 'recharts';
+import React, { Suspense, useState } from 'react';
+const Recharts = React.lazy(() => import('recharts'));
 import { TrendingUp, TrendingDown, Users, Globe, User, Trophy, Calendar, Filter, Download, RefreshCw, ChevronDown } from 'lucide-react';
 import StatsCard from './StatsCard';
+import ChartSkeleton from '../../../components/common/ChartSkeleton';
 
 const StatisticsAdminPanel = () => {
   const [timeRange, setTimeRange] = useState('7d');
@@ -147,24 +148,25 @@ const StatisticsAdminPanel = () => {
                 </select>
               </div>
             </div>
-            <ResponsiveContainer width="100%" height={320}>
-              <AreaChart data={userGrowthData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                <XAxis dataKey="name" stroke="#9CA3AF" fontSize={12} />
-                <YAxis stroke="#9CA3AF" fontSize={12} />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#1F2937', 
+            <Suspense fallback={<ChartSkeleton />}>
+              <Recharts.ResponsiveContainer width="100%" height={320}>
+                <Recharts.AreaChart data={userGrowthData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                <Recharts.XAxis dataKey="name" stroke="#9CA3AF" fontSize={12} />
+                <Recharts.YAxis stroke="#9CA3AF" fontSize={12} />
+                <Recharts.Tooltip
+                  contentStyle={{
+                    backgroundColor: '#1F2937',
                     border: '1px solid #374151',
                     borderRadius: '12px',
                     color: '#F3F4F6'
-                  }} 
+                  }}
                 />
-                <Area 
-                  type="monotone" 
-                  dataKey={selectedMetric} 
-                  stroke="#8B5CF6" 
-                  fill="url(#areaGradient)" 
+                <Recharts.Area
+                  type="monotone"
+                  dataKey={selectedMetric}
+                  stroke="#8B5CF6"
+                  fill="url(#areaGradient)"
                   strokeWidth={3}
                 />
                 <defs>
@@ -173,8 +175,9 @@ const StatisticsAdminPanel = () => {
                     <stop offset="100%" stopColor="#8B5CF6" stopOpacity={0.05} />
                   </linearGradient>
                 </defs>
-              </AreaChart>
-            </ResponsiveContainer>
+                </Recharts.AreaChart>
+              </Recharts.ResponsiveContainer>
+            </Suspense>
           </div>
 
           {/* Device Distribution */}
@@ -183,9 +186,10 @@ const StatisticsAdminPanel = () => {
               <h3 className="text-xl font-bold text-white">Dispositivos</h3>
               <RefreshCw size={18} className="text-gray-400 hover:text-white cursor-pointer transition-colors" />
             </div>
-            <ResponsiveContainer width="100%" height={240}>
-              <PieChart>
-                <Pie
+            <Suspense fallback={<ChartSkeleton />}>
+              <Recharts.ResponsiveContainer width="100%" height={240}>
+                <Recharts.PieChart>
+                  <Recharts.Pie
                   data={deviceData}
                   cx="50%"
                   cy="50%"
@@ -195,19 +199,20 @@ const StatisticsAdminPanel = () => {
                   dataKey="value"
                 >
                   {deviceData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={entry.color} />
+                    <Recharts.Cell key={`cell-${index}`} fill={entry.color} />
                   ))}
-                </Pie>
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#1F2937', 
+                </Recharts.Pie>
+                <Recharts.Tooltip
+                  contentStyle={{
+                    backgroundColor: '#1F2937',
                     border: '1px solid #374151',
                     borderRadius: '8px',
                     color: '#F3F4F6'
-                  }} 
+                  }}
                 />
-              </PieChart>
-            </ResponsiveContainer>
+                </Recharts.PieChart>
+              </Recharts.ResponsiveContainer>
+            </Suspense>
             <div className="space-y-3 mt-4">
               {deviceData.map((item, index) => (
                 <div key={index} className="flex items-center justify-between">
@@ -235,22 +240,24 @@ const StatisticsAdminPanel = () => {
                 <p className="text-gray-400 text-sm">Sessions y duración promedio</p>
               </div>
             </div>
-            <ResponsiveContainer width="100%" height={280}>
-              <BarChart data={engagementData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                <XAxis dataKey="name" stroke="#9CA3AF" fontSize={12} />
-                <YAxis stroke="#9CA3AF" fontSize={12} />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#1F2937', 
-                    border: '1px solid #374151',
-                    borderRadius: '8px',
-                    color: '#F3F4F6'
-                  }} 
-                />
-                <Bar dataKey="sessions" fill="#3B82F6" radius={[4, 4, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
+            <Suspense fallback={<ChartSkeleton />}>
+              <Recharts.ResponsiveContainer width="100%" height={280}>
+                <Recharts.BarChart data={engagementData}>
+                  <Recharts.CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <Recharts.XAxis dataKey="name" stroke="#9CA3AF" fontSize={12} />
+                  <Recharts.YAxis stroke="#9CA3AF" fontSize={12} />
+                  <Recharts.Tooltip
+                    contentStyle={{
+                      backgroundColor: '#1F2937',
+                      border: '1px solid #374151',
+                      borderRadius: '8px',
+                      color: '#F3F4F6'
+                    }}
+                  />
+                  <Recharts.Bar dataKey="sessions" fill="#3B82F6" radius={[4, 4, 0, 0]} />
+                </Recharts.BarChart>
+              </Recharts.ResponsiveContainer>
+            </Suspense>
           </div>
 
           {/* Top Clubs */}

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -1,9 +1,11 @@
-import  { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell } from 'recharts';
-import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target } from 'lucide-react'; 
+import React, { Suspense } from 'react';
+const Recharts = React.lazy(() => import('recharts'));
+import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target } from 'lucide-react';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useGlobalStore } from '../../store/globalStore';
+import ChartSkeleton from '../../../components/common/ChartSkeleton';
 
 const Dashboard = () => {
   const { users, clubs, players, transfers, activities } = useGlobalStore();
@@ -193,33 +195,35 @@ const Dashboard = () => {
                 <span className="text-sm text-gray-300">Usuarios</span>
               </div>
             </div>
-            <ResponsiveContainer width="100%" height={320}>
-              <BarChart data={kpiData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                <XAxis dataKey="name" stroke="#9CA3AF" fontSize={12} />
-                <YAxis stroke="#9CA3AF" fontSize={12} />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#1F2937', 
-                    border: '1px solid #374151',
-                    borderRadius: '12px',
-                    color: '#F3F4F6',
-                    boxShadow: '0 10px 25px rgba(0,0,0,0.3)'
-                  }} 
-                />
-                <Bar 
-                  dataKey="users" 
-                  fill="url(#userGradient)" 
-                  radius={[4, 4, 0, 0]}
-                />
-                <defs>
-                  <linearGradient id="userGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#8B5CF6" />
-                    <stop offset="100%" stopColor="#3B82F6" />
-                  </linearGradient>
-                </defs>
-              </BarChart>
-            </ResponsiveContainer>
+            <Suspense fallback={<ChartSkeleton />}>
+              <Recharts.ResponsiveContainer width="100%" height={320}>
+                <Recharts.BarChart data={kpiData}>
+                  <Recharts.CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <Recharts.XAxis dataKey="name" stroke="#9CA3AF" fontSize={12} />
+                  <Recharts.YAxis stroke="#9CA3AF" fontSize={12} />
+                  <Recharts.Tooltip
+                    contentStyle={{
+                      backgroundColor: '#1F2937',
+                      border: '1px solid #374151',
+                      borderRadius: '12px',
+                      color: '#F3F4F6',
+                      boxShadow: '0 10px 25px rgba(0,0,0,0.3)'
+                    }}
+                  />
+                  <Recharts.Bar
+                    dataKey="users"
+                    fill="url(#userGradient)"
+                    radius={[4, 4, 0, 0]}
+                  />
+                  <defs>
+                    <linearGradient id="userGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#8B5CF6" />
+                      <stop offset="100%" stopColor="#3B82F6" />
+                    </linearGradient>
+                  </defs>
+                </Recharts.BarChart>
+              </Recharts.ResponsiveContainer>
+            </Suspense>
           </div>
 
           {/* Activity Timeline */}

--- a/src/adminPanel/pages/admin/Estadisticas.tsx
+++ b/src/adminPanel/pages/admin/Estadisticas.tsx
@@ -1,6 +1,7 @@
-import  { useState } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import React, { Suspense, useState } from 'react';
+const Recharts = React.lazy(() => import('recharts'));
 import { useGlobalStore } from '../../store/globalStore';
+import ChartSkeleton from '../../../components/common/ChartSkeleton';
 
 const Estadisticas = () => {
   const { users, clubs, players, transfers } = useGlobalStore();
@@ -72,9 +73,10 @@ const Estadisticas = () => {
         {/* Users by Role */}
         <div className="card">
           <h3 className="text-lg font-semibold mb-4">Usuarios por Rol</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
+          <Suspense fallback={<ChartSkeleton />}>
+            <Recharts.ResponsiveContainer width="100%" height={300}>
+              <Recharts.PieChart>
+                <Recharts.Pie
                 data={usersByRole}
                 cx="50%"
                 cy="50%"
@@ -82,63 +84,68 @@ const Estadisticas = () => {
                 dataKey="value"
               >
                 {usersByRole.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
+                  <Recharts.Cell key={`cell-${index}`} fill={entry.color} />
                 ))}
-              </Pie>
-              <Tooltip 
-                contentStyle={{ 
-                  backgroundColor: '#1F2937', 
+              </Recharts.Pie>
+              <Recharts.Tooltip
+                contentStyle={{
+                  backgroundColor: '#1F2937',
                   border: '1px solid #374151',
                   borderRadius: '8px',
                   color: '#F3F4F6'
-                }} 
+                }}
               />
-            </PieChart>
-          </ResponsiveContainer>
+              </Recharts.PieChart>
+            </Recharts.ResponsiveContainer>
+          </Suspense>
         </div>
 
         {/* Monthly Activity */}
         <div className="card">
           <h3 className="text-lg font-semibold mb-4">Actividad Mensual</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={monthlyData}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-              <XAxis dataKey="month" stroke="#9CA3AF" />
-              <YAxis stroke="#9CA3AF" />
-              <Tooltip 
-                contentStyle={{ 
-                  backgroundColor: '#1F2937', 
-                  border: '1px solid #374151',
-                  borderRadius: '8px',
-                  color: '#F3F4F6'
-                }} 
-              />
-              <Bar dataKey="users" fill="#3B82F6" name="Usuarios" />
-              <Bar dataKey="transfers" fill="#10B981" name="Transferencias" />
-            </BarChart>
-          </ResponsiveContainer>
+          <Suspense fallback={<ChartSkeleton />}>
+            <Recharts.ResponsiveContainer width="100%" height={300}>
+              <Recharts.BarChart data={monthlyData}>
+                <Recharts.CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                <Recharts.XAxis dataKey="month" stroke="#9CA3AF" />
+                <Recharts.YAxis stroke="#9CA3AF" />
+                <Recharts.Tooltip
+                  contentStyle={{
+                    backgroundColor: '#1F2937',
+                    border: '1px solid #374151',
+                    borderRadius: '8px',
+                    color: '#F3F4F6'
+                  }}
+                />
+                <Recharts.Bar dataKey="users" fill="#3B82F6" name="Usuarios" />
+                <Recharts.Bar dataKey="transfers" fill="#10B981" name="Transferencias" />
+              </Recharts.BarChart>
+            </Recharts.ResponsiveContainer>
+          </Suspense>
         </div>
       </div>
 
       {/* Transfers by Status */}
       <div className="card">
         <h3 className="text-lg font-semibold mb-4">Estado de Transferencias</h3>
-        <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={transfersByStatus} layout="horizontal">
-            <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-            <XAxis type="number" stroke="#9CA3AF" />
-            <YAxis dataKey="name" type="category" stroke="#9CA3AF" />
-            <Tooltip 
-              contentStyle={{ 
-                backgroundColor: '#1F2937', 
-                border: '1px solid #374151',
-                borderRadius: '8px',
-                color: '#F3F4F6'
-              }} 
-            />
-            <Bar dataKey="value" fill="#8B5CF6" />
-          </BarChart>
-        </ResponsiveContainer>
+        <Suspense fallback={<ChartSkeleton />}>
+          <Recharts.ResponsiveContainer width="100%" height={300}>
+            <Recharts.BarChart data={transfersByStatus} layout="horizontal">
+              <Recharts.CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+              <Recharts.XAxis type="number" stroke="#9CA3AF" />
+              <Recharts.YAxis dataKey="name" type="category" stroke="#9CA3AF" />
+              <Recharts.Tooltip
+                contentStyle={{
+                  backgroundColor: '#1F2937',
+                  border: '1px solid #374151',
+                  borderRadius: '8px',
+                  color: '#F3F4F6'
+                }}
+              />
+              <Recharts.Bar dataKey="value" fill="#8B5CF6" />
+            </Recharts.BarChart>
+          </Recharts.ResponsiveContainer>
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/common/ChartSkeleton.tsx
+++ b/src/components/common/ChartSkeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface ChartSkeletonProps {
+  height?: number | string;
+  className?: string;
+}
+
+const ChartSkeleton = ({ height = 300, className = '' }: ChartSkeletonProps) => (
+  <div
+    className={`grid place-items-center rounded bg-zinc-800/50 animate-pulse ${className}`.trim()}
+    style={{ height }}
+  >
+    <div className="h-12 w-12 rounded-full bg-zinc-700" />
+  </div>
+);
+
+export default ChartSkeleton;

--- a/src/components/dt-dashboard/FinanzasTab.tsx
+++ b/src/components/dt-dashboard/FinanzasTab.tsx
@@ -1,6 +1,8 @@
-import  { motion } from 'framer-motion';
+import React, { Suspense } from 'react';
+import { motion } from 'framer-motion';
 import { DollarSign, TrendingUp, TrendingDown, Target, Users, Trophy } from 'lucide-react';
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, BarChart, Bar } from 'recharts';
+const Recharts = React.lazy(() => import('recharts'));
+import ChartSkeleton from '../common/ChartSkeleton';
 import { useDataStore } from '../../store/dataStore';
 
 const formatCurrency= (amount: number) => `€${amount.toLocaleString()}`;
@@ -112,37 +114,39 @@ export default function FinanzasTab() {
         >
           <h3 className="text-xl font-bold text-white mb-6">Ingresos vs Gastos</h3>
           <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={monthlyData}>
-                <XAxis dataKey="month" stroke="#9CA3AF" />
-                <YAxis stroke="#9CA3AF" tickFormatter={(value) => `€${value / 1000000}M`} />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: '#1F2937', 
-                    border: '1px solid #374151',
-                    borderRadius: '12px',
-                    color: '#F9FAFB'
-                  }}
-                  formatter={(value: number) => [formatCurrency(value), '']}
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="income" 
-                  stroke="#10B981" 
-                  strokeWidth={3}
-                  dot={{ fill: '#10B981', strokeWidth: 2, r: 6 }}
-                  name="Ingresos"
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="expenses" 
-                  stroke="#EF4444" 
-                  strokeWidth={3}
-                  dot={{ fill: '#EF4444', strokeWidth: 2, r: 6 }}
-                  name="Gastos"
-                />
-              </LineChart>
-            </ResponsiveContainer>
+            <Suspense fallback={<ChartSkeleton />}>
+              <Recharts.ResponsiveContainer width="100%" height="100%">
+                <Recharts.LineChart data={monthlyData}>
+                  <Recharts.XAxis dataKey="month" stroke="#9CA3AF" />
+                  <Recharts.YAxis stroke="#9CA3AF" tickFormatter={(value) => `€${value / 1000000}M`} />
+                  <Recharts.Tooltip
+                    contentStyle={{
+                      backgroundColor: '#1F2937',
+                      border: '1px solid #374151',
+                      borderRadius: '12px',
+                      color: '#F9FAFB'
+                    }}
+                    formatter={(value: number) => [formatCurrency(value), '']}
+                  />
+                  <Recharts.Line
+                    type="monotone"
+                    dataKey="income"
+                    stroke="#10B981"
+                    strokeWidth={3}
+                    dot={{ fill: '#10B981', strokeWidth: 2, r: 6 }}
+                    name="Ingresos"
+                  />
+                  <Recharts.Line
+                    type="monotone"
+                    dataKey="expenses"
+                    stroke="#EF4444"
+                    strokeWidth={3}
+                    dot={{ fill: '#EF4444', strokeWidth: 2, r: 6 }}
+                    name="Gastos"
+                  />
+                </Recharts.LineChart>
+              </Recharts.ResponsiveContainer>
+            </Suspense>
           </div>
         </motion.div>
 
@@ -154,26 +158,28 @@ export default function FinanzasTab() {
         >
           <h3 className="text-xl font-bold text-white mb-6">Distribución de Gastos</h3>
           <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={expenseBreakdown} layout="horizontal">
-                <XAxis type="number" stroke="#9CA3AF" tickFormatter={(value) => `€${value / 1000000}M`} />
-                <YAxis type="category" dataKey="category" stroke="#9CA3AF" width={80} />
-                <Tooltip
-                  contentStyle={{ 
-                    backgroundColor: '#1F2937', 
-                    border: '1px solid #374151',
-                    borderRadius: '12px',
-                    color: '#F9FAFB'
-                  }}
-                  formatter={(value: number) => [formatCurrency(value), 'Gasto']}
-                />
-                <Bar 
-                  dataKey="amount" 
-                  radius={[0, 8, 8, 0]}
-                  fill={(entry) => entry.color}
-                />
-              </BarChart>
-            </ResponsiveContainer>
+            <Suspense fallback={<ChartSkeleton />}>
+              <Recharts.ResponsiveContainer width="100%" height="100%">
+                <Recharts.BarChart data={expenseBreakdown} layout="horizontal">
+                  <Recharts.XAxis type="number" stroke="#9CA3AF" tickFormatter={(value) => `€${value / 1000000}M`} />
+                  <Recharts.YAxis type="category" dataKey="category" stroke="#9CA3AF" width={80} />
+                  <Recharts.Tooltip
+                    contentStyle={{
+                      backgroundColor: '#1F2937',
+                      border: '1px solid #374151',
+                      borderRadius: '12px',
+                      color: '#F9FAFB'
+                    }}
+                    formatter={(value: number) => [formatCurrency(value), 'Gasto']}
+                  />
+                  <Recharts.Bar
+                    dataKey="amount"
+                    radius={[0, 8, 8, 0]}
+                    fill={(entry) => entry.color}
+                  />
+                </Recharts.BarChart>
+              </Recharts.ResponsiveContainer>
+            </Suspense>
           </div>
         </motion.div>
       </div>

--- a/src/components/finanzas/IncomeVsExpensesChart.tsx
+++ b/src/components/finanzas/IncomeVsExpensesChart.tsx
@@ -1,14 +1,7 @@
 
-import React, { useState } from "react";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-} from "recharts";
+import React, { Suspense, useState } from "react";
+const Recharts = React.lazy(() => import('recharts'));
+import ChartSkeleton from '../common/ChartSkeleton';
 import financeHistory from "../../data/financeHistory.json";
 
 export interface FinanceHistoryEntry {
@@ -47,16 +40,18 @@ const IncomeVsExpensesChart: React.FC<Props> = ({ data }) => {
           <option value="12m">12 meses</option>
         </select>
       </div>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={chartData}>
-          <XAxis dataKey="month" />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Bar dataKey="income" stackId="a" />
-          <Bar dataKey="expenses" stackId="a" />
-        </BarChart>
-      </ResponsiveContainer>
+      <Suspense fallback={<ChartSkeleton />}>
+        <Recharts.ResponsiveContainer width="100%" height={300}>
+          <Recharts.BarChart data={chartData}>
+            <Recharts.XAxis dataKey="month" />
+            <Recharts.YAxis />
+            <Recharts.Tooltip />
+            <Recharts.Legend />
+            <Recharts.Bar dataKey="income" stackId="a" />
+            <Recharts.Bar dataKey="expenses" stackId="a" />
+          </Recharts.BarChart>
+        </Recharts.ResponsiveContainer>
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `ChartSkeleton` component
- lazy-load `recharts` in several dashboard and finance components
- wrap charts with `Suspense`

## Testing
- `pnpm run build` *(fails: docs/legal/privacy.md - Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_6872c51df7e483338bbd261e54a0ac7a