### PR TITLE
Fix mdx plugin query handling

### DIFF
--- a/scripts/mdxPlugin.ts
+++ b/scripts/mdxPlugin.ts
@@ -17,7 +17,8 @@ export default function mdxPlugin(): Plugin {
   return {
     name: 'mdx-lite',
     transform(code, id) {
-      if (id.endsWith('.md') || id.endsWith('.mdx')) {
+      const [path] = id.split('?');
+      if (path.endsWith('.md') || path.endsWith('.mdx')) {
         const html = mdToHtml(code);
         const component = `import React from 'react';\nexport default function MDXContent(){return <div className="prose prose-invert" dangerouslySetInnerHTML={{__html: ${JSON.stringify(html)}}} />}`;
         return { code: component, map: null };


### PR DESCRIPTION
## Summary
- sanitize id in mdxPlugin so the `.md` check ignores query params

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run test:unit` *(fails: addTournament and missing packages)*
- `npx vite build` *(fails: Expression expected in MD files)*

------
https://chatgpt.com/codex/tasks/task_e_68792e8afd688333b0004339427d22e6