### PR TITLE
Fix tournament details links on homepage

### DIFF
--- a/src/components/Home/FeaturedTournaments.tsx
+++ b/src/components/Home/FeaturedTournaments.tsx
@@ -116,8 +116,8 @@ const FeaturedTournaments = () => {
             </div>
             
             <div className="p-4 border-t border-gray-800">
-              <Link 
-                to={`/torneos/${tournament.id}`} 
+              <Link
+                to={`/torneos/${tournament.slug || tournament.id}`}
                 className="btn-secondary w-full text-center"
               >
                 Ver Detalles


### PR DESCRIPTION
## Summary
- fix FeaturedTournaments links to use tournament slug

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6888e43ef9688333a1c9bb2c4d353936