### PR TITLE
feat: enable DT participation request

### DIFF
--- a/src/components/common/RequestClubModal.tsx
+++ b/src/components/common/RequestClubModal.tsx
@@ -1,0 +1,60 @@
+import { useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import { useAuthStore } from '../../store/authStore';
+import { useActivityLogStore } from '../../store/activityLogStore';
+
+interface Props {
+  onClose: () => void;
+}
+
+const RequestClubModal = ({ onClose }: Props) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
+  const [sent, setSent] = useState(false);
+  const { user } = useAuthStore();
+  const { addLog } = useActivityLogStore();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (user) {
+      addLog('dt_request', user.id, `${user.username} solicitó un club`);
+    }
+    setSent(true);
+    setTimeout(onClose, 1500);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose}></div>
+      <div
+        className="relative bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="request-club-title"
+        ref={dialogRef}
+      >
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+          <X size={24} />
+        </button>
+        {sent ? (
+          <div className="text-center">
+            <p className="font-semibold mb-2">Solicitud enviada</p>
+            <p className="text-sm text-gray-400">Te avisaremos cuando haya un club disponible.</p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <h3 id="request-club-title" className="text-xl font-bold">Solicitar participación</h3>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">Mensaje</label>
+              <textarea className="input w-full" rows={3} required></textarea>
+            </div>
+            <button type="submit" className="btn-primary w-full">Enviar Solicitud</button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RequestClubModal;

--- a/src/pages/UserPanel.tsx
+++ b/src/pages/UserPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
+import RequestClubModal from '../components/common/RequestClubModal';
 import { xpForNextLevel } from '../utils/helpers';
 
 const UserPanel = () => {
@@ -22,6 +23,7 @@ const UserPanel = () => {
   const navigate = useNavigate();
   
   const [activeTab, setActiveTab] = useState('profile');
+  const [showRequestModal, setShowRequestModal] = useState(false);
   
   // Initialize following property if it doesn't exist
   const following = user?.following || { clubs: [], users: [] };
@@ -281,7 +283,10 @@ const UserPanel = () => {
                   <p className="text-gray-300 mb-4">
                     Para participar en la Liga Master necesitas convertirte en Director Técnico y administrar un club. Solicita un puesto para la próxima temporada.
                   </p>
-                  <button className="btn-primary">
+                  <button
+                    className="btn-primary"
+                    onClick={() => setShowRequestModal(true)}
+                  >
                     Solicitar participación como DT
                   </button>
                 </div>
@@ -945,8 +950,11 @@ const UserPanel = () => {
               </div>
             </div>
           )}
-        </div>
       </div>
+    </div>
+    {showRequestModal && (
+      <RequestClubModal onClose={() => setShowRequestModal(false)} />
+    )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add RequestClubModal component for DT participation
- hook up modal in UserPanel so the button opens it

## Testing
- `npm test` *(fails: lint errors in repository)*
- `npm run test:unit` *(fails: localStorage not defined / missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687946db069c833384dd0ed356bc4c62