### PR TITLE
Improve admin panel UX

### DIFF
--- a/src/adminPanel/App.tsx
+++ b/src/adminPanel/App.tsx
@@ -3,6 +3,8 @@ import { Suspense, lazy } from 'react';
 import { Toaster, toast } from 'react-hot-toast';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import SidebarAdmin from './components/SidebarAdmin';
+import TopBar from './components/TopBar';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 const Dashboard = lazy(() => import('./pages/admin/Dashboard'));
 const Usuarios = lazy(() => import('./pages/admin/Usuarios'));
@@ -34,6 +36,7 @@ const AdminLayout = () => {
     <div className="min-h-screen admin-bg flex">
       <SidebarAdmin />
       <main className="flex-1 md:ml-0">
+        <TopBar />
         <Suspense fallback={
           <div className="p-6">
             <div className="animate-pulse space-y-4">
@@ -67,10 +70,11 @@ const AdminLayout = () => {
 
 function App() {
   return (
-    <AuthProvider>
-      <AdminLayout />
-      
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <AdminLayout />
+      </AuthProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/adminPanel/components/TopBar.tsx
+++ b/src/adminPanel/components/TopBar.tsx
@@ -1,0 +1,48 @@
+import { Search, Sun, Moon, User } from 'lucide-react';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTheme } from '../contexts/ThemeContext';
+
+interface Props {
+  onSearch?: (term: string) => void;
+}
+
+const TopBar = ({ onSearch }: Props) => {
+  const { theme, toggleTheme } = useTheme();
+  const [term, setTerm] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearch?.(term);
+  };
+
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <form onSubmit={handleSubmit} className="relative w-full max-w-xs">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+        <input
+          className="input pl-9 w-full"
+          placeholder="Buscar..."
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+        />
+      </form>
+
+      <div className="flex items-center gap-4 ml-4">
+        <button
+          type="button"
+          onClick={toggleTheme}
+          aria-label="Cambiar tema"
+          className="btn-outline p-2 rounded-full"
+        >
+          {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
+        </button>
+        <Link to="/perfil" aria-label="Perfil" className="btn-outline p-2 rounded-full">
+          <User size={18} />
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default TopBar;

--- a/src/adminPanel/components/admin/DataTable.tsx
+++ b/src/adminPanel/components/admin/DataTable.tsx
@@ -62,11 +62,11 @@ function DataTable<T>({ data, columns, keyExtractor, pageSize = 10, onSelectionC
   const visibleRows = sortedData.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <div className="w-full overflow-x-auto">
-      <table className="min-w-full text-sm text-gray-300">
-        <thead>
-          <tr className="bg-gray-800/60">
-            <th className="p-3 w-10">
+    <div className="w-full overflow-x-auto card-elevated shadow-consistent p-2">
+      <table className="min-w-full text-sm text-gray-300" role="table">
+        <thead role="rowgroup">
+          <tr className="bg-gray-800/60" role="row">
+            <th className="p-3 w-10" role="columnheader">
               <input
                 type="checkbox"
                 checked={visibleRows.length>0 && visibleRows.every(r=>selected.has(keyExtractor(r)))}
@@ -77,6 +77,7 @@ function DataTable<T>({ data, columns, keyExtractor, pageSize = 10, onSelectionC
               <th
                 key={col.id}
                 className={`p-3 text-left font-semibold cursor-pointer ${col.width??''}`}
+                role="columnheader"
                 onClick={() => col.sortable && setSort(prev => {
                   if (!prev || prev.id!==col.id) return { id: col.id, dir: 'asc' };
                   return { id: col.id, dir: prev.dir==='asc'? 'desc':'asc' };
@@ -90,13 +91,13 @@ function DataTable<T>({ data, columns, keyExtractor, pageSize = 10, onSelectionC
             ))}
           </tr>
         </thead>
-        <tbody>
+        <tbody role="rowgroup">
           {loading ? (
             Array.from({ length: pageSize }).map((_, i) => (
-              <tr key={i} className="border-b border-gray-700">
-                <td className="p-3"><Skeleton width={20} height={20} /></td>
+              <tr key={i} className="border-b border-gray-700" role="row">
+                <td className="p-3" role="cell"><Skeleton width={20} height={20} /></td>
                 {columns.map(col => (
-                  <td key={col.id} className="p-3"><Skeleton height={16} /></td>
+                  <td key={col.id} className="p-3" role="cell"><Skeleton height={16} /></td>
                 ))}
               </tr>
             ))
@@ -104,12 +105,12 @@ function DataTable<T>({ data, columns, keyExtractor, pageSize = 10, onSelectionC
           visibleRows.map(row => {
             const id = keyExtractor(row);
             return (
-              <tr key={id} className="border-b border-gray-700 hover:bg-gray-700/30">
-                <td className="p-3">
+              <tr key={id} className="border-b border-gray-700 hover:bg-gray-700/30" role="row">
+                <td className="p-3" role="cell">
                   <input type="checkbox" checked={selected.has(id)} onChange={()=>toggleSelect(id)} />
                 </td>
                 {columns.map(col => (
-                  <td key={col.id} className="p-3 whitespace-nowrap">
+                  <td key={col.id} className="p-3 whitespace-nowrap" role="cell">
                     {col.accessor(row)}
                   </td>
                 ))}
@@ -118,14 +119,14 @@ function DataTable<T>({ data, columns, keyExtractor, pageSize = 10, onSelectionC
           })
           )}
           {!loading && visibleRows.length===0 && (
-            <tr><td colSpan={columns.length+1} className="p-4 text-center text-gray-500">Sin resultados</td></tr>
+            <tr role="row"><td role="cell" colSpan={columns.length+1} className="p-4 text-center text-gray-500">Sin resultados</td></tr>
           )}
         </tbody>
       </table>
 
       {/* pagination */}
       { !loading && totalPages>1 && (
-        <div className="flex justify-between items-center mt-4 text-xs text-gray-400">
+        <div className="flex justify-between items-center mt-4 text-xs text-gray-400" role="navigation" aria-label="Paginación">
           <span>Página {page} / {totalPages}</span>
           <div className="flex gap-2">
             <button className="btn-outline" disabled={page===1} onClick={()=>setPage(p=>p-1)}>Anterior</button>

--- a/src/adminPanel/components/admin/SearchFilter.tsx
+++ b/src/adminPanel/components/admin/SearchFilter.tsx
@@ -1,4 +1,5 @@
-import  { Search } from 'lucide-react';
+import { Search } from 'lucide-react';
+import { useEffect } from 'react';
 
 interface Props {
   search: string;
@@ -6,9 +7,25 @@ interface Props {
   filters?: { label: string; value: string; options: { label: string; value: string }[] }[];
   onFilterChange?: (filterValue: string, value: string) => void;
   placeholder?: string;
+  storageKey?: string;
 }
 
-const SearchFilter = ({ search, onSearchChange, filters, onFilterChange, placeholder = "Buscar..." }: Props) => {
+
+const SearchFilter = ({ search, onSearchChange, filters, onFilterChange, placeholder = "Buscar...", storageKey }: Props) => {
+  useEffect(() => {
+    if (!storageKey) return;
+    const stored = localStorage.getItem(storageKey);
+    if (stored !== null) {
+      onSearchChange(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (storageKey) {
+      localStorage.setItem(storageKey, search);
+    }
+  }, [search, storageKey]);
+
   return (
     <div className="flex flex-col sm:flex-row gap-4">
       <div className="relative flex-1">

--- a/src/adminPanel/components/admin/StatsCard.tsx
+++ b/src/adminPanel/components/admin/StatsCard.tsx
@@ -14,7 +14,7 @@ const StatsCard = ({ title, value, change, changeType = 'neutral', icon: Icon, g
                      changeType === 'negative' ? 'text-red-400' : 'text-gray-400';
 
   return (
-    <div className="kpi-card group">
+    <div className="card-elevated hover-lift group shadow-consistent-xl">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-gray-400 text-sm font-medium">{title}</p>

--- a/src/adminPanel/contexts/ThemeContext.tsx
+++ b/src/adminPanel/contexts/ThemeContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = (localStorage.getItem('theme') as Theme) || 'dark';
+    setTheme(stored);
+    document.documentElement.classList.toggle('dark', stored === 'dark');
+  }, []);
+
+  const toggleTheme = () => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/adminPanel/pages/admin/Dashboard.tsx
+++ b/src/adminPanel/pages/admin/Dashboard.tsx
@@ -1,17 +1,18 @@
 import  { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell } from 'recharts';
-import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target, Sun, Moon } from 'lucide-react'; 
-import { useEffect, useState, useRef } from 'react';
+import { Users, Globe, User, ShoppingBag, TrendingUp, Activity, AlertCircle, CheckCircle, Clock, Star, Trophy, Target, Sun, Moon } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import html2canvas from 'html2canvas';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useGlobalStore } from '../../store/globalStore';
+import { useTheme } from '../../contexts/ThemeContext';
 
 const Dashboard = () => {
   const { users, clubs, players, transfers, activities } = useGlobalStore();
   const { isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
-  const [isDark, setIsDark] = useState(true);
+  const { theme, toggleTheme } = useTheme();
   const [activitiesCount, setActivitiesCount] = useState(5);
 
   const usersChartRef = useRef<HTMLDivElement>(null);
@@ -25,28 +26,6 @@ const Dashboard = () => {
     link.href = canvas.toDataURL('image/png');
     link.click();
   };
-
-  const toggleTheme = () => {
-    const newTheme = isDark ? 'light' : 'dark';
-    if (newTheme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-    localStorage.setItem('theme', newTheme);
-    setIsDark(!isDark);
-  };
-
-  useEffect(() => {
-    const storedTheme = localStorage.getItem('theme') ?? 'dark';
-    if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark');
-      setIsDark(true);
-    } else {
-      document.documentElement.classList.remove('dark');
-      setIsDark(false);
-    }
-  }, []);
 
   // Distribución de posiciones de jugadores para PieChart
   const positionCounts: Record<string, number> = {};
@@ -75,7 +54,7 @@ const Dashboard = () => {
   const recentActivities = activities.slice(-activitiesCount);
 
    return (
-    <div className={`min-h-screen p-6 ${isDark ? 'bg-gradient-to-br from-gray-900 via-purple-900/20 to-blue-900/20' : 'bg-gradient-to-br from-gray-100 via-white to-gray-200'}`}>
+    <div className={`min-h-screen p-6 ${theme === 'dark' ? 'bg-gradient-to-br from-gray-900 via-purple-900/20 to-blue-900/20' : 'bg-gradient-to-br from-gray-100 via-white to-gray-200'}`}>
       <div className="max-w-7xl mx-auto space-y-8">
         {/* Hero Header */}
         <div className="relative overflow-hidden glass-card bg-gradient-to-r from-purple-900/50 to-blue-900/50 p-8">
@@ -85,7 +64,7 @@ const Dashboard = () => {
             className="absolute top-4 right-4 bg-gray-700/50 hover:bg-gray-600 text-gray-300 hover:text-white p-2 rounded-full transition-colors"
             aria-label="Toggle Theme"
           >
-            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+            {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
           </button>
                    <div className="absolute inset-0 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%239C92AC%22%20fill-opacity%3D%220.05%22%3E%3Ccircle%20cx%3D%2230%22%20cy%3D%2230%22%20r%3D%224%22/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-50"></div> 
           <div className="relative flex flex-col lg:flex-row lg:justify-between lg:items-center gap-6">

--- a/src/adminPanel/pages/admin/Usuarios.tsx
+++ b/src/adminPanel/pages/admin/Usuarios.tsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Plus, Search, Filter, Edit, Trash, Users, Shield, Eye, MoreVertical } from 'lucide-react'; 
 import toast from 'react-hot-toast';
 import { useGlobalStore } from '../../store/globalStore';
@@ -16,6 +16,22 @@ const Usuarios = () => {
   const [roleFilter, setRoleFilter] = useState('all');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
+
+  // Persist search and role filter
+  useEffect(() => {
+    const storedSearch = localStorage.getItem('admin-users-search');
+    const storedRole = localStorage.getItem('admin-users-role');
+    if (storedSearch) setSearch(storedSearch);
+    if (storedRole) setRoleFilter(storedRole);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('admin-users-search', search);
+  }, [search]);
+
+  useEffect(() => {
+    localStorage.setItem('admin-users-role', roleFilter);
+  }, [roleFilter]);
 
   const filteredUsers = users.filter(user => {
     const matchesSearch = user.username.toLowerCase().includes(search.toLowerCase()) ||
@@ -105,8 +121,8 @@ const Usuarios = () => {
               </div>
             </div>
             
-            <button 
-              className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white px-6 py-3 rounded-xl font-medium transition-all duration-300 flex items-center space-x-2 shadow-lg hover:shadow-xl transform hover:scale-105"
+            <button
+              className="btn-gradient-primary flex items-center space-x-2"
               onClick={() => setShowNew(true)}
             >
               <Plus size={20} />


### PR DESCRIPTION
## Summary
- share theme across admin panel with `ThemeProvider`
- add global `TopBar` component with theme toggle
- persist search criteria in admin users page
- adopt gradient button style in users page
- apply design classes to stats cards and table component
- improve DataTable accessibility

## Testing
- `npm run test` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888efa84b7c8333b7763d73013079dd