### PR TITLE
Fix html2canvas definition newline

### DIFF
--- a/src/types/html2canvas.d.ts
+++ b/src/types/html2canvas.d.ts
@@ -1,1 +1,1 @@
-declare module 'html2canvas'; 
+declare module 'html2canvas';


### PR DESCRIPTION
## Summary
- add a trailing newline to `src/types/html2canvas.d.ts`

## Testing
- `npm run test --silent` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68825ecab1008333ab7f527c280f8fb0