### PR TITLE
Implement public Feed module

### DIFF
--- a/src/components/feed/AchievementCard.tsx
+++ b/src/components/feed/AchievementCard.tsx
@@ -1,0 +1,28 @@
+import { formatDate } from '@/utils/helpers';
+import type { FeedItem } from '@/types';
+import { Trophy } from 'lucide-react';
+
+interface Props { item: Extract<FeedItem, { type: 'achievement' }>; }
+
+const AchievementCard = ({ item }: Props) => (
+  <a
+    href={item.link}
+    className="card p-4 flex gap-3 hover:border-primary focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent"
+    title={item.title}
+  >
+    {item.meta.emblem ? (
+      <img src={item.meta.emblem} alt="" className="w-10 h-10 rounded" loading="lazy" />
+    ) : (
+      <div className="w-10 h-10 bg-yellow-500/20 rounded flex items-center justify-center" aria-hidden="true">
+        <Trophy size={20} className="text-yellow-400" />
+      </div>
+    )}
+    <div className="flex-1">
+      <div className="text-xs text-gray-400 mb-1">{formatDate(item.date)}</div>
+      <h3 className="font-medium mb-1">{item.title}</h3>
+      <p className="text-sm text-gray-300">{item.summary}</p>
+    </div>
+  </a>
+);
+
+export default AchievementCard;

--- a/src/components/feed/EventCard.tsx
+++ b/src/components/feed/EventCard.tsx
@@ -1,0 +1,24 @@
+import { formatDate } from '@/utils/helpers';
+import type { FeedItem } from '@/types';
+import { Calendar } from 'lucide-react';
+
+interface Props { item: Extract<FeedItem, { type: 'event' }>; }
+
+const EventCard = ({ item }: Props) => (
+  <a
+    href={item.link}
+    className="card p-4 flex gap-3 hover:border-primary focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent"
+    title={item.title}
+  >
+    <div className="w-10 h-10 bg-blue-500/20 rounded flex items-center justify-center" aria-hidden="true">
+      <Calendar size={20} className="text-blue-400" />
+    </div>
+    <div className="flex-1">
+      <div className="text-xs text-gray-400 mb-1">{formatDate(item.date)}</div>
+      <h3 className="font-medium mb-1">{item.title}</h3>
+      <p className="text-sm text-gray-300">{item.summary}</p>
+    </div>
+  </a>
+);
+
+export default EventCard;

--- a/src/components/feed/MatchCard.tsx
+++ b/src/components/feed/MatchCard.tsx
@@ -1,0 +1,54 @@
+import { formatDate, formatTime } from '@/utils/helpers';
+import type { FeedItem } from '@/types';
+
+interface Props { item: Extract<FeedItem, { type: 'match' }>; }
+
+const statusLabel = (status: string) => {
+  if (status === 'live') return 'En vivo';
+  if (status === 'finished') return 'Finalizado';
+  return 'Programado';
+};
+
+const MatchCard = ({ item }: Props) => (
+  <a
+    href={item.link}
+    className="card p-4 hover:border-primary focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent"
+    title={item.title}
+  >
+    <div className="text-xs text-gray-400 mb-2 flex items-center gap-2">
+      <span>{formatDate(item.date)}</span>
+      <span>{formatTime(item.date)}</span>
+      <span
+        className={`badge whitespace-nowrap ${
+          item.meta.status === 'live'
+            ? 'bg-red-500/20 text-red-400'
+            : item.meta.status === 'finished'
+            ? 'bg-green-500/20 text-green-400'
+            : 'bg-yellow-500/20 text-yellow-400'
+        }`}
+      >
+        {statusLabel(item.meta.status)}
+      </span>
+    </div>
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2">
+        <span className="font-medium">{item.meta.homeTeam}</span>
+      </div>
+      <div className="text-sm text-gray-300">
+        {item.meta.score
+          ? `${item.meta.score.home}-${item.meta.score.away}`
+          : 'vs'}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="font-medium">{item.meta.awayTeam}</span>
+      </div>
+    </div>
+    {item.meta.tournament && (
+      <div className="text-xs text-gray-400 mt-1">
+        {item.meta.tournament}
+      </div>
+    )}
+  </a>
+);
+
+export default MatchCard;

--- a/src/components/feed/NewsCard.tsx
+++ b/src/components/feed/NewsCard.tsx
@@ -1,0 +1,35 @@
+import { formatDate } from '@/utils/helpers';
+import type { FeedItem } from '@/types';
+
+interface Props { item: Extract<FeedItem, { type: 'news' }>; }
+
+const NewsCard = ({ item }: Props) => (
+  <a
+    href={item.link}
+    className="card p-4 flex gap-4 hover:border-primary focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent"
+    title={item.title}
+  >
+    {item.meta.image && (
+      <img
+        src={item.meta.image}
+        alt=""
+        className="w-20 h-20 object-cover rounded"
+        loading="lazy"
+      />
+    )}
+    <div className="flex-1">
+      <div className="text-xs text-gray-400 mb-1 flex items-center gap-2">
+        <span>{formatDate(item.date)}</span>
+        {item.meta.category && (
+          <span className="badge bg-primary/20 text-primary whitespace-nowrap">
+            {item.meta.category}
+          </span>
+        )}
+      </div>
+      <h3 className="font-medium mb-1">{item.title}</h3>
+      <p className="text-sm text-gray-300 line-clamp-2">{item.summary}</p>
+    </div>
+  </a>
+);
+
+export default NewsCard;

--- a/src/components/feed/TransferCard.tsx
+++ b/src/components/feed/TransferCard.tsx
@@ -1,0 +1,27 @@
+import { formatDate, formatCurrency } from '@/utils/helpers';
+import type { FeedItem } from '@/types';
+import { User2 } from 'lucide-react';
+
+interface Props { item: Extract<FeedItem, { type: 'transfer' }>; }
+
+const TransferCard = ({ item }: Props) => (
+  <a
+    href={item.link}
+    className="card p-4 flex gap-3 hover:border-primary focus-visible:outline-dashed focus-visible:outline-1 focus-visible:outline-accent"
+    title={item.title}
+  >
+    <div className="w-10 h-10 bg-green-500/20 rounded flex items-center justify-center" aria-hidden="true">
+      <User2 size={20} className="text-green-400" />
+    </div>
+    <div className="flex-1">
+      <div className="text-xs text-gray-400 mb-1">{formatDate(item.date)}</div>
+      <h3 className="font-medium mb-1">{item.title}</h3>
+      <p className="text-sm text-gray-300">
+        {item.summary}
+        {item.meta.fee && ` por ${formatCurrency(item.meta.fee)}`}
+      </p>
+    </div>
+  </a>
+);
+
+export default TransferCard;

--- a/src/hooks/useFeedItems.ts
+++ b/src/hooks/useFeedItems.ts
@@ -1,72 +1,24 @@
 import { useMemo } from 'react';
 import { useDataStore } from '../store/dataStore';
-import { FeedItem } from '../types';
+import type { FeedItem } from '../types';
+import fixtures from '../data/fixtures.json';
+import { buildFeed, CalendarEvent } from '../modules/feed/adapters';
 
 const useFeedItems = (): FeedItem[] => {
-  const { newsItems, transfers, tournaments, clubs } = useDataStore();
+  const { newsItems, transfers, tournaments, clubs, events } = useDataStore();
+  const calendar = fixtures as CalendarEvent[];
 
-  return useMemo(() => {
-    const items: FeedItem[] = [];
-
-    // Noticias
-    newsItems.forEach(n => {
-      items.push({
-        id: `news-${n.id}`,
-        type: 'news',
-        title: n.title,
-        date: n.publishDate,
-        summary: n.content,
-        link: `/blog/${n.id}`,
-        media: n.imageUrl
-      });
-    });
-
-    // Fichajes confirmados
-    transfers.forEach(t => {
-      items.push({
-        id: `transfer-${t.id}`,
-        type: 'transfer',
-        title: `${t.playerName} al ${t.toClub}`,
-        date: t.date,
-        summary: `${t.playerName} pasa de ${t.fromClub} a ${t.toClub}.`,
-        link: '#'
-      });
-    });
-
-    // Partidos y resultados
-    tournaments.forEach(t => {
-      t.matches.forEach(m => {
-        const title = `${m.homeTeam} vs ${m.awayTeam}`;
-        const summary = m.status === 'finished' && m.homeScore !== undefined && m.awayScore !== undefined
-          ? `${m.homeTeam} ${m.homeScore}-${m.awayScore} ${m.awayTeam}`
-          : `Jornada ${m.round} • ${t.name}`;
-        items.push({
-          id: `match-${m.id}`,
-          type: 'match',
-          title,
-          date: m.date,
-          summary,
-          link: '/liga-master/fixture'
-        });
-      });
-    });
-
-    // Logros (títulos de club)
-    clubs.forEach(c => {
-      c.titles.forEach(title => {
-        items.push({
-          id: `ach-${c.id}-${title.id}`,
-          type: 'achievement',
-          title: `${c.name} ganó ${title.name}`,
-          date: `${title.year}-01-01`,
-          summary: `${c.name} se coronó campeón de ${title.name} en ${title.year}.`,
-          link: `/liga-master/club/${c.slug}`
-        });
-      });
-    });
-
-    return items.sort((a,b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-  }, [newsItems, transfers, tournaments, clubs]);
+  return useMemo(
+    () =>
+      buildFeed({
+        news: newsItems,
+        transfers,
+        tournaments,
+        clubs,
+        events: [...calendar, ...events]
+      }),
+    [newsItems, transfers, tournaments, clubs, events]
+  );
 };
 
 export default useFeedItems;

--- a/src/modules/feed/adapters.ts
+++ b/src/modules/feed/adapters.ts
@@ -1,0 +1,109 @@
+import type { NewsItem, Tournament, Transfer } from '../../types';
+import type { Club } from '../../types/shared';
+import type { FeedItem, MatchMeta, NewsMeta, TransferMeta, AchievementMeta } from '../../types';
+
+// Eventos de calendario que aún no cuentan con slice dedicado
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  date: string;
+  category: string;
+}
+
+// Adaptador de noticias
+export const mapNews = (news: NewsItem[]): FeedItem[] =>
+  news.map(n => ({
+    id: `news-${n.id}`,
+    type: 'news',
+    title: n.title,
+    date: new Date(n.publishDate).toISOString(),
+    summary: n.content,
+    link: `/blog/${n.id}`,
+    meta: { category: n.category, image: n.imageUrl } as NewsMeta
+  }));
+
+// Adaptador de fichajes
+export const mapTransfers = (transfers: Transfer[]): FeedItem[] =>
+  transfers.map(t => ({
+    id: `transfer-${t.id}`,
+    type: 'transfer',
+    title: `${t.playerName} al ${t.toClub}`,
+    date: new Date(t.date).toISOString(),
+    summary: `${t.playerName} pasa de ${t.fromClub} a ${t.toClub}.`,
+    link: '/liga-master/mercado',
+    meta: { player: t.playerName, from: t.fromClub, to: t.toClub, fee: t.fee } as TransferMeta
+  }));
+
+// Adaptador de partidos de torneos
+export const mapMatches = (tournaments: Tournament[]): FeedItem[] =>
+  tournaments.flatMap(t =>
+    t.matches.map(m => ({
+      id: `match-${m.id}`,
+      type: 'match',
+      title: `${m.homeTeam} vs ${m.awayTeam}`,
+      date: new Date(m.date).toISOString(),
+      summary:
+        m.status === 'finished' && m.homeScore !== undefined && m.awayScore !== undefined
+          ? `${m.homeTeam} ${m.homeScore}-${m.awayScore} ${m.awayTeam}`
+          : `Jornada ${m.round} • ${t.name}`,
+      link: '/liga-master/fixture',
+      meta: {
+        homeTeam: m.homeTeam,
+        awayTeam: m.awayTeam,
+        status: m.status,
+        score:
+          m.homeScore !== undefined && m.awayScore !== undefined
+            ? { home: m.homeScore, away: m.awayScore }
+            : undefined,
+        tournament: t.name
+      } as MatchMeta
+    }))
+  );
+
+// Adaptador de logros basados en títulos de clubes
+export const mapAchievements = (clubs: Club[]): FeedItem[] =>
+  clubs.flatMap(c =>
+    c.titles.map(title => ({
+      id: `ach-${c.id}-${title.id}`,
+      type: 'achievement',
+      title: `${c.name} ganó ${title.name}`,
+      date: `${title.year}-01-01T00:00:00.000Z`,
+      summary: `${c.name} se coronó campeón de ${title.name} en ${title.year}.`,
+      link: `/liga-master/club/${c.slug}`,
+      meta: { club: c.name, emblem: c.logo } as AchievementMeta
+    }))
+  );
+
+// Adaptador para eventos de calendario simples
+export const mapCalendarEvents = (events: CalendarEvent[]): FeedItem[] =>
+  events.map(ev => ({
+    id: `ev-${ev.id}`,
+    type: 'event',
+    title: ev.title,
+    date: new Date(ev.date).toISOString(),
+    summary: ev.title,
+    link: '/liga-master/calendario',
+    meta: { label: ev.category }
+  }));
+
+// Unifica todas las fuentes en una sola lista ordenada
+export const buildFeed = (sources: {
+  news: NewsItem[];
+  transfers: Transfer[];
+  tournaments: Tournament[];
+  clubs: Club[];
+  events: CalendarEvent[];
+}): FeedItem[] => {
+  const items = [
+    ...mapNews(sources.news),
+    ...mapTransfers(sources.transfers),
+    ...mapMatches(sources.tournaments),
+    ...mapCalendarEvents(sources.events),
+    ...mapAchievements(sources.clubs)
+  ];
+  const unique = new Map<string, FeedItem>();
+  for (const item of items) unique.set(item.id, item);
+  return Array.from(unique.values()).sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+};

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -1,87 +1,201 @@
-import { useState } from 'react';
-import { motion } from 'framer-motion';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 import PageHeader from '../components/common/PageHeader';
 import FilterChip from '../components/common/FilterChip';
 import useFeedItems from '../hooks/useFeedItems';
+import usePersistentState from '../hooks/usePersistentState';
+import NewsCard from '../components/feed/NewsCard';
+import MatchCard from '../components/feed/MatchCard';
+import TransferCard from '../components/feed/TransferCard';
+import AchievementCard from '../components/feed/AchievementCard';
+import EventCard from '../components/feed/EventCard';
+import CardSkeleton from '../components/common/CardSkeleton';
+import SEO from '../components/SEO';
+import { VZ_FEED_PREFS_KEY } from '../utils/storageKeys';
+import type { FeedItem } from '../types';
+
+const ITEMS_PER_PAGE = 20;
 
 const Feed = () => {
-  const feedItems = useFeedItems();
-  const [filter, setFilter] = useState<'all' | 'news' | 'match' | 'transfer' | 'achievement'>('all');
-  const [query, setQuery] = useState('');
-  const [visible, setVisible] = useState(20);
+  const items = useFeedItems();
 
-  const filtered = feedItems.filter(item => {
-    if (filter !== 'all' && item.type !== filter) return false;
-    if (query && !item.title.toLowerCase().includes(query.toLowerCase()) && !item.summary.toLowerCase().includes(query.toLowerCase())) return false;
-    return true;
+  const [prefs, setPrefs] = usePersistentState(VZ_FEED_PREFS_KEY, {
+    filter: 'all' as 'all' | FeedItem['type'],
+    query: '',
+    range: 'all' as 'all' | '7d' | '30d',
+    sort: 'date' as 'date' | 'relevance'
   });
 
-  const visibleItems = filtered.slice(0, visible);
-  const canLoadMore = visible < filtered.length;
+  const [visible, setVisible] = useState(ITEMS_PER_PAGE);
+  const [loading, setLoading] = useState(true);
+  const loader = useRef<HTMLDivElement | null>(null);
+  const liveRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset visible when preferences change
+  useEffect(() => {
+    setVisible(ITEMS_PER_PAGE);
+  }, [prefs]);
+
+  // Simulate async loading for skeletons
+  useEffect(() => {
+    setLoading(true);
+    const t = setTimeout(() => setLoading(false), 300);
+    return () => clearTimeout(t);
+  }, [visible, prefs]);
+
+  // IntersectionObserver for infinite scroll
+  useEffect(() => {
+    const node = loader.current;
+    if (!node) return;
+    const obs = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        setVisible(v => Math.min(v + ITEMS_PER_PAGE, filtered.length));
+      }
+    });
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [loader, items, prefs]);
+
+  const filtered = useMemo(() => {
+    const now = Date.now();
+    const q = prefs.query.toLowerCase();
+    return items.filter(item => {
+      if (prefs.filter !== 'all' && item.type !== prefs.filter) return false;
+      if (prefs.range !== 'all') {
+        const days = prefs.range === '7d' ? 7 : 30;
+        if (now - new Date(item.date).getTime() > days * 86400000) return false;
+      }
+      if (
+        q &&
+        !(
+          item.title.toLowerCase().includes(q) ||
+          item.summary.toLowerCase().includes(q)
+        )
+      )
+        return false;
+      return true;
+    });
+  }, [items, prefs]);
+
+  const sorted = useMemo(() => {
+    if (prefs.sort === 'date' || !prefs.query) {
+      return filtered.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+      );
+    }
+    const score = (it: FeedItem) => {
+      const q = prefs.query.toLowerCase();
+      return (
+        (it.title.toLowerCase().includes(q) ? 2 : 0) +
+        (it.summary.toLowerCase().includes(q) ? 1 : 0)
+      );
+    };
+    return filtered
+      .map(it => ({ it, s: score(it) }))
+      .sort((a, b) => b.s - a.s || new Date(b.it.date).getTime() - new Date(a.it.date).getTime())
+      .map(x => x.it);
+  }, [filtered, prefs.sort, prefs.query]);
+
+  const visibleItems = sorted.slice(0, visible);
+
+  useEffect(() => {
+    if (liveRef.current) {
+      liveRef.current.textContent = `${visibleItems.length} elementos cargados`;
+    }
+  }, [visibleItems.length]);
+
+  const clearFilters = () =>
+    setPrefs({ filter: 'all', query: '', range: 'all', sort: 'date' });
 
   return (
     <div>
+      <SEO
+        title="Feed | La Virtual Zone"
+        description="Eventos y noticias más relevantes de la comunidad"
+        canonical="https://lavirtualzone.com/liga-master/feed"
+      />
       <PageHeader
         title="Feed"
         subtitle="Eventos recientes de La Virtual Zone"
-        image="https://images.unsplash.com/photo-1511406361295-0a1ff814c0ce?ixid=M3w3MjUzNDh8MHwxfHNlYXJjaHwyfHxlc3BvcnRzJTIwZ2FtaW5nJTIwZGFyayUyMHRoZW1lfGVufDB8fHx8MTc0NzA3MTE4MHww&ixlib=rb-4.1.0"
+        image="https://images.unsplash.com/photo-1511406361295-0a1ff814c0ce?ixlib=rb-4.1.0"
       />
       <div className="container mx-auto px-4 py-8">
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
           <div className="flex gap-2 overflow-x-auto pb-1">
-            <FilterChip label="Todo" active={filter==='all'} onClick={()=>{setFilter('all'); setVisible(20);}} />
-            <FilterChip label="Noticias" active={filter==='news'} onClick={()=>{setFilter('news'); setVisible(20);}} />
-            <FilterChip label="Partidos" active={filter==='match'} onClick={()=>{setFilter('match'); setVisible(20);}} />
-            <FilterChip label="Fichajes" active={filter==='transfer'} onClick={()=>{setFilter('transfer'); setVisible(20);}} />
-            <FilterChip label="Logros" active={filter==='achievement'} onClick={()=>{setFilter('achievement'); setVisible(20);}} />
+            {(['all', 'news', 'match', 'event', 'transfer', 'achievement'] as const).map(t => (
+              <FilterChip
+                key={t}
+                label={t === 'all' ? 'Todo' : t.charAt(0).toUpperCase() + t.slice(1)}
+                active={prefs.filter === t}
+                onClick={() => setPrefs(p => ({ ...p, filter: t }))}
+              />
+            ))}
           </div>
-          <div className="relative max-w-xs w-full">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <Search size={16} className="text-gray-500" />
+          <div className="flex gap-2 w-full md:w-auto">
+            <div className="relative flex-1 md:w-56">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <Search size={16} className="text-gray-500" aria-hidden="true" />
+              </div>
+              <input
+                type="text"
+                placeholder="Buscar..."
+                className="input pl-10 w-full"
+                value={prefs.query}
+                onChange={e => setPrefs(p => ({ ...p, query: e.target.value }))}
+              />
             </div>
-            <input
-              type="text"
-              placeholder="Buscar..."
-              className="input pl-10 w-full"
-              value={query}
-              onChange={(e) => { setQuery(e.target.value); setVisible(20); }}
-            />
+            <select
+              className="input py-2 pr-8 text-sm"
+              value={prefs.range}
+              onChange={e => setPrefs(p => ({ ...p, range: e.target.value as any }))}
+            >
+              <option value="all">Todo</option>
+              <option value="7d">Últimos 7 días</option>
+              <option value="30d">Últimos 30 días</option>
+            </select>
+            <select
+              className="input py-2 pr-8 text-sm"
+              value={prefs.sort}
+              onChange={e => setPrefs(p => ({ ...p, sort: e.target.value as any }))}
+            >
+              <option value="date">Fecha</option>
+              <option value="relevance">Relevancia</option>
+            </select>
+            <button
+              className="btn-secondary whitespace-nowrap"
+              onClick={clearFilters}
+            >
+              Limpiar
+            </button>
           </div>
         </div>
 
+        {loading && <CardSkeleton lines={3} className="mb-4" />}
+
         <ul className="space-y-4" role="list">
-          {visibleItems.map(item => (
-            <motion.li
-              key={item.id}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2 }}
-              role="listitem"
-            >
-              <a href={item.link} className="card p-4 flex space-x-4 hover:border-primary" title={item.title}>
-                {item.media && (
-                  <img src={item.media} alt="" className="w-20 h-20 object-cover rounded" />
-                )}
-                <div className="flex-1">
-                  <div className="text-xs text-gray-400 mb-1">
-                    {new Date(item.date).toLocaleDateString('es-ES')}
-                  </div>
-                  <h3 className="font-medium mb-1">{item.title}</h3>
-                  <p className="text-sm text-gray-300 line-clamp-2">{item.summary}</p>
-                </div>
-              </a>
-            </motion.li>
-          ))}
+          <AnimatePresence>
+            {visibleItems.map(item => (
+              <motion.li
+                key={item.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                role="listitem"
+              >
+                {item.type === 'news' && <NewsCard item={item} />}
+                {item.type === 'match' && <MatchCard item={item} />}
+                {item.type === 'transfer' && <TransferCard item={item} />}
+                {item.type === 'achievement' && <AchievementCard item={item} />}
+                {item.type === 'event' && <EventCard item={item} />}
+              </motion.li>
+            ))}
+          </AnimatePresence>
         </ul>
 
-        {canLoadMore && (
-          <div className="text-center mt-6">
-            <button className="btn-primary" onClick={() => setVisible(v => v + 20)}>
-              Cargar más
-            </button>
-          </div>
-        )}
+        <div ref={loader} />
+        <div aria-live="polite" className="sr-only" ref={liveRef} />
       </div>
     </div>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -294,12 +294,48 @@ export interface Attachment {
   uploadedAt?: string;
 }
 
-export interface FeedItem {
+// ----- Modelo unificado para el feed público -----
+export interface FeedItemBase {
   id: string;
-  type: 'news' | 'match' | 'transfer' | 'achievement';
+  type: 'news' | 'match' | 'event' | 'transfer' | 'achievement';
   title: string;
+  /** Fecha normalizada en UTC ISO */
   date: string;
   summary: string;
   link: string;
-  media?: string;
 }
+
+export interface NewsMeta {
+  category?: string;
+  image?: string;
+}
+
+export interface MatchMeta {
+  homeTeam: string;
+  awayTeam: string;
+  status: 'scheduled' | 'live' | 'finished';
+  score?: { home: number; away: number };
+  tournament?: string;
+  venue?: string;
+}
+
+export interface TransferMeta {
+  player: string;
+  from: string;
+  to: string;
+  fee?: number;
+}
+
+export interface AchievementMeta {
+  user?: string;
+  club?: string;
+  emblem?: string;
+  level?: number;
+}
+
+export type FeedItem =
+  | (FeedItemBase & { type: 'news'; meta: NewsMeta })
+  | (FeedItemBase & { type: 'match'; meta: MatchMeta })
+  | (FeedItemBase & { type: 'event'; meta: { label: string } })
+  | (FeedItemBase & { type: 'transfer'; meta: TransferMeta })
+  | (FeedItemBase & { type: 'achievement'; meta: AchievementMeta });

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -25,3 +25,4 @@ export const VZ_EVENTS_KEY = 'vz_events';
 export const VZ_OBJECTIVES_KEY = 'vz_objectives';
 export const VZ_MARKET_KEY = 'vz_market';
 export const VZ_CLUB_KEY = 'vz_club';
+export const VZ_FEED_PREFS_KEY = 'vz_feed_prefs';


### PR DESCRIPTION
## Summary
- define stable FeedItem model with per-type metadata
- create adapters to map news, transfers, matches, events and achievements
- expose unified feed via `useFeedItems`
- design specific cards for each item type
- overhaul Feed page with filters, search and infinite scroll
- persist preferences in localStorage via new storage key

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build` *(fails: esbuild error in BlogPost.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68857b3a51388333a4b1802286b4c0f3