### PR TITLE
Use admin store state in public shop

### DIFF
--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -18,12 +18,15 @@ const Store = () => {
   const [previewItem, setPreviewItem] = useState<StoreItem | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
 
-  const { activeItems } = useStoreSlice();
-  const { ownedItemIds, cartIds, addToCart, removeFromCart, clearCart, checkout } = useShopStore();
+  const { activeItems, purchases } = useStoreSlice();
+  const { cartIds, addToCart, removeFromCart, clearCart, checkout } = useShopStore();
   const { user } = useAuthStore();
   const { getBalance } = useEconomySlice();
   const coins = getBalance(user?.id || 'anonymous');
   const userLevel = user?.level ?? 1;
+  const ownedItemIds = purchases
+    .filter(p => p.status === 'success' && p.userId === (user?.id || 'anonymous'))
+    .map(p => p.productId);
   
   // Filter store items
   let filteredItems = activeItems().filter(product => {


### PR DESCRIPTION
## Summary
- derive owned items from the shared store slice on the public store page

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68855a631a74833387a34fdd55b26f31