### PR TITLE
Enhance economy management and store integration

### DIFF
--- a/src/adminPanel/components/admin/StoreAdminPanel.tsx
+++ b/src/adminPanel/components/admin/StoreAdminPanel.tsx
@@ -28,7 +28,7 @@ const StoreAdminPanel = () => {
   const [form, setForm] = useState(initialForm);
   const [editingProduct, setEditingProduct] = useState<StoreItem | null>(null);
 
-  const { purchases } = useStoreSlice();
+  const { purchases, refundPurchase } = useStoreSlice();
 
   const [filterUser, setFilterUser] = useState('');
   const [filterProduct, setFilterProduct] = useState('');
@@ -207,7 +207,15 @@ const StoreAdminPanel = () => {
                   <td className="py-2">{tx.productId}</td>
                   <td className="py-2">{tx.userId}</td>
                   <td className="py-2">{new Date(tx.date).toLocaleString()}</td>
-                  <td className="py-2">{tx.status==='success' ? <span className="text-green-400">Entregado</span> : <span className="text-red-400">Revertido</span>}</td>
+                  <td className="py-2">
+                    {tx.status==='success' ? (
+                      <button aria-label="Revertir" className="text-yellow-400" onClick={()=>{refundPurchase(tx.id); toast.success('Compra revertida');}}>
+                        Revertir
+                      </button>
+                    ) : (
+                      <span className="text-red-400">Revertido</span>
+                    )}
+                  </td>
                 </tr>
               ))}
               {filteredPurchases.length===0 && (<tr><td colSpan={5} className="text-center py-6 text-gray-500">Sin resultados</td></tr>)}

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -4,6 +4,7 @@ import { Search, AlertCircle, ShoppingCart, X } from 'lucide-react';
 import { useStoreSlice } from '../store/storeSlice';
 import { useAuthStore } from '../store/authStore';
 import { useShopStore } from '../store/shopStore';
+import { useEconomySlice } from '../store/economySlice';
 import toast from 'react-hot-toast';
 import { formatCurrency } from '../utils/helpers';
 import { getRarityClasses } from '../utils/rarity';
@@ -18,8 +19,10 @@ const Store = () => {
   const [showConfirm, setShowConfirm] = useState(false);
 
   const { activeItems } = useStoreSlice();
-  const { coins, ownedItemIds, cartIds, addToCart, removeFromCart, clearCart, checkout } = useShopStore();
+  const { ownedItemIds, cartIds, addToCart, removeFromCart, clearCart, checkout } = useShopStore();
   const { user } = useAuthStore();
+  const { getBalance } = useEconomySlice();
+  const coins = getBalance(user?.id || 'anonymous');
   const userLevel = user?.level ?? 1;
   
   // Filter store items

--- a/src/store/storeSlice.ts
+++ b/src/store/storeSlice.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
 import { StoreItem } from '../types';
 import { storeItems as seedItems } from '../data/mockData';
+import { useEconomySlice } from './economySlice';
 
 export interface PurchaseTx {
   id: string;
@@ -20,6 +21,8 @@ interface StoreSlice {
   updateStoreItem: (id: string, data: Partial<StoreItem>) => void;
   removeStoreItem: (id: string) => void;
   addPurchase: (productId: string, userId: string) => void;
+  purchaseProduct: (productId: string, userId: string) => { success: boolean; message: string };
+  refundPurchase: (purchaseId: string) => void;
   /* Selectors */
   activeItems: () => StoreItem[];
   soldOutItems: () => StoreItem[];
@@ -95,6 +98,45 @@ export const useStoreSlice = create<StoreSlice>()(
         });
         get().refreshStatuses();
       },
+      purchaseProduct: (productId, userId) => {
+        const product = get().products.find(p => p.id === productId);
+        if (!product) return { success: false, message: 'Producto no encontrado' };
+        const price = product.price;
+        const ok = useEconomySlice.getState().createTransaction({
+          userId,
+          amount: price,
+          type: 'debit',
+          source: 'store',
+          reason: `Compra ${product.name}`,
+          refId: productId,
+        });
+        if (!ok) return { success: false, message: 'Saldo insuficiente' };
+        get().addPurchase(productId, userId);
+        return { success: true, message: 'Compra realizada' };
+      },
+      refundPurchase: (purchaseId) => {
+        const purchase = get().purchases.find(p => p.id === purchaseId && p.status === 'success');
+        if (!purchase) return;
+        const product = get().products.find(p => p.id === purchase.productId);
+        if (product?.stock !== undefined && product.stock !== null) {
+          const newStock = (product.stock || 0) + 1;
+          set({
+            products: get().products.map(p => p.id === product.id ? { ...p, stock: newStock, inStock: true } : p)
+          });
+        }
+        set({
+          purchases: get().purchases.map(p => p.id === purchaseId ? { ...p, status: 'refunded' } : p),
+        });
+        useEconomySlice.getState().createTransaction({
+          userId: purchase.userId,
+          amount: product?.price || 0,
+          type: 'credit',
+          source: 'store',
+          reason: 'Reverso compra',
+          refId: purchaseId,
+        });
+        get().refreshStatuses();
+      },
       /* Memoized selectors usando closures */
       activeItems: () => get().products.filter((p) => isActive(p)),
       soldOutItems: () => get().products.filter((p) => !p.inStock),
@@ -112,4 +154,4 @@ export const useStoreSlice = create<StoreSlice>()(
 );
 
 // efecto inicial para refrescar estados una vez cargado
-useStoreSlice.getState().refreshStatuses(); 
+useStoreSlice.getState().refreshStatuses();


### PR DESCRIPTION
## Summary
- refactor economy slice with strict typing for wallets, transactions and rules
- add purchase/refund logic to store slice and hook shop store to it
- display balance from economy state in the public store
- show KPIs and charts from transactions in admin panel with filters and CSV export
- allow admins to revert store purchases

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688555852cd88333a922293b93fffe15