### PR TITLE
Fix broken import paths

### DIFF
--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { supabase } from '@/lib/supabaseClient'
+import { supabase } from '../lib/supabaseClient'
 
 function usePersistentState<T>(key: string, defaultValue: T): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [state, setState] = useState<T>(defaultValue)

--- a/src/router/AdminRoute.tsx
+++ b/src/router/AdminRoute.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import { Navigate, Outlet } from 'react-router-dom'
-import { AuthContext } from '@/contexts/AuthContext'
+import { AuthContext } from '../contexts/AuthContext'
 
 export const AdminRoute = () => {
   const { user } = useContext(AuthContext)

--- a/src/store/commentStore.ts
+++ b/src/store/commentStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
-import { supabase } from '@/lib/supabaseClient'
-import { Comment } from '@/types'
+import { supabase } from '../lib/supabaseClient'
+import { Comment } from '../types'
 
 interface CommentState {
   comments: Comment[]

--- a/src/utils/clubService.ts
+++ b/src/utils/clubService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabaseClient'
+import { supabase } from '../lib/supabaseClient'
 
 export const fetchClubs = async () => {
   const { data, error } = await supabase

--- a/src/utils/offerService.ts
+++ b/src/utils/offerService.ts
@@ -1,5 +1,5 @@
-import { supabase } from '@/lib/supabaseClient'
-import { TransferOffer } from '@/types'
+import { supabase } from '../lib/supabaseClient'
+import { TransferOffer } from '../types'
 
 export const fetchOffers = async () => {
   const { data, error } = await supabase

--- a/src/utils/playerService.ts
+++ b/src/utils/playerService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabaseClient'
+import { supabase } from '../lib/supabaseClient'
 
 export const fetchPlayers = async () => {
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- use relative imports instead of `@/` alias

## Testing
- `npm run lint` *(fails: no-unused-vars and other errors)*
- `npm run test:unit` *(fails: getClubs not a function)*
- `npm run build` *(fails: docs/legal/terms.md Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_687561d9517883339bba0d02e752978e