### PR TITLE
Phase 2 supabase migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ The platform now stores all data in a PostgreSQL database managed by Prisma. Run
 
 5. Start the API and the web app as usual. The backend will now connect to Supabase using the credentials from `.env`.
 
+### Seed Supabase
+
+Run the following command to populate the Supabase tables with demo data:
+
+```bash
+pnpm seed:supabase
+```
+
 ## Recuperar contraseña
 
 Puedes solicitar un enlace en `/recuperar-password`; con el token recibido podrás definir una nueva contraseña en `/reset/:token`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lhci": "lhci autorun",
     "cypress:open": "cypress open",
     "test:unit": "vitest run",
-    "test": "npm run lint && npm run build && npm run test:unit && (npx cypress run || echo \"Skipping e2e tests: Cypress not installed\")"
+    "test": "npm run lint && npm run build && npm run test:unit && (npx cypress run || echo \"Skipping e2e tests: Cypress not installed\")",
+    "seed:supabase": "ts-node scripts/seedSupabase.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -58,5 +59,6 @@
     "typescript-eslint": "^8.34.1",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"
+    ,"ts-node": "^10.9.1"
   }
 }

--- a/scripts/seedData.json
+++ b/scripts/seedData.json
@@ -1,0 +1,10 @@
+{
+  "clubs": [
+    { "id": "1", "name": "Demo FC", "slug": "demo-fc", "owner_id": "1" },
+    { "id": "2", "name": "Sample United", "slug": "sample-united", "owner_id": "2" }
+  ],
+  "players": [
+    { "id": "1", "name": "Player One", "club_id": "1", "position": "GK", "rating": 80 },
+    { "id": "2", "name": "Player Two", "club_id": "2", "position": "ST", "rating": 85 }
+  ]
+}

--- a/scripts/seedSupabase.ts
+++ b/scripts/seedSupabase.ts
@@ -1,0 +1,29 @@
+import { createClient } from '@supabase/supabase-js'
+import fs from 'fs'
+
+const supabase = createClient(
+  process.env.VITE_SUPABASE_URL || '',
+  process.env.VITE_SUPABASE_SERVICE_KEY || ''
+)
+
+async function run() {
+  const file = fs.readFileSync('scripts/seedData.json', 'utf-8')
+  const data = JSON.parse(file)
+
+  if (data.clubs) {
+    for (const club of data.clubs) {
+      await supabase.from('clubs').insert(club)
+    }
+  }
+
+  if (data.players) {
+    for (const player of data.players) {
+      await supabase.from('players').insert(player)
+    }
+  }
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const ClubProfile = lazy(() => import("./pages/ClubProfile"));
 const ClubFinances = lazy(() => import("./pages/ClubFinances"));
 const ClubSquad = lazy(() => import("./pages/ClubSquad"));
 const Admin = lazy(() => import("./pages/Admin"));
+import { AdminRoute } from "./router/AdminRoute";
 
 function App() {
   return (
@@ -63,7 +64,9 @@ function App() {
             <Route path="usuarios/:username" element={<PublicProfile />} />
             <Route path="usuario" element={<UserPanel />} />
             <Route path="dt-dashboard" element={<DtDashboard />} />
-            <Route path="admin/*" element={<Admin />} />
+            <Route element={<AdminRoute />}>
+              <Route path="admin/*" element={<Admin />} />
+            </Route>
 
             <Route path="torneos">
               <Route index element={<Tournaments />} />

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,22 +1,44 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react'
+import { supabase } from '@/lib/supabaseClient'
 
 function usePersistentState<T>(key: string, defaultValue: T): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [state, setState] = useState<T>(() => {
-    if (typeof localStorage === 'undefined') return defaultValue;
-    const stored = localStorage.getItem(key);
-    return stored ? JSON.parse(stored) as T : defaultValue;
-  });
+  const [state, setState] = useState<T>(defaultValue)
 
   useEffect(() => {
-    if (typeof localStorage === 'undefined') return;
-    try {
-      localStorage.setItem(key, JSON.stringify(state));
-    } catch {
-      // ignore write errors
+    let isMounted = true
+    supabase
+      .from('persistent_state')
+      .select('value')
+      .eq('key', key)
+      .single()
+      .then(({ data, error }) => {
+        if (!error && data && isMounted) {
+          setState(data.value as T)
+        } else if (typeof localStorage !== 'undefined') {
+          const stored = localStorage.getItem(key)
+          if (stored && isMounted) setState(JSON.parse(stored) as T)
+        }
+      })
+    return () => {
+      isMounted = false
     }
-  }, [key, state]);
+  }, [key])
 
-  return [state, setState];
+  useEffect(() => {
+    supabase
+      .from('persistent_state')
+      .upsert({ key, value: state })
+      .catch(() => {})
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem(key, JSON.stringify(state))
+      } catch {
+        // ignore write errors
+      }
+    }
+  }, [key, state])
+
+  return [state, setState]
 }
 
-export default usePersistentState;
+export default usePersistentState

--- a/src/router/AdminRoute.tsx
+++ b/src/router/AdminRoute.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { Navigate, Outlet } from 'react-router-dom'
+import { AuthContext } from '@/contexts/AuthContext'
+
+export const AdminRoute = () => {
+  const { user } = useContext(AuthContext)
+  return user?.user_metadata?.role === 'ADMIN' ? <Outlet /> : <Navigate to="/" />
+}

--- a/src/store/commentStore.ts
+++ b/src/store/commentStore.ts
@@ -1,61 +1,41 @@
-import { create } from 'zustand';
-import { Comment } from '../types';
-import { VZ_COMMENTS_KEY } from '../utils/storageKeys';
-
-const loadComments = (): Comment[] => {
-  const json = localStorage.getItem(VZ_COMMENTS_KEY);
-  return json ? JSON.parse(json) : [];
-};
-
-const saveComments = (comments: Comment[]) => {
-  localStorage.setItem(VZ_COMMENTS_KEY, JSON.stringify(comments));
-};
+import { create } from 'zustand'
+import { supabase } from '@/lib/supabaseClient'
+import { Comment } from '@/types'
 
 interface CommentState {
-  comments: Comment[];
-  addComment: (comment: Comment) => void;
-  reportComment: (id: string) => void;
-  approveComment: (id: string) => void;
-  hideComment: (id: string) => void;
-  deleteComment: (id: string) => void;
+  comments: Comment[]
+  fetchComments: () => Promise<void>
+  addComment: (comment: Omit<Comment, 'id' | 'created_at'>) => Promise<void>
+  approveComment: (id: string) => Promise<void>
+  hideComment: (id: string) => Promise<void>
+  deleteComment: (id: string) => Promise<void>
 }
 
-export const useCommentStore = create<CommentState>(set => ({
-  comments: loadComments(),
-  addComment: comment =>
-    set(state => {
-      const updated = [comment, ...state.comments];
-      saveComments(updated);
-      return { comments: updated };
-    }),
-  reportComment: id =>
-    set(state => {
-      const updated = state.comments.map(c =>
-        c.id === id ? { ...c, reported: true } : c
-      );
-      saveComments(updated);
-      return { comments: updated };
-    }),
-  approveComment: id =>
-    set(state => {
-      const updated = state.comments.map(c =>
-        c.id === id ? { ...c, reported: false, hidden: false } : c
-      );
-      saveComments(updated);
-      return { comments: updated };
-    }),
-  hideComment: id =>
-    set(state => {
-      const updated = state.comments.map(c =>
-        c.id === id ? { ...c, hidden: true, reported: false } : c
-      );
-      saveComments(updated);
-      return { comments: updated };
-    }),
-  deleteComment: id =>
-    set(state => {
-      const updated = state.comments.filter(c => c.id !== id);
-      saveComments(updated);
-      return { comments: updated };
-    }),
-}));
+export const useCommentStore = create<CommentState>((set) => ({
+  comments: [],
+  fetchComments: async () => {
+    const { data, error } = await supabase.from('comments').select('*').order('created_at')
+    if (error) throw error
+    set({ comments: data })
+  },
+  addComment: async (comment) => {
+    const { data, error } = await supabase.from('comments').insert(comment).single()
+    if (error) throw error
+    set((state) => ({ comments: [data, ...state.comments] }))
+  },
+  approveComment: async (id) => {
+    const { data, error } = await supabase.from('comments').update({ reported: false, hidden: false }).eq('id', id).single()
+    if (error) throw error
+    set((state) => ({ comments: state.comments.map(c => c.id === id ? data : c) }))
+  },
+  hideComment: async (id) => {
+    const { data, error } = await supabase.from('comments').update({ hidden: true, reported: false }).eq('id', id).single()
+    if (error) throw error
+    set((state) => ({ comments: state.comments.map(c => c.id === id ? data : c) }))
+  },
+  deleteComment: async (id) => {
+    const { error } = await supabase.from('comments').delete().eq('id', id)
+    if (error) throw error
+    set((state) => ({ comments: state.comments.filter(c => c.id !== id) }))
+  }
+}))

--- a/src/utils/clubService.ts
+++ b/src/utils/clubService.ts
@@ -1,30 +1,34 @@
-import { Club } from '../types/shared';
-import { VZ_CLUBS_KEY } from './storageKeys';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabaseClient'
 
-export const getClubs = (): Club[] => {
-  const json =
-    typeof localStorage === 'undefined'
-      ? null
-      : localStorage.getItem(VZ_CLUBS_KEY);
-  if (json) {
-    try {
-      return JSON.parse(json) as Club[];
-    } catch {
-      // ignore parse errors and fall back to seed
-    }
-  }
-  supabase.from('clubs').select('*').then(({ data, error }) => {
-    if (!error && data) {
-      if (typeof localStorage !== 'undefined') {
-        localStorage.setItem(VZ_CLUBS_KEY, JSON.stringify(data));
-      }
-    }
-  });
-  return [] as Club[];
-};
+export const fetchClubs = async () => {
+  const { data, error } = await supabase
+    .from('clubs')
+    .select('*')
+    .order('created_at')
+  if (error) throw error
+  return data
+}
 
-export const saveClubs = (clubs: Club[]): void => {
-  if (typeof localStorage === 'undefined') return;
-  localStorage.setItem(VZ_CLUBS_KEY, JSON.stringify(clubs));
-};
+export const createClub = async (payload: { name: string; owner_id: string }) => {
+  const { data, error } = await supabase
+    .from('clubs')
+    .insert(payload)
+    .single()
+  if (error) throw error
+  return data
+}
+
+export const updateClub = async (id: string, payload: Partial<{ name: string; owner_id: string }>) => {
+  const { data, error } = await supabase
+    .from('clubs')
+    .update(payload)
+    .eq('id', id)
+    .single()
+  if (error) throw error
+  return data
+}
+
+export const deleteClub = async (id: string) => {
+  const { error } = await supabase.from('clubs').delete().eq('id', id)
+  if (error) throw error
+}

--- a/src/utils/offerService.ts
+++ b/src/utils/offerService.ts
@@ -1,20 +1,35 @@
-import { TransferOffer } from '../types';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabaseClient'
+import { TransferOffer } from '@/types'
 
-export const getOffers = (): TransferOffer[] => {
-  supabase.from('transfers').select('*').then(({ data, error }) => {
-    if (error) console.error(error);
-    else if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('vz_offers', JSON.stringify(data));
-    }
-  });
-  const json = typeof localStorage === 'undefined' ? null : localStorage.getItem('vz_offers');
-  return json ? JSON.parse(json) as TransferOffer[] : [];
-};
+export const fetchOffers = async () => {
+  const { data, error } = await supabase
+    .from('transfers')
+    .select('*')
+    .order('created_at')
+  if (error) throw error
+  return data as TransferOffer[]
+}
 
-export const saveOffers = (data: TransferOffer[]): void => {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('vz_offers', JSON.stringify(data));
-  }
-  supabase.from('transfers').upsert(data).catch(console.error);
-};
+export const createOffer = async (payload: Omit<TransferOffer, 'id' | 'created_at'>) => {
+  const { data, error } = await supabase
+    .from('transfers')
+    .insert(payload)
+    .single()
+  if (error) throw error
+  return data as TransferOffer
+}
+
+export const updateOffer = async (id: string, payload: Partial<TransferOffer>) => {
+  const { data, error } = await supabase
+    .from('transfers')
+    .update(payload)
+    .eq('id', id)
+    .single()
+  if (error) throw error
+  return data as TransferOffer
+}
+
+export const deleteOffer = async (id: string) => {
+  const { error } = await supabase.from('transfers').delete().eq('id', id)
+  if (error) throw error
+}

--- a/src/utils/playerService.ts
+++ b/src/utils/playerService.ts
@@ -1,24 +1,34 @@
-import { Player } from '../types/shared';
-import { VZ_PLAYERS_KEY } from './storageKeys';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabaseClient'
 
-export const getPlayers = (): Player[] => {
-  const json = localStorage.getItem(VZ_PLAYERS_KEY);
-  if (json) {
-    try {
-      return JSON.parse(json) as Player[];
-    } catch {
-      // ignore
-    }
-  }
-  supabase.from('players').select('*').then(({ data, error }) => {
-    if (!error && data) {
-      localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(data));
-    }
-  });
-  return [] as Player[];
-};
+export const fetchPlayers = async () => {
+  const { data, error } = await supabase
+    .from('players')
+    .select('*')
+    .order('created_at')
+  if (error) throw error
+  return data
+}
 
-export const savePlayers = (data: Player[]): void => {
-  localStorage.setItem(VZ_PLAYERS_KEY, JSON.stringify(data));
-};
+export const createPlayer = async (payload: { name: string; club_id: string; position: string; rating: number }) => {
+  const { data, error } = await supabase
+    .from('players')
+    .insert(payload)
+    .single()
+  if (error) throw error
+  return data
+}
+
+export const updatePlayer = async (id: string, payload: Partial<{ name: string; club_id: string; position: string; rating: number }>) => {
+  const { data, error } = await supabase
+    .from('players')
+    .update(payload)
+    .eq('id', id)
+    .single()
+  if (error) throw error
+  return data
+}
+
+export const deletePlayer = async (id: string) => {
+  const { error } = await supabase.from('players').delete().eq('id', id)
+  if (error) throw error
+}


### PR DESCRIPTION
## Summary
- fetch and mutate data in Supabase for clubs, players and offers
- migrate comment store to Supabase
- keep persistent state in Supabase with local cache fallback
- protect admin routes with new AdminRoute component
- add script to seed demo data into Supabase
- document new `seed:supabase` script

## Testing
- `pnpm test` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68755f25e61c8333983a5f0c9817b3da