### PR TITLE
Integrar Lighthouse CI con presupuesto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI/CD
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   build:
@@ -48,6 +49,7 @@ jobs:
           record: false
 
       - name: Lighthouse CI
+        if: github.event_name == 'pull_request'
         run: npm run lhci
 
       - name: Deploy frontend to Vercel

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,13 +1,12 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./dist"
+      "url": ["http://localhost"],
+      "numberOfRuns": 1
     },
     "assert": {
-      "preset": "lighthouse:recommended"
-    },
-    "upload": {
-      "target": "temporary-public-storage"
+      "preset": "lighthouse:recommended",
+      "budgetsFile": "budgets.json"
     }
   }
 }

--- a/budgets.json
+++ b/budgets.json
@@ -1,0 +1,16 @@
+[
+  {
+    "resourceSizes": [
+      {
+        "resourceType": "total",
+        "budget": 1600
+      }
+    ],
+    "timings": [
+      {
+        "metric": "first-contentful-paint",
+        "budget": 2000
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- config for lighthouse budgets using `budgets.json`
- update `.lighthouserc.json` to collect from localhost and use budgets
- run lighthouse in CI only on pull requests

## Testing
- `npm test` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68731395e1108333b9344b125d40a3c4