### PR TITLE
Fix Windows path resolution for Vite alias

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import mdx from './scripts/mdxPlugin';
 import path from 'node:path';
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+import { fileURLToPath } from 'node:url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- ensure `__dirname` is computed with `fileURLToPath`

## Testing
- `npm run test` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688575bdd5c48333b8dadefb730f5739