### PR TITLE
Fix admin panel instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ starting the E2E tests.
 To access the administrator interface:
 
 1. Start the development server with `npm run dev`.
-nTo start the API server run:
+To start the API server run:
 ```bash
 (cd server && npm install && npm run start:dev)
 ```


### PR DESCRIPTION
## Summary
- fix stray `n` in README admin panel instructions

## Testing
- `npm test` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68825ec991588333805d574e5ce3ea4e