### PR TITLE
Fix lazy import of recharts

### DIFF
--- a/src/adminPanel/components/admin/StatisticsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/StatisticsAdminPanel.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from 'react';
-const Recharts = React.lazy(() => import('recharts'));
+import * as Recharts from 'recharts';
 import { TrendingUp, TrendingDown, Users, Globe, User, Trophy, Calendar, Filter, Download, RefreshCw, ChevronDown } from 'lucide-react';
 import StatsCard from './StatsCard';
 import ChartSkeleton from '../../../components/common/ChartSkeleton';

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-const Recharts = React.lazy(() => import('recharts'));
+import * as Recharts from 'recharts';
 import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target } from 'lucide-react';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/src/adminPanel/pages/admin/Estadisticas.tsx
+++ b/src/adminPanel/pages/admin/Estadisticas.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from 'react';
-const Recharts = React.lazy(() => import('recharts'));
+import * as Recharts from 'recharts';
 import { useGlobalStore } from '../../store/globalStore';
 import ChartSkeleton from '../../../components/common/ChartSkeleton';
 

--- a/src/components/dt-dashboard/FinanzasTab.tsx
+++ b/src/components/dt-dashboard/FinanzasTab.tsx
@@ -1,7 +1,7 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import { DollarSign, TrendingUp, TrendingDown, Target, Users, Trophy } from 'lucide-react';
-const Recharts = React.lazy(() => import('recharts'));
+import * as Recharts from 'recharts';
 import ChartSkeleton from '../common/ChartSkeleton';
 import { useDataStore } from '../../store/dataStore';
 

--- a/src/components/finanzas/IncomeVsExpensesChart.tsx
+++ b/src/components/finanzas/IncomeVsExpensesChart.tsx
@@ -1,6 +1,6 @@
 
 import React, { Suspense, useState } from "react";
-const Recharts = React.lazy(() => import('recharts'));
+import * as Recharts from 'recharts';
 import ChartSkeleton from '../common/ChartSkeleton';
 import financeHistory from "../../data/financeHistory.json";
 


### PR DESCRIPTION
## Summary
- fix `recharts` import in admin and dashboard components

## Testing
- `npm run test` *(fails: @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_6872c7aa006c833387081f578be69872