### PR TITLE
feat(ui): migrar <img> internas a <Image /> con alt y dimensiones para reducir CLS

### DIFF
--- a/src/adminPanel/components/admin/LogoUploadField.tsx
+++ b/src/adminPanel/components/admin/LogoUploadField.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Image, Upload, X, Camera } from 'lucide-react';
+import { Image as ImageIcon, Upload, X, Camera } from 'lucide-react';
+import Image from '@/components/ui/Image';
 import { toast } from 'react-hot-toast';
 
 interface LogoUploadFieldProps {
@@ -119,7 +120,7 @@ const LogoUploadField: React.FC<LogoUploadFieldProps> = ({
   return (
     <div className={`space-y-3 ${className}`}>
       <label className="block text-sm font-medium text-gray-300 mb-2">
-        <Image size={16} className="inline mr-2" />
+        <ImageIcon size={16} className="inline mr-2" />
         {label}
       </label>
 
@@ -165,9 +166,11 @@ const LogoUploadField: React.FC<LogoUploadFieldProps> = ({
           ) : previewUrl ? (
             <div className="flex flex-col items-center space-y-2">
               <div className="w-16 h-16 rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center border border-gray-600">
-                <img 
-                  src={previewUrl} 
-                  alt="Logo preview" 
+                <Image
+                  src={previewUrl}
+                  alt="Logo preview"
+                  width={64}
+                  height={64}
                   className="w-full h-full object-cover"
                   onError={() => setPreviewUrl(null)}
                 />
@@ -207,9 +210,11 @@ const LogoUploadField: React.FC<LogoUploadFieldProps> = ({
       {showPreview && previewUrl && (
         <div className="relative">
           <div className="w-24 h-24 mx-auto rounded-xl overflow-hidden bg-gray-700 flex items-center justify-center border border-gray-600">
-            <img 
-              src={previewUrl} 
-              alt="Logo preview" 
+            <Image
+              src={previewUrl}
+              alt="Logo preview"
+              width={96}
+              height={96}
               className="w-full h-full object-cover"
               onError={() => setPreviewUrl(null)}
             />

--- a/src/adminPanel/components/admin/NewClubModal.tsx
+++ b/src/adminPanel/components/admin/NewClubModal.tsx
@@ -1,4 +1,5 @@
 import  { useState, useRef, useEffect } from 'react';
+import Image from '@/components/ui/Image';
 import { Club } from '../../types';
 import { useGlobalStore } from '../../store/globalStore';
 import { slugify } from '../../utils/helpers';
@@ -95,7 +96,7 @@ const NewClubModal = ({ onClose, onSave }: Props) => {
           {/* Previsualización del logo */}
           {logoPreview && (
             <div className="sm:col-span-2 w-24 h-24 mx-auto rounded-xl overflow-hidden bg-gray-700 flex items-center justify-center">
-              <img src={logoPreview} alt="Preview logo" className="w-full h-full object-cover" />
+              <Image src={logoPreview} alt="Preview logo" width={96} height={96} className="w-full h-full object-cover" />
             </div>
           )}
           <div>

--- a/src/adminPanel/components/admin/NewTournamentModal.tsx
+++ b/src/adminPanel/components/admin/NewTournamentModal.tsx
@@ -5,9 +5,9 @@ import {
   Calendar, 
   Users, 
   MapPin, 
-  DollarSign, 
-  FileText, 
-  Image, 
+  DollarSign,
+  FileText,
+  Image as ImageIcon,
   Settings,
   Play,
   Clock,
@@ -17,6 +17,7 @@ import {
 import { Tournament } from '../../types';
 import { slugify } from '../../../utils/slugify';
 import LogoUploadField from './LogoUploadField';
+import Image from '@/components/ui/Image';
 
 interface Props {
   onClose: () => void;
@@ -240,12 +241,14 @@ const NewTournamentModal = ({ onClose, onSave, tournament }: Props) => {
             <div className="flex justify-center mb-3">
               <div className="relative">
                 <div className="w-20 h-20 rounded-xl overflow-hidden bg-gray-700 flex items-center justify-center border-2 border-gray-600">
-                  <img 
-                    src={formData.logo} 
-                    alt="Logo del torneo" 
+                  <Image
+                    src={formData.logo}
+                    alt="Logo del torneo"
+                    width={80}
+                    height={80}
                     className="w-full h-full object-cover"
                     onError={(e) => {
-                      e.currentTarget.src = defaultLogo;
+                      (e.currentTarget as HTMLImageElement).src = defaultLogo;
                     }}
                   />
                 </div>

--- a/src/adminPanel/components/admin/NewsAdminPanel.tsx
+++ b/src/adminPanel/components/admin/NewsAdminPanel.tsx
@@ -1,4 +1,5 @@
 import  React, { useState } from 'react';
+import Image from '@/components/ui/Image';
 import { Edit, Plus, Trash, Search, Calendar, User, Eye, EyeOff, FileText, Star } from 'lucide-react';
 import StatsCard from './StatsCard';
 import { useGlobalStore } from '../../store/globalStore';
@@ -262,9 +263,11 @@ const NewsAdminPanel = () => {
                 {/* Article Image */}
                 {article.image && (
                   <div className="lg:w-64 h-48 lg:h-auto overflow-hidden">
-                    <img
+                    <Image
                       src={article.image}
                       alt={article.title}
+                      width={256}
+                      height={192}
                       className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                     />
                   </div>

--- a/src/adminPanel/components/admin/StoreAdminPanel.tsx
+++ b/src/adminPanel/components/admin/StoreAdminPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Image from '@/components/ui/Image';
 import { Plus } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { useStoreSlice, PurchaseTx } from '../../../store/storeSlice';
@@ -138,7 +139,13 @@ const StoreAdminPanel = () => {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {products.map(p=> (
             <div key={p.id} className="relative group rounded-xl overflow-hidden border border-gray-700/40 bg-gray-900/40">
-              <img src={p.image} alt={p.name} className={`w-full h-40 object-cover ${rarityRing(p.rarity)}`} />
+              <Image
+                src={p.image}
+                alt={p.name}
+                height={160}
+                className={`w-full h-40 object-cover ${rarityRing(p.rarity)}`}
+                style={{ width: '100%' }}
+              />
               <div className="p-4 space-y-1">
                 <h3 className="text-white font-semibold flex items-center justify-between">
                   {p.name}

--- a/src/adminPanel/pages/admin/Clubes.tsx
+++ b/src/adminPanel/pages/admin/Clubes.tsx
@@ -1,4 +1,5 @@
 import  { useState } from 'react';
+import Image from '@/components/ui/Image';
 import { Plus, Search, Edit, Trash, Building, Trophy, Users, Eye, MoreVertical, Filter } from 'lucide-react'; 
 import toast from 'react-hot-toast';
 import { useGlobalStore } from '../../store/globalStore';
@@ -161,9 +162,11 @@ const Clubes = () => {
                     <div className="relative">
                       <div className="w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center">
                         {club.logo ? (
-                          <img 
-                            src={club.logo} 
+                          <Image
+                            src={club.logo}
                             alt={club.name}
+                            width={64}
+                            height={64}
                             className="w-full h-full object-cover"
                           />
                         ) : (

--- a/src/adminPanel/pages/admin/Jugadores.tsx
+++ b/src/adminPanel/pages/admin/Jugadores.tsx
@@ -1,4 +1,5 @@
 import  { useState } from 'react';
+import Image from '@/components/ui/Image';
 import { Plus, Search, Edit, Trash, Filter, User, Trophy, Star, Eye, MoreVertical, Users } from 'lucide-react'; 
 import toast from 'react-hot-toast';
 import { useGlobalStore } from '../../store/globalStore';
@@ -192,9 +193,11 @@ const Jugadores = () => {
                     <div className="relative">
                       <div className="w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-gray-700 to-gray-800">
                         {player.image ? (
-                          <img 
-                            src={player.image} 
+                          <Image
+                            src={player.image}
                             alt={player.name}
+                            width={64}
+                            height={64}
                             className="w-full h-full object-cover"
                           />
                         ) : (

--- a/src/components/calendar/EventModal.tsx
+++ b/src/components/calendar/EventModal.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react';
+import Image from '@/components/ui/Image';
 
 export interface CalendarEvent {
   id: string;
@@ -34,14 +35,14 @@ const EventModal = ({ event, onClose }: Props) => (
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             {event.homeLogo && (
-              <img src={event.homeLogo} alt={event.homeTeam} className="h-8 w-8 rounded-full" />
+              <Image src={event.homeLogo} alt={event.homeTeam} width={32} height={32} className="h-8 w-8 rounded-full" />
             )}
             <span>{event.homeTeam}</span>
           </div>
           <span className="text-sm text-gray-400">vs</span>
           <div className="flex items-center gap-2">
             {event.awayLogo && (
-              <img src={event.awayLogo} alt={event.awayTeam} className="h-8 w-8 rounded-full" />
+              <Image src={event.awayLogo} alt={event.awayTeam} width={32} height={32} className="h-8 w-8 rounded-full" />
             )}
             <span>{event.awayTeam}</span>
           </div>

--- a/src/components/comments/Comments.tsx
+++ b/src/components/comments/Comments.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useCommentStore } from '../../store/commentStore';
 import { useAuthStore } from '../../store/authStore';
+import Image from '@/components/ui/Image';
 
 interface Props {
   postId: string;
@@ -34,9 +35,11 @@ const Comments = ({ postId }: Props) => {
         {postComments.map(c => (
           <div className="flex" key={c.id}>
             <div className="w-10 h-10 rounded-full overflow-hidden mr-3 flex-shrink-0">
-              <img
+              <Image
                 src={`https://ui-avatars.com/api/?name=${c.author}&background=111827&color=fff&size=128`}
                 alt={c.author}
+                width={40}
+                height={40}
                 className="w-full h-full object-cover"
               />
             </div>

--- a/src/components/common/ClubListItem.tsx
+++ b/src/components/common/ClubListItem.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Club } from '../../types/shared';
+import Image from '@/components/ui/Image';
 
 interface ClubListItemProps {
   club: Club;
@@ -12,9 +13,11 @@ const ClubListItem = ({ club, to, className = '' }: ClubListItemProps) => {
     <div
       className={`flex items-center p-3 rounded-lg hover:bg-gray-800 transition-colors ${className}`.trim()}
     >
-      <img
+      <Image
         src={club.logo}
         alt={club.name}
+        width={48}
+        height={48}
         className="w-12 h-12 object-contain mr-4"
         loading="lazy"
       />

--- a/src/components/common/RankingRow.tsx
+++ b/src/components/common/RankingRow.tsx
@@ -1,4 +1,5 @@
 import { DtRanking } from '../../types';
+import Image from '@/components/ui/Image';
 
 interface RankingRowProps {
   rank: number;
@@ -10,7 +11,7 @@ const RankingRow = ({ rank, data }: RankingRowProps) => (
     <td>{rank}</td>
     <td>{data.username}</td>
     <td className="flex items-center justify-center gap-1">
-      <img src={data.clubLogo} alt={data.clubName} className="h-4 w-4" />
+      <Image src={data.clubLogo} alt={data.clubName} width={16} height={16} className="h-4 w-4" />
     </td>
     <td className="text-right">{data.elo}</td>
   </tr>

--- a/src/components/common/SmartAvatar.tsx
+++ b/src/components/common/SmartAvatar.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import Image from '@/components/ui/Image';
 
 type Props = {
   src?: string | null;
@@ -73,13 +74,13 @@ const SmartAvatar: React.FC<Props> = ({
   }
 
   return (
-    <img
+    <Image
       src={currentSrc}
       alt={label}
       width={size}
       height={size}
       onError={handleError}
-      className={`${rounded ? "rounded-full" : "rounded"} object-cover ${className || ""}`}
+      className={`${rounded ? 'rounded-full' : 'rounded'} object-cover ${className || ''}`}
       style={{ width: size, height: size }}
     />
   );

--- a/src/components/common/UploadMediaModal.tsx
+++ b/src/components/common/UploadMediaModal.tsx
@@ -5,6 +5,7 @@ import { MediaItem } from '@/types';
 import { notifySuccess, notifyError } from '../../utils/toast';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useEscapeKey from '../../hooks/useEscapeKey';
+import Image from '@/components/ui/Image';
 
 interface UploadMediaModalProps {
   isOpen: boolean;
@@ -96,7 +97,7 @@ const UploadMediaModal: React.FC<UploadMediaModalProps> = ({
           >
             {preview ? (
               // Previsualización
-              <img src={preview} alt="preview" className="h-full object-contain rounded" />
+              <Image src={preview} alt="preview" height={160} className="h-full object-contain rounded" style={{ width: '100%' }} />
             ) : (
               <span className="text-gray-400 text-sm text-center px-4">
                 Arrastra tu archivo aquí o <span className="text-primary underline">haz clic para seleccionar</span>

--- a/src/components/dt-dashboard/CalendarioTab.tsx
+++ b/src/components/dt-dashboard/CalendarioTab.tsx
@@ -1,6 +1,7 @@
 import  { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { ChevronLeft, ChevronRight, Clock, MapPin, Trophy, Calendar as CalendarIcon } from 'lucide-react';
+import Image from '@/components/ui/Image';
 import { useDataStore } from '../../store/dataStore';
 
 const months = [
@@ -115,9 +116,11 @@ export default function CalendarioTab() {
               <div>
                 <div className="flex items-center gap-4 mb-4">
                   <div className="text-center">
-                    <img 
-                      src={club?.logo} 
-                      alt={club?.name}
+                    <Image
+                      src={club?.logo}
+                      alt={club?.name || 'Escudo del club'}
+                      width={48}
+                      height={48}
                       className="w-12 h-12 rounded-xl mx-auto mb-2"
                     />
                     <p className="text-sm text-white/70">{club?.name}</p>

--- a/src/components/dt-dashboard/FixtureTab.tsx
+++ b/src/components/dt-dashboard/FixtureTab.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Clock, CheckCircle, Trophy, Calendar, MapPin, Filter } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { useAuthStore } from '../../store/authStore';
+import Image from '@/components/ui/Image';
 
 export default function FixtureTab() {
   const { user } = useAuthStore();
@@ -154,9 +155,11 @@ export default function FixtureTab() {
                 <div className="flex items-center justify-between">
                   {/* Home Team */}
                   <div className="flex items-center gap-4 flex-1">
-                    <img 
-                      src={homeClub?.logo} 
-                      alt={homeClub?.name}
+                    <Image
+                      src={homeClub?.logo}
+                      alt={homeClub?.name || 'Escudo del club'}
+                      width={48}
+                      height={48}
                       className="w-12 h-12 object-contain rounded-lg"
                     />
                     <div>
@@ -192,9 +195,11 @@ export default function FixtureTab() {
                       <h3 className="font-bold text-lg">{match.awayTeam}</h3>
                       <p className="text-sm text-gray-400">{awayClub?.stadium}</p>
                     </div>
-                    <img 
-                      src={awayClub?.logo} 
-                      alt={awayClub?.name}
+                    <Image
+                      src={awayClub?.logo}
+                      alt={awayClub?.name || 'Escudo del club'}
+                      width={48}
+                      height={48}
                       className="w-12 h-12 object-contain rounded-lg"
                     />
                   </div>

--- a/src/components/dt-dashboard/MercadoTab.tsx
+++ b/src/components/dt-dashboard/MercadoTab.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../../store/authStore';
 import { Player } from '../../types/shared';
 import toast from 'react-hot-toast';
 import OffersPanel from '../market/OffersPanel';
+import Image from '@/components/ui/Image';
 import OfferModal from '../market/OfferModal';
 
 export default function MercadoTab() {
@@ -187,10 +188,12 @@ export default function MercadoTab() {
                 className="bg-black/20 backdrop-blur-xl rounded-2xl overflow-hidden border border-white/10 group hover:border-primary/30 transition-all duration-300"
               >
                 <div className="relative">
-                  <img 
-                    src={player.image} 
+                  <Image
+                    src={player.image}
                     alt={player.name}
+                    height={192}
                     className="w-full h-48 object-cover"
+                    style={{ width: '100%' }}
                   />
                   <div className="absolute top-3 left-3 bg-black/70 px-2 py-1 rounded-lg text-xs font-medium">
                     {player.position}

--- a/src/components/dt-dashboard/TacticasTab.tsx
+++ b/src/components/dt-dashboard/TacticasTab.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { RotateCcw, Save, Settings } from 'lucide-react';
 import { useDataStore } from '../../store/dataStore';
 import { Player } from '../../types/shared';
+import Image from '@/components/ui/Image';
 
 const formations = [
   { name: '4-4-2', positions: [
@@ -140,9 +141,11 @@ export default function TacticasTab() {
                 dragElastic={0.1}
               >
                 <div className="relative">
-                  <img
+                  <Image
                     src={player.image}
                     alt={player.name}
+                    width={48}
+                    height={48}
                     className="w-12 h-12 rounded-full border-2 border-white shadow-lg"
                   />
                   <div className="absolute -bottom-6 left-1/2 transform -translate-x-1/2 bg-black/70 text-white text-xs px-2 py-1 rounded whitespace-nowrap">
@@ -172,9 +175,11 @@ export default function TacticasTab() {
                     : 'bg-white/5 hover:bg-white/10'
                 }`}
               >
-                <img
+                <Image
                   src={player.image}
                   alt={player.name}
+                  width={40}
+                  height={40}
                   className="w-10 h-10 rounded-full"
                 />
                 <div className="flex-1 min-w-0">

--- a/src/components/feed/AchievementCard.tsx
+++ b/src/components/feed/AchievementCard.tsx
@@ -1,6 +1,7 @@
 import { formatDate } from '@/utils/helpers';
 import type { FeedItem } from '@/types';
 import { Trophy } from 'lucide-react';
+import Image from '@/components/ui/Image';
 
 interface Props { item: Extract<FeedItem, { type: 'achievement' }>; }
 
@@ -11,7 +12,7 @@ const AchievementCard = ({ item }: Props) => (
     title={item.title}
   >
     {item.meta.emblem ? (
-      <img src={item.meta.emblem} alt="" className="w-10 h-10 rounded" loading="lazy" />
+      <Image src={item.meta.emblem} alt={item.title} width={40} height={40} className="w-10 h-10 rounded" loading="lazy" />
     ) : (
       <div className="w-10 h-10 bg-yellow-500/20 rounded flex items-center justify-center" aria-hidden="true">
         <Trophy size={20} className="text-yellow-400" />

--- a/src/components/feed/NewsCard.tsx
+++ b/src/components/feed/NewsCard.tsx
@@ -1,5 +1,6 @@
 import { formatDate } from '@/utils/helpers';
 import type { FeedItem } from '@/types';
+import Image from '@/components/ui/Image';
 
 interface Props { item: Extract<FeedItem, { type: 'news' }>; }
 
@@ -10,9 +11,11 @@ const NewsCard = ({ item }: Props) => (
     title={item.title}
   >
     {item.meta.image && (
-      <img
+      <Image
         src={item.meta.image}
-        alt=""
+        alt={item.title}
+        width={80}
+        height={80}
         className="w-20 h-20 object-cover rounded"
         loading="lazy"
       />

--- a/src/components/market/OfferModal.tsx
+++ b/src/components/market/OfferModal.tsx
@@ -6,6 +6,7 @@ import { Player } from '../../types/shared';
 import { makeOffer, getMinOfferAmount, getMaxOfferAmount } from '../../utils/transferService';
 import { formatCurrency } from '../../utils/helpers';
 import toast from 'react-hot-toast';
+import Image from '@/components/ui/Image';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useEscapeKey from '../../hooks/useEscapeKey';
 
@@ -138,9 +139,11 @@ const OfferModal = ({ player, onClose, onOfferSent }: OfferModalProps) => {
             )}
             
             <div className="flex items-center space-x-4 mb-6">
-              <img
+              <Image
                 src={player.image}
                 alt={player.name}
+                width={64}
+                height={64}
                 className="w-16 h-16 rounded-full object-cover"
                 loading="lazy"
               />

--- a/src/components/market/OffersPanel.tsx
+++ b/src/components/market/OffersPanel.tsx
@@ -6,6 +6,7 @@ import { processTransfer } from '../../utils/transferService';
 import { TransferOffer } from '../../types';
 import { formatCurrency, formatDate, getStatusBadge } from '../../utils/helpers';
 import Card from '../common/Card';
+import Image from '@/components/ui/Image';
 import RenegotiateModal from './RenegotiateModal';
 import ConfirmModal from '../common/ConfirmModal';
 import toast from 'react-hot-toast';
@@ -219,9 +220,11 @@ const OffersPanel = ({
           <div className="p-4 cursor-pointer" onClick={() => toggleOfferDetails(offer.id)}>
             <div className="flex justify-between items-center">
               <div className="flex items-center space-x-3">
-                <img
+                <Image
                   src={getClubLogo(offer.toClub)}
                   alt={offer.toClub}
+                  width={32}
+                  height={32}
                   className="w-8 h-8 object-contain"
                   loading="lazy"
                 />
@@ -285,9 +288,11 @@ const OffersPanel = ({
                 <div>
                   <p className="text-xs text-gray-400 mb-1">Club vendedor</p>
                   <div className="flex items-center space-x-2">
-                    <img
+                    <Image
                       src={getClubLogo(offer.fromClub)}
                       alt={offer.fromClub}
+                      width={24}
+                      height={24}
                       className="w-6 h-6 object-contain"
                       loading="lazy"
                     />
@@ -297,9 +302,11 @@ const OffersPanel = ({
                 <div>
                   <p className="text-xs text-gray-400 mb-1">Club comprador</p>
                   <div className="flex items-center space-x-2">
-                    <img
+                    <Image
                       src={getClubLogo(offer.toClub)}
                       alt={offer.toClub}
+                      width={24}
+                      height={24}
                       className="w-6 h-6 object-contain"
                       loading="lazy"
                     />

--- a/src/components/plantilla/PlayerDrawer.tsx
+++ b/src/components/plantilla/PlayerDrawer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { Player } from '../../types/shared';
 import { formatCurrency, formatDate } from '../../utils/helpers';
 import useFocusTrap from '../../hooks/useFocusTrap';
+import Image from '@/components/ui/Image';
 
 interface Props {
   player: Player;
@@ -40,7 +41,7 @@ const PlayerDrawer = ({ player, onClose }: Props) => {
           <X size={20} />
         </button>
         <div className="flex items-center mb-4">
-          <img src={player.image} alt={player.name} className="w-16 h-16 mr-4 rounded-full" />
+          <Image src={player.image} alt={player.name} width={64} height={64} className="w-16 h-16 mr-4 rounded-full" />
           <div>
             <h3 className="text-xl font-bold">{player.name}</h3>
             <p className="text-sm text-gray-400">{player.position} • {player.age} años</p>

--- a/src/components/plantilla/ResumenClub.tsx
+++ b/src/components/plantilla/ResumenClub.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency } from '../../utils/helpers';
 import { Player, Club } from '../../types/shared';
 import ProgressBar from '../common/ProgressBar';
+import Image from '@/components/ui/Image';
 
 interface Props {
   club?: Club;
@@ -14,7 +15,7 @@ const ResumenClub = ({ club, players }: Props) => {
 
   return (
     <div className="card p-6 flex items-center">
-      <img src={club?.logo || ''} alt={club?.name || ''} className="w-16 h-16 mr-4" />
+      <Image src={club?.logo || ''} alt={club?.name || 'Escudo del club'} width={64} height={64} className="w-16 h-16 mr-4" />
       <div>
         <h2 className="text-xl font-bold mb-1">{club?.name}</h2>
         <p className="text-sm text-gray-400">

--- a/src/components/tacticas/PlayerCard.tsx
+++ b/src/components/tacticas/PlayerCard.tsx
@@ -1,4 +1,5 @@
 import { Player } from '../../types/shared';
+import Image from '@/components/ui/Image';
 
 interface PlayerCardProps {
   player: Player;
@@ -11,7 +12,7 @@ const PlayerCard = ({ player }: PlayerCardProps) => (
     onDragStart={e => e.dataTransfer.setData('text/plain', player.id)}
     className="bg-gray-900 text-xs text-center rounded p-1 cursor-move"
   >
-    <img src={player.image} alt={player.name} className="w-8 h-8 mx-auto rounded-full mb-1" />
+    <Image src={player.image} alt={player.name} width={32} height={32} className="w-8 h-8 mx-auto rounded-full mb-1" />
     <div>{player.dorsal}</div>
   </div>
 );

--- a/src/components/ui/Image.tsx
+++ b/src/components/ui/Image.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 export interface ImageProps {
   src: string;
   alt: string;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   className?: string;
   decoding?: 'sync' | 'async' | 'auto';
   fetchPriority?: 'high' | 'low' | 'auto';
@@ -27,8 +27,8 @@ export default function Image({
     <img
       src={src}
       alt={alt}
-      width={width}
-      height={height}
+      {...(width ? { width } : {})}
+      {...(height ? { height } : {})}
       decoding={decoding}
       fetchpriority={fetchPriority}
       loading={loading}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,6 +5,7 @@ import { Calendar, Search, ChevronRight, FileText } from 'lucide-react';
 import { srcSet, withWidth, defaultSizes } from '@/utils/imageHelpers';
 import { useDataStore } from '../store/dataStore';
 import SEO from '../components/SEO';
+import Image from '@/components/ui/Image';
 
 const Blog = () => {
   const [searchQuery, setSearchQuery] = useState('');
@@ -66,11 +67,13 @@ const Blog = () => {
                   <div key={post.id} className="bg-dark-light rounded-lg overflow-hidden border border-gray-800 group">
                     <div className="flex flex-col md:flex-row">
                       <div className="md:w-1/3 aspect-video md:aspect-square overflow-hidden">
-                        <img
+                        <Image
                           src={withWidth(post.image, 480)}
                           srcSet={srcSet(post.image)}
                           sizes={defaultSizes}
                           alt={post.title}
+                          width={480}
+                          height={270}
                           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                           loading="lazy"
                         />
@@ -95,9 +98,11 @@ const Blog = () => {
                         <div className="flex items-center justify-between">
                           <div className="flex items-center">
                             <div className="w-8 h-8 rounded-full overflow-hidden mr-2">
-                              <img
+                              <Image
                                 src={`https://ui-avatars.com/api/?name=${post.author}&background=111827&color=fff&size=128`}
                                 alt={post.author}
+                                width={32}
+                                height={32}
                                 className="w-full h-full object-cover"
                                 loading="lazy"
                               />
@@ -164,11 +169,13 @@ const Blog = () => {
                     className="flex items-start group"
                   >
                     <div className="w-20 h-20 rounded-lg overflow-hidden flex-shrink-0 mr-3">
-                      <img
+                      <Image
                         src={withWidth(post.image, 160)}
                         srcSet={srcSet(post.image)}
                         sizes="80px"
                         alt={post.title}
+                        width={80}
+                        height={80}
                         className="w-full h-full object-cover"
                         loading="lazy"
                       />

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -4,6 +4,7 @@ import { useDataStore } from '../store/dataStore';
 import Comments from '../components/comments/Comments';
 import { srcSet, withWidth, defaultSizes } from '@/utils/imageHelpers';
 import SEO from '../components/SEO';
+import Image from '@/components/ui/Image';
 
 const BlogPost = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -53,11 +54,13 @@ const BlogPost = () => {
       <div>
         <div className="relative h-80 overflow-hidden">
         <div className="absolute inset-0">
-          <img
+          <Image
             src={withWidth(post.image, 800)}
             srcSet={srcSet(post.image)}
             sizes={defaultSizes}
             alt={post.title}
+            width={800}
+            height={320}
             className="w-full h-full object-cover"
             loading="lazy"
           />
@@ -81,9 +84,11 @@ const BlogPost = () => {
           
           <div className="flex items-center">
             <div className="w-8 h-8 rounded-full overflow-hidden mr-2">
-              <img
+              <Image
                 src={`https://ui-avatars.com/api/?name=${post.author}&background=111827&color=fff&size=128`}
                 alt={post.author}
+                width={32}
+                height={32}
                 className="w-full h-full object-cover"
                 loading="lazy"
               />
@@ -144,9 +149,11 @@ const BlogPost = () => {
               
               <div className="flex items-center mb-4">
                 <div className="w-16 h-16 rounded-full overflow-hidden mr-4">
-                  <img
+                  <Image
                     src={`https://ui-avatars.com/api/?name=${post.author}&background=111827&color=fff&size=128`}
                     alt={post.author}
+                    width={64}
+                    height={64}
                     className="w-full h-full object-cover"
                     loading="lazy"
                   />
@@ -182,11 +189,13 @@ const BlogPost = () => {
                       className="flex items-start group"
                     >
                       <div className="w-20 h-20 rounded-lg overflow-hidden flex-shrink-0 mr-3">
-                        <img
+                        <Image
                           src={withWidth(relatedPost.image, 160)}
                           srcSet={srcSet(relatedPost.image)}
                           sizes="80px"
                           alt={relatedPost.title}
+                          width={80}
+                          height={80}
                           className="w-full h-full object-cover"
                           loading="lazy"
                         />

--- a/src/pages/ClubFinances.tsx
+++ b/src/pages/ClubFinances.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ArrowUp, ArrowDown, DollarSign, ShoppingBag, Clipboard } f
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 import { formatCurrency, formatDate } from '../utils/helpers';
+import Image from '@/components/ui/Image';
 
 const ClubFinances = () => {
   const { clubName } = useParams<{ clubName: string }>();
@@ -68,7 +69,7 @@ const ClubFinances = () => {
         <div className="mb-8">
           <div className="flex items-center mb-6">
             <div className="w-12 h-12 rounded-full overflow-hidden mr-3">
-              <img src={club.logo} alt={club.name} className="w-full h-full object-cover" />
+              <Image src={club.logo} alt={club.name} width={48} height={48} className="w-full h-full object-cover" />
             </div>
             <div>
               <h2 className="text-2xl font-bold">{club.name}</h2>

--- a/src/pages/ClubProfile.tsx
+++ b/src/pages/ClubProfile.tsx
@@ -13,6 +13,7 @@ import PageHeader from '../components/common/PageHeader';
 import StatsCard from '../components/common/StatsCard';
 import { useDataStore } from '../store/dataStore';
 import { formatDate, formatCurrency, getMatchResult } from '../utils/helpers';
+import Image from '@/components/ui/Image';
 
 const ClubProfile = () => {
   const { clubName } = useParams<{ clubName: string }>();
@@ -118,9 +119,11 @@ const ClubProfile = () => {
         <div className="flex flex-col md:flex-row gap-6 mb-8">
           <div className="w-full md:w-1/3">
             <div className="card p-6 text-center">
-              <img 
-                src={club.logo} 
+              <Image
+                src={club.logo}
                 alt={club.name}
+                width={128}
+                height={128}
                 className="w-32 h-32 mx-auto mb-4"
               />
               <h1 className="text-2xl font-bold mb-1">{club.name}</h1>
@@ -289,9 +292,11 @@ const ClubProfile = () => {
                               return (
                                 <div key={match.id} className="flex items-center p-3 bg-gray-800 rounded-lg">
                                   <div className="w-12 h-12 flex items-center justify-center mr-3">
-                                    <img 
-                                      src={opponentClub?.logo} 
-                                      alt={opponentClub?.name}
+                                    <Image
+                                      src={opponentClub?.logo}
+                                      alt={opponentClub?.name || 'Escudo del club'}
+                                      width={40}
+                                      height={40}
                                       className="w-10 h-10 object-contain"
                                     />
                                   </div>
@@ -361,9 +366,11 @@ const ClubProfile = () => {
                             >
                               <div className="flex items-center">
                                 <div className="w-10 h-10 flex items-center justify-center mr-3">
-                                  <img 
-                                    src={opponentClub?.logo} 
-                                    alt={opponentClub?.name}
+                                  <Image
+                                    src={opponentClub?.logo}
+                                    alt={opponentClub?.name || 'Escudo del club'}
+                                    width={32}
+                                    height={32}
                                     className="w-8 h-8 object-contain"
                                   />
                                 </div>
@@ -442,9 +449,11 @@ const ClubProfile = () => {
                               <tr key={player.id} className="hover:bg-gray-800">
                                 <td className="p-3">
                                   <div className="flex items-center">
-                                    <img 
-                                      src={player.image} 
+                                    <Image
+                                      src={player.image}
                                       alt={player.name}
+                                      width={32}
+                                      height={32}
                                       className="w-8 h-8 rounded-full object-cover mr-2"
                                     />
                                     <span className="font-medium">{player.name}</span>

--- a/src/pages/ClubSquad.tsx
+++ b/src/pages/ClubSquad.tsx
@@ -4,6 +4,7 @@ import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
 import { formatCurrency, getOverallColor } from '../utils/helpers';
 import { useState } from 'react';
+import Image from '@/components/ui/Image';
 
 const ClubSquad = () => {
   const { clubName, clubId } = useParams<{ clubName?: string; clubId?: string }>();
@@ -90,7 +91,7 @@ const ClubSquad = () => {
         <div className="mb-8">
           <div className="flex items-center mb-4">
             <div className="w-12 h-12 rounded-full overflow-hidden mr-3">
-              <img src={club.logo} alt={club.name} className="w-full h-full object-cover" />
+              <Image src={club.logo} alt={club.name} width={48} height={48} className="w-full h-full object-cover" />
             </div>
             <div>
               <h2 className="text-2xl font-bold">{club.name}</h2>

--- a/src/pages/Fixtures.tsx
+++ b/src/pages/Fixtures.tsx
@@ -6,6 +6,7 @@ import Card from '../components/common/Card';
 import { useDataStore } from '../store/dataStore';
 import { formatDate } from '../utils/helpers';
 import usePersistentState from '../hooks/usePersistentState';
+import Image from '@/components/ui/Image';
 
 const Fixtures = () => {
   const [selectedRound, setSelectedRound] = usePersistentState<number | null>('fixtures_round', null);
@@ -149,9 +150,11 @@ const Fixtures = () => {
                 <div className="p-5">
                   <div className="flex items-center justify-between">
                     <div className="flex flex-col items-center w-2/5 sm:w-1/3">
-                      <img
+                      <Image
                         src={homeClub?.logo}
-                        alt={homeClub?.name}
+                        alt={homeClub?.name || 'Escudo del club'}
+                        width={80}
+                        height={80}
                         className="w-16 h-16 sm:w-20 sm:h-20 object-contain mb-2"
                       />
                       <span className="font-medium text-center">{homeClub?.name}</span>
@@ -185,9 +188,11 @@ const Fixtures = () => {
                     </div>
                     
                     <div className="flex flex-col items-center w-2/5 sm:w-1/3">
-                      <img
+                      <Image
                         src={awayClub?.logo}
-                        alt={awayClub?.name}
+                        alt={awayClub?.name || 'Escudo del club'}
+                        width={80}
+                        height={80}
                         className="w-16 h-16 sm:w-20 sm:h-20 object-contain mb-2"
                       />
                       <span className="font-medium text-center">{awayClub?.name}</span>
@@ -212,9 +217,11 @@ const Fixtures = () => {
                                   {scorer.minute}'
                                 </div>
                                 <div className="flex items-center">
-                                  <img 
-                                    src={club?.logo} 
-                                    alt={club?.name}
+                                  <Image
+                                    src={club?.logo}
+                                    alt={club?.name || 'Escudo del club'}
+                                    width={20}
+                                    height={20}
                                     className="w-5 h-5 mr-2"
                                   />
                                   <span>{scorer.playerName}</span>

--- a/src/pages/GalleryDetail.tsx
+++ b/src/pages/GalleryDetail.tsx
@@ -4,6 +4,7 @@ import { Heart, Eye, Share2, Download } from 'lucide-react';
 import { useState } from 'react';
 import { srcSet, withWidth, defaultSizes } from '@/utils/imageHelpers';
 import SEO from '../components/SEO';
+import Image from '@/components/ui/Image';
 
 const GalleryDetail = () => {
   const { mediaId } = useParams();
@@ -52,11 +53,13 @@ const GalleryDetail = () => {
             className="w-full rounded-lg mb-4"
           />
         ) : (
-          <img
+          <Image
             src={withWidth(media.url, 800)}
             srcSet={srcSet(media.url)}
             sizes={defaultSizes}
             alt={media.title}
+            width={800}
+            height={450}
             className="w-full rounded-lg mb-4"
             loading="lazy"
           />

--- a/src/pages/HallOfFame.tsx
+++ b/src/pages/HallOfFame.tsx
@@ -3,6 +3,7 @@ import { useDataStore } from '../store/dataStore';
 import { Link } from 'react-router-dom';
 import { Award, ChevronLeft, Star, Shield, Trophy } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
+import Image from '@/components/ui/Image';
 
 const HallOfFame = () => {
   const [activeSection, setActiveSection] = useState('clubs');
@@ -235,9 +236,11 @@ const HallOfFame = () => {
                 {legendaryClubs.map(club => (
                   <div key={club.id} className="card overflow-hidden">
                     <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-6 text-center">
-                      <img 
-                        src={club.logo} 
+                      <Image
+                        src={club.logo}
                         alt={club.name}
+                        width={96}
+                        height={96}
                         className="w-24 h-24 mx-auto mb-4"
                       />
                       <h3 className="text-xl font-bold">{club.name}</h3>
@@ -294,9 +297,11 @@ const HallOfFame = () => {
                 {legendaryPlayers.map(player => (
                   <div key={player.id} className="card overflow-hidden">
                     <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-6 flex items-center">
-                      <img 
-                        src={player.image} 
+                      <Image
+                        src={player.image}
                         alt={player.name}
+                        width={64}
+                        height={64}
                         className="w-16 h-16 rounded-full mr-4"
                       />
                       <div>
@@ -359,9 +364,11 @@ const HallOfFame = () => {
                 {legendaryManagers.map(manager => (
                   <div key={manager.id} className="card overflow-hidden">
                     <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-6 text-center">
-                      <img 
-                        src={manager.avatar} 
+                      <Image
+                        src={manager.avatar}
                         alt={manager.name}
+                        width={96}
+                        height={96}
                         className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-primary"
                       />
                       <h3 className="text-xl font-bold">{manager.name}</h3>
@@ -410,9 +417,11 @@ const HallOfFame = () => {
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 {legendaryMoments.map(moment => (
                   <div key={moment.id} className="card overflow-hidden">
-                    <img 
-                      src={moment.image} 
+                    <Image
+                      src={moment.image}
                       alt={moment.title}
+                      width={600}
+                      height={192}
                       className="w-full h-48 object-cover"
                     />
                     <div className="p-6">

--- a/src/pages/LigaMaster.tsx
+++ b/src/pages/LigaMaster.tsx
@@ -16,6 +16,7 @@ import {
   Zap
 } from 'lucide-react';
 import PageHeader from '../components/common/PageHeader';
+import Image from '@/components/ui/Image';
 import StatsCard from '../components/common/StatsCard';
 import ClubListItem from '../components/common/ClubListItem';
 import { useDataStore } from '../store/dataStore';
@@ -261,9 +262,11 @@ const LigaMaster = () => {
                               to={`/liga-master/club/${club?.slug ?? ''}`}
                               className="flex items-center"
                             >
-                              <img 
+                              <Image
                                 src={club?.logo}
-                                alt={club?.name}
+                                alt={club?.name || 'Escudo del club'}
+                                width={24}
+                                height={24}
                                 className="w-6 h-6 mr-2"
                               />
                               <span className="font-medium">{club?.name}</span>
@@ -314,9 +317,11 @@ const LigaMaster = () => {
                         
                         <div className="flex items-center justify-between">
                           <div className="flex flex-col items-center w-2/5">
-                            <img
+                            <Image
                               src={homeClub?.logo}
-                              alt={homeClub?.name}
+                              alt={homeClub?.name || 'Escudo del club'}
+                              width={64}
+                              height={64}
                               className="w-16 h-16 object-contain mb-1"
                             />
                             <span className="font-medium text-center">{homeClub?.name}</span>
@@ -325,9 +330,11 @@ const LigaMaster = () => {
                             <span className="text-2xl font-bold neon-text-blue">VS</span>
                           </div>
                           <div className="flex flex-col items-center w-2/5">
-                            <img
+                            <Image
                               src={awayClub?.logo}
-                              alt={awayClub?.name}
+                              alt={awayClub?.name || 'Escudo del club'}
+                              width={64}
+                              height={64}
                               className="w-16 h-16 object-contain mb-1"
                             />
                             <span className="font-medium text-center">{awayClub?.name}</span>
@@ -417,17 +424,21 @@ const LigaMaster = () => {
                             {index + 1}
                           </span>
                         </div>
-                        <img 
-                          src={player.image} 
+                        <Image
+                          src={player.image}
                           alt={player.name}
+                          width={40}
+                          height={40}
                           className="w-10 h-10 rounded-full object-cover mr-3"
                         />
                         <div>
                           <p className="font-medium">{player.name}</p>
                           <div className="flex items-center text-xs text-gray-400">
-                            <img 
-                              src={club?.logo} 
-                              alt={club?.name}
+                            <Image
+                              src={club?.logo}
+                              alt={club?.name || 'Escudo del club'}
+                              width={16}
+                              height={16}
                               className="w-4 h-4 mr-1"
                             />
                             <span>{club?.name}</span>

--- a/src/pages/PublicProfile.tsx
+++ b/src/pages/PublicProfile.tsx
@@ -4,6 +4,7 @@ import PageHeader from '../components/common/PageHeader';
 import { getUserByUsername } from '../utils/userService';
 import { User } from '../types/shared';
 import { slugify } from '../utils/helpers';
+import Image from '@/components/ui/Image';
 
 const PublicProfile = () => {
   const { username } = useParams<{ username: string }>();
@@ -31,7 +32,7 @@ const PublicProfile = () => {
       <PageHeader title={user.username} subtitle="Perfil público" />
       <div className="container mx-auto px-4 py-8">
         <div className="flex items-center space-x-6 mb-8">
-          <img src={user.avatar} alt={user.username} className="w-24 h-24 rounded-full" />
+          <Image src={user.avatar} alt={user.username} width={96} height={96} className="w-24 h-24 rounded-full" />
           <div>
             <p className="text-gray-300 mb-2">{user.bio}</p>
             <p className="text-sm">Nivel {user.level} &bull; XP {user.xp}</p>

--- a/src/pages/UserPanel.tsx
+++ b/src/pages/UserPanel.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
-import { 
-  User, 
-  Settings, 
-  LogOut, 
-  Trophy, 
-  Clipboard, 
+import {
+  User,
+  Settings,
+  LogOut,
+  Trophy,
+  Clipboard,
   Users, 
   ShoppingCart, 
   Bell,
@@ -29,6 +29,7 @@ import {
   Globe,
   Loader2
 } from 'lucide-react';
+import Image from '@/components/ui/Image';
 import toast from 'react-hot-toast';
 import { useAuthStore } from '../store/authStore';
 import { useDataStore } from '../store/dataStore';
@@ -276,9 +277,11 @@ const UserPanel = () => {
               {user.role === 'dt' && userClub && (
                 <div className="mt-4 p-4 bg-gradient-to-r from-dark-light to-dark rounded-xl border border-gray-800/50">
                   <div className="flex items-center justify-center">
-                    <img 
-                      src={userClub.logo} 
-                      alt={userClub.name} 
+                    <Image
+                      src={userClub.logo}
+                      alt={userClub.name}
+                      width={40}
+                      height={40}
                       className="w-10 h-10 mr-3 rounded-full"
                     />
                     <span className="font-medium text-sm">{userClub.name}</span>
@@ -641,7 +644,7 @@ const UserPanel = () => {
                 <div className="card-elevated p-8">
                   <div className="flex flex-wrap justify-between items-center mb-8 gap-4">
                     <div className="flex items-center">
-                      <img src={userClub.logo} alt={userClub.name} className="w-16 h-16 mr-4 rounded-lg"/>
+                      <Image src={userClub.logo} alt={userClub.name} width={64} height={64} className="w-16 h-16 mr-4 rounded-lg" />
                       <div>
                         <h2 className="text-3xl font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
                           {userClub.name}
@@ -686,7 +689,7 @@ const UserPanel = () => {
                     <h3 className="text-xl font-semibold mb-4">Próximo Partido</h3>
                     <div className="flex items-center justify-around text-center">
                       <div className="flex flex-col items-center w-1/3">
-                        <img src={userClub.logo} alt={userClub.name} className="w-20 h-20 mb-2"/>
+                        <Image src={userClub.logo} alt={userClub.name} width={80} height={80} className="w-20 h-20 mb-2" />
                         <span className="font-bold text-lg">{userClub.name}</span>
                       </div>
                       <div className="w-1/3">
@@ -696,7 +699,7 @@ const UserPanel = () => {
                         </p>
                       </div>
                       <div className="flex flex-col items-center w-1/3">
-                        <img src="https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true" alt="Atlético Pixelado" className="w-20 h-20 mb-2"/>
+                        <Image src="https://ui-avatars.com/api/?name=AP&background=3b82f6&color=fff&size=128&bold=true" alt="Atlético Pixelado" width={80} height={80} className="w-20 h-20 mb-2" />
                         <span className="font-bold text-lg">Atlético Pixelado</span>
                       </div>
                     </div>

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,5 +1,6 @@
 import { useParams, Link } from 'react-router-dom';
 import { Star, Shield, Award, Mail, Calendar, Users, ChevronRight, Trophy, Camera } from 'lucide-react';
+import Image from '@/components/ui/Image';
 import toast from 'react-hot-toast';
 import PageHeader from '../components/common/PageHeader';
 import { useDataStore } from '../store/dataStore';
@@ -72,9 +73,11 @@ const UserProfile = () => {
             <div className="card p-6 text-center mb-6">
               <div className="w-24 h-24 mx-auto mb-4 relative group overflow-visible">
                 <div className="w-full h-full rounded-full overflow-hidden">
-                  <img 
-                    src={user.avatar} 
-                    alt={user.username} 
+                  <Image
+                    src={user.avatar}
+                    alt={user.username}
+                    width={96}
+                    height={96}
                     className="w-full h-full rounded-full object-cover"
                   />
                 </div>
@@ -195,7 +198,7 @@ const UserProfile = () => {
                 
                 <div className="flex items-center mb-4">
                   <div className="w-16 h-16 rounded-full overflow-hidden mr-3">
-                    <img src={club.logo} alt={club.name} className="w-full h-full object-cover" />
+                    <Image src={club.logo} alt={club.name} width={64} height={64} className="w-full h-full object-cover" />
                   </div>
                   <div>
                     <h4 className="font-bold">{club.name}</h4>
@@ -396,9 +399,11 @@ const UserProfile = () => {
                       <div className="flex items-center justify-between mb-2">
                         <div className="flex items-center">
                           <div className="w-8 h-8 rounded-full overflow-hidden mr-2">
-                            <img 
-                              src="https://ui-avatars.com/api/?name=PM&background=10b981&color=fff&size=128" 
+                            <Image
+                              src="https://ui-avatars.com/api/?name=PM&background=10b981&color=fff&size=128"
                               alt="pixelmanager"
+                              width={32}
+                              height={32}
                               className="w-full h-full object-cover"
                             />
                           </div>
@@ -415,9 +420,11 @@ const UserProfile = () => {
                       <div className="flex items-center justify-between mb-2">
                         <div className="flex items-center">
                           <div className="w-8 h-8 rounded-full overflow-hidden mr-2">
-                            <img 
-                              src="https://ui-avatars.com/api/?name=NM&background=c026d3&color=fff&size=128" 
+                            <Image
+                              src="https://ui-avatars.com/api/?name=NM&background=c026d3&color=fff&size=128"
                               alt="neonmanager"
+                              width={32}
+                              height={32}
                               className="w-full h-full object-cover"
                             />
                           </div>


### PR DESCRIPTION
## Summary
- replace internal `<img>` usages with new `Image` component across the frontend
- include alt text and dimensions where possible to avoid CLS
- make `Image` width and height optional

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a5bd943148333b55e6e98554b526b