### PR TITLE
Add global error boundary

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,7 +32,9 @@ if (typeof localStorage !== 'undefined') {
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-      <App />
+      <AppErrorBoundary>
+        <App />
+      </AppErrorBoundary>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap the app with AppErrorBoundary so errors render a friendly fallback

## Testing
- `npm run test` *(fails: lots of eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879303a9c4083338d38350ccf107a66