### PR TITLE
Add Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Multi-stage build for La Virtual Zone
+
+# ----- Builder -----
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+COPY server/package*.json ./server/
+RUN corepack enable && pnpm install --frozen-lockfile && cd server && pnpm install --frozen-lockfile && cd ..
+COPY . .
+RUN pnpm run build && pnpm --filter ./server... run build
+
+# ----- API Runtime -----
+FROM node:20-alpine AS api-runtime
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/server ./server
+COPY --from=builder /app/node_modules ./node_modules
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["node","server/dist/main.js"]
+
+# ----- Web Runtime -----
+FROM nginx:alpine AS web-runtime
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx","-g","daemon off;"]

--- a/README.md
+++ b/README.md
@@ -138,3 +138,13 @@ El archivo `src/data/seed.json` contiene los valores iniciales que se importan e
 El proyecto se despliega automáticamente mediante **GitHub Actions**. El flujo ejecuta `npm run test` y las pruebas de `server/`, mide el rendimiento con Lighthouse CI y publica el front end en **Vercel** y el back end en **Fly.io**.
 Se requiere definir los secretos `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `FLY_API_TOKEN` y `FLY_APP` en los ajustes del repositorio. También se recomienda configurar `SENTRY_DSN` para el seguimiento de errores.
 
+
+## Despliegue con Docker
+
+Se incluye un `Dockerfile` multi-stage y un `docker-compose.yml` para levantar la base de datos, la API y la web. Ejecuta:
+
+```bash
+docker compose up --build
+```
+
+La API quedará disponible en `http://localhost:3000` y la interfaz web en `http://localhost`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: lavirtual
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  api:
+    build:
+      context: .
+      target: api-runtime
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+  web:
+    build:
+      context: .
+      target: web-runtime
+    ports:
+      - "80:80"
+    depends_on:
+      - api
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for building API and web
- add docker-compose.yml for database, API, and web containers
- document Docker deployment

## Testing
- `npm test` *(fails: 67 errors from eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6872cb1199208333bd0161cde5d54a5b