### PR TITLE
Improve accessibility for menus and modals

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -31,6 +31,7 @@ const Footer = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white"
+                aria-label="GitHub"
               >
                 <Github size={20} />
               </a>
@@ -39,6 +40,7 @@ const Footer = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white"
+                aria-label="Twitter"
               >
                 <Twitter size={20} />
               </a>
@@ -47,6 +49,7 @@ const Footer = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white"
+                aria-label="Instagram"
               >
                 <Instagram size={20} />
               </a>
@@ -55,6 +58,7 @@ const Footer = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white"
+                aria-label="Facebook"
               >
                 <Facebook size={20} />
               </a>

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -1,12 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Menu, X, User, LogOut, ChevronDown, Settings, Trophy, Shield, ShoppingCart } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { calculateLevel } from '../../utils/helpers';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement>(null);
   const { user, isAuthenticated, logout } = useAuthStore();
   const navigate = useNavigate();
   
@@ -23,6 +26,16 @@ const Navbar = () => {
       window.removeEventListener('popstate', closeMenu);
     };
   }, []);
+
+  useFocusTrap(userMenuRef);
+  useEscapeKey(() => setUserMenuOpen(false), userMenuOpen);
+
+  useEffect(() => {
+    if (userMenuOpen && userMenuRef.current) {
+      const first = userMenuRef.current.querySelector<HTMLElement>('a,button');
+      first?.focus();
+    }
+  }, [userMenuOpen]);
   
   const handleLogout = () => {
     logout();
@@ -95,6 +108,7 @@ const Navbar = () => {
               <div className="relative ml-3">
                 <div>
                   <button
+                    aria-label="Menú de usuario"
                     onClick={() => setUserMenuOpen(!userMenuOpen)}
                     className="flex items-center text-sm rounded-full focus:outline-none"
                   >
@@ -113,8 +127,8 @@ const Navbar = () => {
                 
                 {/* User dropdown menu */}
                 {userMenuOpen && (
-                  <div className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
-                    <div className="py-1">
+                  <div className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-10" ref={userMenuRef}>
+                    <div className="py-1" role="menu">
                       <Link
                         to="/usuario"
                         className="text-gray-300 hover:bg-gray-700 hover:text-white block px-4 py-2 text-sm"
@@ -207,10 +221,11 @@ const Navbar = () => {
             {/* Mobile menu button */}
             <div className="flex md:hidden ml-3">
               <button
+                aria-label={isOpen ? 'Cerrar menú' : 'Abrir menú'}
                 onClick={() => setIsOpen(!isOpen)}
                 className="bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none"
               >
-                <span className="sr-only">Open main menu</span>
+                <span className="sr-only">{isOpen ? 'Cerrar menú' : 'Abrir menú'}</span>
                 {isOpen ? (
                   <X size={24} aria-hidden="true" />
                 ) : (

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { X } from 'lucide-react';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 
 interface ConfirmModalProps {
   title?: string;
@@ -21,6 +22,7 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useEscapeKey(onCancel, true);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70" onClick={onCancel}></div>
@@ -31,6 +33,7 @@ export default function ConfirmModal({
         ref={dialogRef}
       >
         <button
+          aria-label="Cerrar"
           onClick={onCancel}
           className="absolute top-4 right-4 text-gray-400 hover:text-white"
         >

--- a/src/components/common/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu.tsx
@@ -1,4 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 
 interface DropdownContextValue {
   open: boolean;
@@ -14,6 +16,18 @@ interface DropdownMenuProps {
 export const DropdownMenu = ({ children }: DropdownMenuProps) => {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const itemsRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(itemsRef);
+  useEscapeKey(() => setOpen(false), open);
+
+  useEffect(() => {
+    if (open && itemsRef.current) {
+      const first = itemsRef.current.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      first?.focus();
+    }
+  }, [open]);
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -37,7 +51,7 @@ export const DropdownMenu = ({ children }: DropdownMenuProps) => {
         {trigger}
         {open && (
           <div className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
-            <div className="py-1" role="menu">
+            <div ref={itemsRef} className="py-1" role="menu">
               {items}
             </div>
           </div>

--- a/src/components/common/RequestClubModal.tsx
+++ b/src/components/common/RequestClubModal.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { X, Phone, Mail, Clock, Trophy, MessageSquare, User, Calendar, Heart } from 'lucide-react';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 import { useAuthStore } from '../../store/authStore';
 import { useActivityLogStore } from '../../store/activityLogStore';
 
@@ -22,6 +23,7 @@ interface RequestForm {
 const RequestClubModal = ({ isOpen, onClose }: Props) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useEscapeKey(onClose, isOpen);
   const [sent, setSent] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
   const { user } = useAuthStore();
@@ -88,8 +90,9 @@ const RequestClubModal = ({ isOpen, onClose }: Props) => {
         aria-labelledby="request-club-title"
         ref={dialogRef}
       >
-        <button 
-          onClick={onClose} 
+        <button
+          aria-label="Cerrar"
+          onClick={onClose}
           className="absolute top-6 right-6 text-gray-400 hover:text-white transition-colors"
         >
           <X size={24} />

--- a/src/components/common/TeamRegistrationModal.tsx
+++ b/src/components/common/TeamRegistrationModal.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { X, Trophy, Users } from 'lucide-react';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 import { useDataStore } from '../../store/dataStore';
 import { Tournament } from '../../types';
 
@@ -13,6 +14,7 @@ interface Props {
 const TeamRegistrationModal: React.FC<Props> = ({ tournament, isOpen, onClose }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useEscapeKey(onClose, isOpen);
   const { tournaments, updateTournaments } = useDataStore();
   const [teamName, setTeamName] = useState('');
   const [contactName, setContactName] = useState('');
@@ -48,6 +50,7 @@ const TeamRegistrationModal: React.FC<Props> = ({ tournament, isOpen, onClose })
         ref={dialogRef}
       >
         <button
+          aria-label="Cerrar"
           onClick={onClose}
           className="absolute top-6 right-6 text-gray-400 hover:text-white transition-colors"
         >

--- a/src/components/common/UploadMediaModal.tsx
+++ b/src/components/common/UploadMediaModal.tsx
@@ -1,18 +1,23 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useDataStore } from '../../store/dataStore';
 import { MediaItem } from '@/types';
 import { notifySuccess, notifyError } from '../../utils/toast';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 
 interface UploadMediaModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-const UploadMediaModal: React.FC<UploadMediaModalProps> = ({ 
-  isOpen, 
-  onClose 
+const UploadMediaModal: React.FC<UploadMediaModalProps> = ({
+  isOpen,
+  onClose
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
+  useEscapeKey(onClose, isOpen);
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -66,9 +71,15 @@ const UploadMediaModal: React.FC<UploadMediaModalProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="relative w-full max-w-lg rounded-2xl bg-[#1f1f2c] border border-white/10 shadow-xl">
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-lg rounded-2xl bg-[#1f1f2c] border border-white/10 shadow-xl"
+        role="dialog"
+        aria-modal="true"
+      >
         {/* Botón cerrar */}
         <button
+          aria-label="Cerrar"
           onClick={onClose}
           className="absolute top-3 right-3 text-gray-400 hover:text-white focus-visible:outline-dashed focus-visible:outline-accent"
         >

--- a/src/components/finanzas/RequestFundsModal.tsx
+++ b/src/components/finanzas/RequestFundsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { X } from 'lucide-react';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 
 interface Props {
   onClose: () => void;
@@ -9,6 +10,7 @@ interface Props {
 const RequestFundsModal = ({ onClose }: Props) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useEscapeKey(onClose, true);
   const [sent, setSent] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -27,7 +29,11 @@ const RequestFundsModal = ({ onClose }: Props) => {
         aria-labelledby="request-funds-title"
         ref={dialogRef}
       >
-        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+        <button
+          aria-label="Cerrar"
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-white"
+        >
           <X size={24} />
         </button>
         {sent ? (

--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -7,6 +7,7 @@ import { makeOffer, getMinOfferAmount, getMaxOfferAmount } from '../../utils/tra
 import { formatCurrency } from '../../utils/helpers';
 import toast from 'react-hot-toast';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 
 interface OfferModalProps {
   player: Player;
@@ -17,6 +18,7 @@ interface OfferModalProps {
 const OfferModal = ({ player, onClose, onOfferSent }: OfferModalProps) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useEscapeKey(onClose, true);
   const [offerAmount, setOfferAmount] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<boolean>(false);
@@ -111,7 +113,8 @@ const OfferModal = ({ player, onClose, onOfferSent }: OfferModalProps) => {
         aria-labelledby="offer-modal-title"
         ref={dialogRef}
       >
-        <button 
+        <button
+          aria-label="Cerrar"
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-400 hover:text-white"
         >

--- a/src/components/market/RenegotiateModal.tsx
+++ b/src/components/market/RenegotiateModal.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { TransferOffer } from '../../types';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
 import { formatCurrency } from '../../utils/helpers';
 
 interface Props {
@@ -13,6 +14,7 @@ interface Props {
 const RenegotiateModal = ({ offer, onClose }: Props) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useEscapeKey(onClose, true);
   const [amount, setAmount] = useState<number>(offer.amount);
   const [sent, setSent] = useState(false);
 
@@ -33,7 +35,11 @@ const RenegotiateModal = ({ offer, onClose }: Props) => {
         aria-labelledby="renegotiate-title"
         ref={dialogRef}
       >
-        <button onClick={onClose} className="absolute top-4 right-4 text-gray-400 hover:text-white">
+        <button
+          aria-label="Cerrar"
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-white"
+        >
           <X size={24} />
         </button>
         {sent ? (

--- a/src/components/plantilla/PlayerDrawer.tsx
+++ b/src/components/plantilla/PlayerDrawer.tsx
@@ -33,6 +33,7 @@ const PlayerDrawer = ({ player, onClose }: Props) => {
         onKeyDown={handleKeyDown}
       >
         <button
+          aria-label="Cerrar"
           onClick={onClose}
           className="text-gray-400 hover:text-white absolute right-4 top-4"
         >

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export default function useEscapeKey(handler: () => void, active = true) {
+  useEffect(() => {
+    if (!active) return;
+    const listener = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handler();
+    };
+    document.addEventListener('keydown', listener);
+    return () => document.removeEventListener('keydown', listener);
+  }, [handler, active]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -314,3 +314,7 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   @apply bg-gray-500;
 }
+
+/* Improve contrast for dark theme */
+.dark .text-gray-500 { color: #9ca3af; }
+


### PR DESCRIPTION
## Summary
- add global rule to fix low contrast text in dark mode
- create `useEscapeKey` hook for reusable Esc handling
- apply Esc closing and focus trap to all modals and dropdown
- enhance navbar menu button and user menu with proper labels and focus control
- give social links accessible labels

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68855a7551848333bada5ff5b26aa59e