### PR TITLE
Fix JWT secret sample in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 VITE_GA_ID=YOUR_GA_ID
 VITE_SMTP_API_KEY=demo-key
 # Replace with a strong secret key (at least 32 characters)
-JWT_SECRET=change-me-to-a-long-secret-key
+JWT_SECRET=change-me-to-a-very-long-secret-key!!
 # Connection string for your Supabase project
 # Example: postgresql://USER:PASSWORD@db.supabase.co:5432/postgres?sslmode=require
 DATABASE_URL=postgresql://user:password@db.supabase.co:5432/postgres?sslmode=require


### PR DESCRIPTION
## Summary
- provide a longer JWT secret sample in `.env.example`

## Testing
- `npm test` *(fails: 67 errors from eslint)*

------
https://chatgpt.com/codex/tasks/task_e_687329075e3c83338de4f4de9533f4d6