### PR TITLE
Fix missing closing div in tournaments page

### DIFF
--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -201,6 +201,7 @@ const Tournaments = () => {
           </div>
         </div>
       </div>
+    </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- close an unclosed `<div>` at the end of `Tournaments.tsx`

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm test` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688581c59a388333adfe7aa483474644