### PR TITLE
feat(api): valida variables de entorno con Zod

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,26 +10,28 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
     "@prisma/client": "^5.0.0",
+    "@sentry/node": "^7.92.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
-    "@sentry/node": "^7.92.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
-    "prisma": "^5.0.0",
-    "ts-jest": "^29.1.0",
-    "typescript": "^5.0.2",
     "@types/express": "^4.17.14",
     "@types/jest": "^29.2.5",
     "@types/node": "^18.16.0",
+    "jest": "^29.5.0",
+    "prisma": "^5.0.0",
     "supertest": "^6.3.3",
-    "jest": "^29.5.0"
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.2"
   }
 }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { envSchema } from './config/env.validation';
 import { AuthModule } from './auth/auth.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { HealthController } from './health.controller';
@@ -7,7 +9,17 @@ import { PlayersModule } from './players/players.module';
 import { MarketModule } from './market/market.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, ClubsModule, PlayersModule, MarketModule],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validate: (config) => envSchema.parse(config),
+    }),
+    PrismaModule,
+    AuthModule,
+    ClubsModule,
+    PlayersModule,
+    MarketModule,
+  ],
   controllers: [HealthController],
 })
 export class AppModule {}

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
@@ -10,9 +11,12 @@ import { PrismaModule } from '../prisma/prisma.module';
   imports: [
     PrismaModule,
     PassportModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET || 'secret',
-      signOptions: { expiresIn: '15m' },
+    JwtModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '15m' },
+      }),
+      inject: [ConfigService],
     }),
   ],
   controllers: [AuthController],

--- a/server/src/auth/strategies/jwt.strategy.ts
+++ b/server/src/auth/strategies/jwt.strategy.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly config: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.JWT_SECRET || 'secret',
+      secretOrKey: config.get<string>('JWT_SECRET'),
     });
   }
 

--- a/server/src/config/env.validation.ts
+++ b/server/src/config/env.validation.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  JWT_SECRET: z.string().min(32),
+  SENTRY_DSN: z.string().optional(),
+  PORT: z.string().regex(/^\d+$/).default('3000'),
+});

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,11 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
 import * as Sentry from '@sentry/node';
+import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  Sentry.init({ dsn: process.env.SENTRY_DSN });
   const app = await NestFactory.create(AppModule, { cors: false });
+  const config = app.get(ConfigService);
+  Sentry.init({ dsn: config.get<string>('SENTRY_DSN') });
   app.enableCors({
     origin: ['https://la-virtual-zone.app', 'http://localhost:5173'],
     credentials: true,
@@ -13,7 +15,7 @@ async function bootstrap() {
     allowedHeaders: 'Content-Type,Authorization',
   });
   app.use(cookieParser());
-  await app.listen(3000);
+  await app.listen(config.get<number>('PORT'));
 }
 
 bootstrap();

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -3,6 +3,9 @@ import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { AppModule } from '../src/app.module';
 
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
+process.env.JWT_SECRET = 'supersecretkeysupersecretkey1234';
+
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 

--- a/server/test/cors.e2e-spec.ts
+++ b/server/test/cors.e2e-spec.ts
@@ -3,6 +3,9 @@ import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { AppModule } from '../src/app.module';
 
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
+process.env.JWT_SECRET = 'supersecretkeysupersecretkey1234';
+
 describe('CORS', () => {
   let app: INestApplication;
 


### PR DESCRIPTION
## Summary
- validate environment using @nestjs/config and Zod
- wire config module globally with validation schema
- read config values via ConfigService
- update e2e tests with env vars

## Testing
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6872fd5b1c488333ac92f15e504d49af