### PR TITLE
Fix Supabase client process env fallback

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,10 +1,19 @@
 import { createClient } from '@supabase/supabase-js'
+
+interface Env {
+  VITE_SUPABASE_URL?: string
+  VITE_SUPABASE_ANON_KEY?: string
+}
+
+const env = import.meta.env as Env
+
 const url =
-  (import.meta as any).env?.VITE_SUPABASE_URL ||
-  process.env.VITE_SUPABASE_URL ||
+  env.VITE_SUPABASE_URL ||
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_URL : undefined) ||
   'http://localhost'
+
 const key =
-  (import.meta as any).env?.VITE_SUPABASE_ANON_KEY ||
-  process.env.VITE_SUPABASE_ANON_KEY ||
+  env.VITE_SUPABASE_ANON_KEY ||
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_ANON_KEY : undefined) ||
   'public-anon-key'
 export const supabase = createClient(url, key)


### PR DESCRIPTION
## Summary
- guard against undefined `process` in `supabaseClient`

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68752f0381748333b0ae31a58ee2464b